### PR TITLE
Rename Polygon -> PolySurface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 .DS_Store
 Manifest.toml
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.jl.mem
 .DS_Store
 Manifest.toml
-/.vscode
+.vscode

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -74,7 +74,7 @@ export
   windingnumber, orientation,
 
   # polygons
-  Polygon,
+  PolySurface,
   rings, hasholes, issimple,
   windingnumber, orientation,
 

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -73,7 +73,7 @@ export
   isclosed, issimple,
   windingnumber, orientation,
 
-  # polygons
+  # polysurfaces
   PolySurface,
   rings, hasholes, issimple,
   windingnumber, orientation,

--- a/src/discretization/fist.jl
+++ b/src/discretization/fist.jl
@@ -23,7 +23,7 @@ to heuristics implemented in the algorithm.
 """
 struct FIST <: DiscretizationMethod end
 
-function discretize(polygon::PolySurface, method::FIST)
+function discretize(polysurface::PolySurface, method::FIST)
   verts, perms = _fist_remove_duplicates(polygon)
 end
 

--- a/src/discretization/fist.jl
+++ b/src/discretization/fist.jl
@@ -23,7 +23,7 @@ to heuristics implemented in the algorithm.
 """
 struct FIST <: DiscretizationMethod end
 
-function discretize(polygon::Polygon, method::FIST)
+function discretize(polygon::PolySurface, method::FIST)
   verts, perms = _fist_remove_duplicates(polygon)
 end
 

--- a/src/discretization/fist.jl
+++ b/src/discretization/fist.jl
@@ -24,11 +24,11 @@ to heuristics implemented in the algorithm.
 struct FIST <: DiscretizationMethod end
 
 function discretize(polysurface::PolySurface, method::FIST)
-  verts, perms = _fist_remove_duplicates(polygon)
+  verts, perms = _fist_remove_duplicates(polysurface)
 end
 
-function _fist_remove_duplicates(polygon)
-  outer, inners = rings(polygon)
+function _fist_remove_duplicates(polysurface)
+  outer, inners = rings(polysurface)
 
   # retrieve vertices from rings
   verts = [@view vertices(r)[begin:end-1] for r in [outer; inners]]

--- a/src/plotrecipes/polygons.jl
+++ b/src/plotrecipes/polygons.jl
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-@recipe function f(polygon::Polygon)
+@recipe function f(polygon::PolySurface)
   seriestype --> :path
   seriescolor --> :black
   label --> "polygon"

--- a/src/plotrecipes/polygons.jl
+++ b/src/plotrecipes/polygons.jl
@@ -2,12 +2,12 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-@recipe function f(polygon::PolySurface)
+@recipe function f(polysurface::PolySurface)
   seriestype --> :path
   seriescolor --> :black
-  label --> "polygon"
+  label --> "polysurface"
 
-  outer, inners = rings(polygon)
+  outer, inners = rings(polysurface)
 
   # plot outer ring
   @series begin

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -5,7 +5,7 @@
 """
     PolySurface(outer, [inner1, inner2, ..., innerk])
 
-A polygon with `outer` ring, and optional inner
+A polygon surface with `outer` ring, and optional inner
 rings `inner1`, `inner2`, ..., `innerk`.
 
 Rings can be a vector of [`Point`](@ref) or a
@@ -40,39 +40,39 @@ PolySurface(outer::Vararg{P}) where {P<:Point} = PolySurface(collect(outer))
 PolySurface(outer::Vararg{TP}) where {TP<:Tuple} = PolySurface(collect(Point.(outer)))
 
 """
-    rings(polygon)
+    rings(polysurface)
 
 Return the outer and inner rings of the polygon.
 """
 rings(p::PolySurface) = p.outer, p.inners
 
 """
-    hasholes(polygon)
+    hasholes(polysurface)
 
-Tells whether or not the `polygon` contains holes.
+Tells whether or not the `polysurface` contains holes.
 """
 hasholes(p::PolySurface) = !isempty(p.inners)
 
 """
-    issimple(polygon)
+    issimple(polysurface)
 
-Tells whether or not the `polygon` is simple.
+Tells whether or not the `polysurface` is a simple polygon.
 See https://en.wikipedia.org/wiki/Simple_polygon.
 """
 issimple(p::PolySurface) = !hasholes(p) && issimple(p.outer)
 
 """
-    windingnumber(point, polygon)
+    windingnumber(point, polysurface)
 
-Winding number of `point` with respect to the `polygon`.
+Winding number of `point` with respect to the `polysurface`.
 """
-windingnumber(point::Point, polygon::PolySurface) =
-  windingnumber(point, polygon.outer)
+windingnumber(point::Point, p::PolySurface) =
+  windingnumber(point, p.outer)
 
 """
-    orientation(polygon)
+    orientation(polysurface)
 
-Returns the orientation of the `polygon` as either
+Returns the orientation of the `polysurface` as either
 counter-clockwise (CCW) or clockwise (CW).
 
 For polygons with holes, returns a list of orientations.

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -5,7 +5,7 @@
 """
     PolySurface(outer, [inner1, inner2, ..., innerk])
 
-A polygon surface with `outer` ring, and optional inner
+A polygonal surface with `outer` ring, and optional inner
 rings `inner1`, `inner2`, ..., `innerk`.
 
 Rings can be a vector of [`Point`](@ref) or a

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 """
-    Polygon(outer, [inner1, inner2, ..., innerk])
+    PolySurface(outer, [inner1, inner2, ..., innerk])
 
 A polygon with `outer` ring, and optional inner
 rings `inner1`, `inner2`, ..., `innerk`.
