### PR TITLE
Make Chain/Face constructors available for all polytopes

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -12,10 +12,6 @@ struct Chain{Dim,T} <: Polytope{1,Dim,T}
   vertices::Vector{Point{Dim,T}}
 end
 
-Chain(points::Vararg{P}) where {P<:Point} = Chain(collect(points))
-Chain(points::AbstractVector{TP}) where {TP<:Tuple} = Chain(Point.(points))
-Chain(points::Vararg{TP}) where {TP<:Tuple} = Chain(collect(points))
-
 """
     isclosed(chain)
 

--- a/src/geometries.jl
+++ b/src/geometries.jl
@@ -146,11 +146,11 @@ parametric dimension of the polytope. For example, a segment is a 1-face, a tria
 """
 abstract type Face{N,Dim,T} <: Polytope{N,Dim,T} end
 
-(::Type{F})(vertices::Vararg{P}) where {F<:Face,P<:Point} = F(SVector(vertices))
-(::Type{F})(vertices::AbstractVector{TP}) where {F<:Face,TP<:Tuple} = F(Point.(vertices))
-(::Type{F})(vertices::Vararg{TP}) where {F<:Face,TP<:Tuple} = F(collect(vertices))
+(::Type{F})(vertices::Vararg{TP}) where {F<:Polytope,TP<:Tuple} = F(collect(vertices))
+(::Type{F})(vertices::AbstractVector{TP}) where {F<:Polytope,TP<:Tuple} = F(Point.(vertices))
+(::Type{F})(vertices::Vararg{P}) where {F<:Polytope,P<:Point} = F(SVector(vertices))
 
-==(f1::Face, f2::Face) = f1.vertices == f2.vertices
+==(p1::Polytope, p2::Polytope) = p1.vertices == p2.vertices
 
 function Base.show(io::IO, f::Face)
   kind = nameof(typeof(f))

--- a/src/plotrecipes/faces.jl
+++ b/src/plotrecipes/faces.jl
@@ -12,8 +12,8 @@
 end
 
 # plot facets in a recursion
-@recipe function f(face::Face)
-  for fa in facets(face)
+@recipe function f(p::Polytope)
+  for fa in facets(p)
     @series begin
       primary --> false
       fa


### PR DESCRIPTION
I think it may be safe to assume that all the (geometric) polytopes will have vertices. In that case, the convenience constructors can be defined for all polytopes, not just `Face`s. Since a `Chain` is a 1-polytope, there is no need to specify other constructors for it, so I removed them.
I also believe that the plot recipe can apply to any polytope. They will just need to have a `facets` function defined.