@@ -15,43 +15,43 @@ Most algorithms assume that the outer ring is oriented
 counter-clockwise (CCW) and that all inner rings are
 oriented clockwise (CW).
 """
-struct Polygon{Dim,T,C<:Chain{Dim,T}} <: Polytope{Dim,T}
+struct PolySurface{Dim,T,C<:Chain{Dim,T}} <: Polytope{Dim,T}
   outer::C
   inners::Vector{C}
 
-  function Polygon{Dim,T,C}(outer, inners) where {Dim,T,C}
+  function PolySurface{Dim,T,C}(outer, inners) where {Dim,T,C}
     @assert isclosed(outer) "invalid outer ring"
     @assert all(isclosed.(inners)) "invalid inner rings"
     new(outer, inners)
   end
 end
 
-Polygon(outer::C, inners=[]) where {Dim,T,C<:Chain{Dim,T}} =
-  Polygon{Dim,T,Chain{Dim,T}}(outer, inners)
+PolySurface(outer::C, inners=[]) where {Dim,T,C<:Chain{Dim,T}} =
+  PolySurface{Dim,T,Chain{Dim,T}}(outer, inners)
 
-Polygon(outer::AbstractVector{P}, inners=[]) where {P<:Point} =
-  Polygon(Chain(outer), [Chain(inner) for inner in inners])
+PolySurface(outer::AbstractVector{P}, inners=[]) where {P<:Point} =
+  PolySurface(Chain(outer), [Chain(inner) for inner in inners])
 
-Polygon(outer::AbstractVector{TP}, inners=[]) where {TP<:Tuple} =
-  Polygon(Point.(outer), [Point.(inner) for inner in inners])
+PolySurface(outer::AbstractVector{TP}, inners=[]) where {TP<:Tuple} =
+  PolySurface(Point.(outer), [Point.(inner) for inner in inners])
 
-Polygon(outer::Vararg{P}) where {P<:Point} = Polygon(collect(outer))
+PolySurface(outer::Vararg{P}) where {P<:Point} = PolySurface(collect(outer))
 
-Polygon(outer::Vararg{TP}) where {TP<:Tuple} = Polygon(collect(Point.(outer)))
+PolySurface(outer::Vararg{TP}) where {TP<:Tuple} = PolySurface(collect(Point.(outer)))
 
 """
     rings(polygon)
 
 Return the outer and inner rings of the polygon.
 """
-rings(p::Polygon) = p.outer, p.inners
+rings(p::PolySurface) = p.outer, p.inners
 
 """
     hasholes(polygon)
 
 Tells whether or not the `polygon` contains holes.
 """
-hasholes(p::Polygon) = !isempty(p.inners)
+hasholes(p::PolySurface) = !isempty(p.inners)
 
 """
     issimple(polygon)
@@ -59,14 +59,14 @@ hasholes(p::Polygon) = !isempty(p.inners)
 Tells whether or not the `polygon` is simple.
 See https://en.wikipedia.org/wiki/Simple_polygon.
 """
-issimple(p::Polygon) = !hasholes(p) && issimple(p.outer)
+issimple(p::PolySurface) = !hasholes(p) && issimple(p.outer)
 
 """
     windingnumber(point, polygon)
 
 Winding number of `point` with respect to the `polygon`.
 """
-windingnumber(point::Point, polygon::Polygon) =
+windingnumber(point::Point, polygon::PolySurface) =
   windingnumber(point, polygon.outer)
 
 """
@@ -77,7 +77,7 @@ counter-clockwise (CCW) or clockwise (CW).
 
 For polygons with holes, returns a list of orientations.
 """
-function orientation(p::Polygon)
+function orientation(p::PolySurface)
   if hasholes(p)
     orientation(p.outer), orientation.(p.inners)
   else
@@ -85,16 +85,16 @@ function orientation(p::Polygon)
   end
 end
 
-function Base.show(io::IO, p::Polygon)
+function Base.show(io::IO, p::PolySurface)
   outer = p.outer
   inner = isempty(p.inners) ? "" : ", "*join(p.inners, ", ")
-  print(io, "Polygon($outer$inner)")
+  print(io, "PolySurface($outer$inner)")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", p::Polygon{Dim,T}) where {Dim,T}
+function Base.show(io::IO, ::MIME"text/plain", p::PolySurface{Dim,T}) where {Dim,T}
   outer = "    └─$(p.outer)"
   inner = ["    └─$v" for v in p.inners]
-  println(io, "Polygon{$Dim,$T}")
+  println(io, "PolySurface{$Dim,$T}")
   println(io, "  outer")
   if isempty(inner)
     print(io, outer)

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -1,6 +1,6 @@
 @testset "Discretization" begin
   @testset "FIST" begin
-    p = Polygon((0,0), (1,0), (1,0), (1,1), (1,2), (0,2), (0,1), (0,1), (0,0))
+    p = PolySurface((0,0), (1,0), (1,0), (1,1), (1,2), (0,2), (0,1), (0,1), (0,0))
     verts, perms = Meshes._fist_remove_duplicates(p)
     @test verts == [Point.([(0,0), (1,0), (1,1), (1,2), (0,2), (0,1)])]
     @test perms == [[1,6,5,2,3,4]]

--- a/test/polygons.jl
+++ b/test/polygons.jl
@@ -23,7 +23,7 @@
         push!(inners, inner)
       end
 
-      Polygon(outer, inners)
+      PolySurface(outer, inners)
     end
   end
 


### PR DESCRIPTION
Everything should be renamed properly from `Polygon` to `PolySurface`, as suggested in #6.
I also updated the docstrings and variable names to "polysurface" instead of "polygon" when it referenced the new `PolySurface` type.