### PR TITLE
Use explicit and customizable ordering conventions

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -25,6 +25,7 @@ include("angles.jl")
 include("geometries.jl")
 include("connectivities.jl")
 include("mesh.jl")
+include("conventions/gmsh.jl")
 
 # algorithms
 include("sampling.jl")
@@ -78,6 +79,8 @@ export
   # connectivities
   Connectivity,
   polytopetype, connect, materialize,
+  OrderingConvention, GMSH,
+  connectivity,
 
   # meshes
   Mesh,

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -25,7 +25,7 @@ include("angles.jl")
 include("geometries.jl")
 include("connectivities.jl")
 include("mesh.jl")
-include("conventions/gmsh.jl")
+include("conventions.jl")
 
 # algorithms
 include("sampling.jl")

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -82,7 +82,7 @@ export
 
   # conventions
   OrderingConvention, GMSH,
-  connectivity,
+  connectivities,
 
   # meshes
   Mesh,

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -24,8 +24,8 @@ include("angles.jl")
 # geometries and meshes
 include("geometries.jl")
 include("connectivities.jl")
-include("mesh.jl")
 include("conventions.jl")
+include("mesh.jl")
 
 # algorithms
 include("sampling.jl")
@@ -79,6 +79,8 @@ export
   # connectivities
   Connectivity,
   polytopetype, connect, materialize,
+
+  # conventions
   OrderingConvention, GMSH,
   connectivity,
 

--- a/src/connectivities.jl
+++ b/src/connectivities.jl
@@ -48,3 +48,27 @@ end
 function Base.show(io::IO, c::Connectivity{PL}) where {PL}
   print(io, "$PL$(c.list)")
 end
+
+"""
+Convention used to reconstruct the faces of a polytope
+from a list of vertices.
+"""
+abstract type OrderingConvention end
+
+"""
+    connectivity(polytope, convention, k)
+
+Return the list of `Connectivity` elements used to construct
+all `k`-faces of a polytope, following an ordering convention.
+"""
+function connectivity(polytope::Type{<:Polytope}, convention::OrderingConvention, k::Integer)
+  connectivity(polytope, convention, Val(k))
+end
+
+function facets(p::Polytope{N}, ordering=GMSH) where {N}
+  faces(p, N-1, ordering)
+end
+
+function faces(p::Polytope{N,Dim}, rank, ordering=GMSH) where {N,Dim}
+  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), ordering, rank))
+end

--- a/src/connectivities.jl
+++ b/src/connectivities.jl
@@ -48,27 +48,3 @@ end
 function Base.show(io::IO, c::Connectivity{PL}) where {PL}
   print(io, "$PL$(c.list)")
 end
-
-"""
-Convention used to reconstruct the faces of a polytope
-from a list of vertices.
-"""
-abstract type OrderingConvention end
-
-"""
-    connectivity(polytope, convention, k)
-
-Return the list of `Connectivity` elements used to construct
-all `k`-faces of a polytope, following an ordering convention.
-"""
-function connectivity(polytope::Type{<:Polytope}, convention::OrderingConvention, k::Integer)
-  connectivity(polytope, convention, Val(k))
-end
-
-function facets(p::Polytope{N}, ordering=GMSH) where {N}
-  faces(p, N-1, ordering)
-end
-
-function faces(p::Polytope{N,Dim}, rank, ordering=GMSH) where {N,Dim}
-  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), ordering, rank))
-end

--- a/src/conventions.jl
+++ b/src/conventions.jl
@@ -1,0 +1,33 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+Convention used to reconstruct the faces of a polytope
+from a list of vertices.
+"""
+abstract type OrderingConvention end
+
+"""
+    connectivity(polytope, convention, k)
+
+Return the list of `Connectivity` elements used to construct
+all `k`-faces of a polytope, following an ordering convention.
+"""
+function connectivity(polytope::Type{<:Polytope}, convention::OrderingConvention, k::Integer)
+  connectivity(polytope, convention, Val(k))
+end
+
+# ---------------------------
+# CONVENTION IMPLEMENTATIONS
+# ---------------------------
+
+include("conventions/gmsh.jl")
+
+function facets(p::Polytope{N}, ordering=GMSH) where {N}
+  faces(p, N-1, ordering)
+end
+
+function faces(p::Polytope{N,Dim}, rank, ordering=GMSH) where {N,Dim}
+  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), ordering, rank))
+end

--- a/src/conventions.jl
+++ b/src/conventions.jl
@@ -24,10 +24,10 @@ end
 
 include("conventions/gmsh.jl")
 
-function facets(p::Polytope{N}, ordering=GMSH) where {N}
-  faces(p, N-1, ordering)
+function facets(p::Polytope{N}, convention=GMSH) where {N}
+  faces(p, N-1, convention)
 end
 
-function faces(p::Polytope, rank, ordering=GMSH)
-  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), rank, ordering))
+function faces(p::Polytope, rank, convention=GMSH)
+  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), rank, convention))
 end

--- a/src/conventions.jl
+++ b/src/conventions.jl
@@ -9,13 +9,13 @@ from a list of vertices.
 abstract type OrderingConvention end
 
 """
-    connectivity(polytope, convention, k)
+    connectivities(polytope, convention, k)
 
 Return the list of `Connectivity` elements used to construct all
 faces of rank `rank` of a polytope, following an ordering convention.
 """
-function connectivity(polytope::Type{<:Polytope}, rank::Integer, convention::OrderingConvention)
-  connectivity(polytope, Val(rank), convention)
+function connectivities(polytope::Type{<:Polytope}, rank::Integer, convention::OrderingConvention)
+  connectivities(polytope, Val(rank), convention)
 end
 
 # ---------------------------
@@ -29,5 +29,5 @@ function facets(p::Polytope{N}, convention=GMSH) where {N}
 end
 
 function faces(p::Polytope, rank, convention=GMSH)
-  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), rank, convention))
+  (materialize(ord, p.vertices) for ord in connectivities(typeof(p), rank, convention))
 end

--- a/src/conventions.jl
+++ b/src/conventions.jl
@@ -11,11 +11,11 @@ abstract type OrderingConvention end
 """
     connectivity(polytope, convention, k)
 
-Return the list of `Connectivity` elements used to construct
-all `k`-faces of a polytope, following an ordering convention.
+Return the list of `Connectivity` elements used to construct all
+faces of rank `rank` of a polytope, following an ordering convention.
 """
-function connectivity(polytope::Type{<:Polytope}, convention::OrderingConvention, k::Integer)
-  connectivity(polytope, convention, Val(k))
+function connectivity(polytope::Type{<:Polytope}, rank::Integer, convention::OrderingConvention)
+  connectivity(polytope, Val(rank), convention)
 end
 
 # ---------------------------
@@ -28,6 +28,6 @@ function facets(p::Polytope{N}, ordering=GMSH) where {N}
   faces(p, N-1, ordering)
 end
 
-function faces(p::Polytope{N,Dim}, rank, ordering=GMSH) where {N,Dim}
-  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), ordering, rank))
+function faces(p::Polytope, rank, ordering=GMSH)
+  (materialize(ord, p.vertices) for ord in connectivity(typeof(p), rank, ordering))
 end

--- a/src/conventions.jl
+++ b/src/conventions.jl
@@ -9,12 +9,13 @@ from a list of vertices.
 abstract type OrderingConvention end
 
 """
-    connectivities(polytope, convention, k)
+    connectivities(polytope, rank, convention)
 
 Return the list of `Connectivity` elements used to construct all
 faces of rank `rank` of a polytope, following an ordering convention.
 """
-function connectivities(polytope::Type{<:Polytope}, rank::Integer, convention::OrderingConvention)
+function connectivities(polytope::Type{<:Polytope}, rank::Integer,
+                        convention::OrderingConvention)
   connectivities(polytope, Val(rank), convention)
 end
 

--- a/src/conventions/gmsh.jl
+++ b/src/conventions/gmsh.jl
@@ -20,7 +20,8 @@ struct GMSH <: OrderingConvention end
 # |        `\       
 # 0----------1 --> u
 
-connectivity(::Type{<:Triangle{GMSH}}, ::Val{1}, ::Type{GMSH}) = connect.([(1, 2), (2, 3), (3, 1)], Segment)
+connectivity(::Type{<:Triangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
+  connect.([(1, 2), (2, 3), (3, 1)], Segment)
 
 # Quadrangle
 #       v
@@ -34,7 +35,8 @@ connectivity(::Type{<:Triangle{GMSH}}, ::Val{1}, ::Type{GMSH}) = connect.([(1, 2
 # |           |      
 # 0-----------1      
 
-connectivity(::Type{<:Quadrangle{GMSH}}, ::Val{1}, ::Type{GMSH}) = connect.([(1, 2), (2, 3), (3, 4), (4, 1)], Segment)
+connectivity(::Type{<:Quadrangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
+  connect.([(1, 2), (2, 3), (3, 4), (4, 1)], Segment)
 
 # Pyramid
 #                4

--- a/src/conventions/gmsh.jl
+++ b/src/conventions/gmsh.jl
@@ -6,7 +6,7 @@
 Ordering convention of the GMSH project:
 https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
 """
-abstract type GMSH <: OrderingConvention end
+struct GMSH <: OrderingConvention end
 
 # Triangle
 # v

--- a/src/conventions/gmsh.jl
+++ b/src/conventions/gmsh.jl
@@ -20,7 +20,7 @@ struct GMSH <: OrderingConvention end
 # |        `\       
 # 0----------1 --> u
 
-connectivity(::Type{<:Triangle{GMSH}}, ::Type{GMSH}, ::Val{1}) = connect.([(1, 2), (2, 3), (3, 1)], Segment)
+connectivity(::Type{<:Triangle{GMSH}}, ::Val{1}, ::Type{GMSH}) = connect.([(1, 2), (2, 3), (3, 1)], Segment)
 
 # Quadrangle
 #       v
@@ -34,7 +34,7 @@ connectivity(::Type{<:Triangle{GMSH}}, ::Type{GMSH}, ::Val{1}) = connect.([(1, 2
 # |           |      
 # 0-----------1      
 
-connectivity(::Type{<:Quadrangle{GMSH}}, ::Type{GMSH}, ::Val{1}) = connect.([(1, 2), (2, 3), (3, 4), (4, 1)], Segment)
+connectivity(::Type{<:Quadrangle{GMSH}}, ::Val{1}, ::Type{GMSH}) = connect.([(1, 2), (2, 3), (3, 4), (4, 1)], Segment)
 
 # Pyramid
 #                4
@@ -54,7 +54,7 @@ connectivity(::Type{<:Quadrangle{GMSH}}, ::Type{GMSH}, ::Val{1}) = connect.([(1,
 #                     `\
 #                        u
 
-function connectivity(::Type{<:Pyramid{GMSH}}, ::Type{GMSH}, ::Val{2})
+function connectivity(::Type{<:Pyramid{GMSH}}, ::Val{2}, ::Type{GMSH})
   base = connect((1,2,3,4), Quadrangle)
   side = connect.([(1,2,5),(2,3,5),(3,4,5),(4,1,5)], Triangle)
   [base; side]
@@ -80,7 +80,7 @@ end
 #                 `\.
 #                    ` w
 
-connectivity(::Type{<:Tetrahedron{GMSH}}, ::Type{GMSH}, ::Val{2}) = 
+connectivity(::Type{<:Tetrahedron{GMSH}}, ::Val{2}, ::Type{GMSH}) =
   connect.([(1,2,3),(1,4,3),(1,4,2),(2,3,4)], Triangle)
 
 # Hexahedron
@@ -97,6 +97,6 @@ connectivity(::Type{<:Tetrahedron{GMSH}}, ::Type{GMSH}, ::Val{2}) =
 #    \|      w  \|     
 #     4----------5     
 
-connectivity(::Type{<:Hexahedron}, ::Type{GMSH}, ::Val{2}) = 
+connectivity(::Type{<:Hexahedron}, ::Val{2}, ::Type{GMSH}) =
   connect.([(1,2,3,4),(5,6,7,8),(1,5,6,2),
-  (2,6,7,3),(3,4,8,7),(1,5,8,4)], Quadrangle)
+            (2,6,7,3),(3,4,8,7),(1,5,8,4)], Quadrangle)

--- a/src/conventions/gmsh.jl
+++ b/src/conventions/gmsh.jl
@@ -20,7 +20,7 @@ struct GMSH <: OrderingConvention end
 # |        `\       
 # 0----------1 --> u
 
-connectivity(::Type{<:Triangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
+connectivities(::Type{<:Triangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
   connect.([(1, 2), (2, 3), (3, 1)], Segment)
 
 # Quadrangle
@@ -35,7 +35,7 @@ connectivity(::Type{<:Triangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
 # |           |      
 # 0-----------1      
 
-connectivity(::Type{<:Quadrangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
+connectivities(::Type{<:Quadrangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
   connect.([(1, 2), (2, 3), (3, 4), (4, 1)], Segment)
 
 # Pyramid
@@ -56,7 +56,7 @@ connectivity(::Type{<:Quadrangle{GMSH}}, ::Val{1}, ::Type{GMSH}) =
 #                     `\
 #                        u
 
-function connectivity(::Type{<:Pyramid{GMSH}}, ::Val{2}, ::Type{GMSH})
+function connectivities(::Type{<:Pyramid{GMSH}}, ::Val{2}, ::Type{GMSH})
   base = connect((1,2,3,4), Quadrangle)
   side = connect.([(1,2,5),(2,3,5),(3,4,5),(4,1,5)], Triangle)
   [base; side]
@@ -82,7 +82,7 @@ end
 #                 `\.
 #                    ` w
 
-connectivity(::Type{<:Tetrahedron{GMSH}}, ::Val{2}, ::Type{GMSH}) =
+connectivities(::Type{<:Tetrahedron{GMSH}}, ::Val{2}, ::Type{GMSH}) =
   connect.([(1,2,3),(1,4,3),(1,4,2),(2,3,4)], Triangle)
 
 # Hexahedron
@@ -99,6 +99,6 @@ connectivity(::Type{<:Tetrahedron{GMSH}}, ::Val{2}, ::Type{GMSH}) =
 #    \|      w  \|     
 #     4----------5     
 
-connectivity(::Type{<:Hexahedron}, ::Val{2}, ::Type{GMSH}) =
+connectivities(::Type{<:Hexahedron}, ::Val{2}, ::Type{GMSH}) =
   connect.([(1,2,3,4),(5,6,7,8),(1,5,6,2),
             (2,6,7,3),(3,4,8,7),(1,5,8,4)], Quadrangle)

--- a/src/conventions/gmsh.jl
+++ b/src/conventions/gmsh.jl
@@ -1,0 +1,102 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+Ordering convention of the GMSH project:
+https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
+"""
+abstract type GMSH <: OrderingConvention end
+
+# Triangle
+# v
+# ^                 
+# |                 
+# 2                 
+# |`\               
+# |  `\             
+# |    `\           
+# |      `\         
+# |        `\       
+# 0----------1 --> u
+
+connectivity(::Type{<:Triangle{GMSH}}, ::Type{GMSH}, ::Val{1}) = connect.([(1, 2), (2, 3), (3, 1)], Segment)
+
+# Quadrangle
+#       v
+#       ^
+#       |
+# 3-----------2      
+# |     |     |      
+# |     |     |      
+# |     +---- | --> u
+# |           |      
+# |           |      
+# 0-----------1      
+
+connectivity(::Type{<:Quadrangle{GMSH}}, ::Type{GMSH}, ::Val{1}) = connect.([(1, 2), (2, 3), (3, 4), (4, 1)], Segment)
+
+# Pyramid
+#                4
+#              ,/|\
+#            ,/ .'|\
+#          ,/   | | \
+#        ,/    .' | `.
+#      ,/      |  '.  \
+#    ,/       .' w |   \
+#  ,/         |  ^ |    \
+# 0----------.'--|-3    `.
+#  `\        |   |  `\    \
+#    `\     .'   +----`\ - \ -> v
+#      `\   |    `\     `\  \
+#        `\.'      `\     `\`
+#           1----------------2
+#                     `\
+#                        u
+
+function connectivity(::Type{<:Pyramid{GMSH}}, ::Type{GMSH}, ::Val{2})
+  base = connect((1,2,3,4), Quadrangle)
+  side = connect.([(1,2,5),(2,3,5),(3,4,5),(4,1,5)], Triangle)
+  [base; side]
+end
+
+# Tetrahedron
+#                    v
+#                  .
+#                ,/
+#               /
+#            2                 
+#          ,/|`\               
+#        ,/  |  `\             
+#      ,/    '.   `\           
+#    ,/       |     `\         
+#  ,/         |       `\       
+# 0-----------'.--------1 --> u
+#  `\.         |      ,/       
+#     `\.      |    ,/         
+#        `\.   '. ,/           
+#           `\. |/             
+#              `3              
+#                 `\.
+#                    ` w
+
+connectivity(::Type{<:Tetrahedron{GMSH}}, ::Type{GMSH}, ::Val{2}) = 
+  connect.([(1,2,3),(1,4,3),(1,4,2),(2,3,4)], Triangle)
+
+# Hexahedron
+#        v
+# 3----------2         
+# |\     ^   |\        
+# | \    |   | \       
+# |  \   |   |  \      
+# |   7------+---6     
+# |   |  +-- |-- | -> u
+# 0---+---\--1   |     
+#  \  |    \  \  |     
+#   \ |     \  \ |     
+#    \|      w  \|     
+#     4----------5     
+
+connectivity(::Type{<:Hexahedron}, ::Type{GMSH}, ::Val{2}) = 
+  connect.([(1,2,3,4),(5,6,7,8),(1,5,6,2),
+  (2,6,7,3),(3,4,8,7),(1,5,8,4)], Quadrangle)

--- a/src/polytopes/hexahedron.jl
+++ b/src/polytopes/hexahedron.jl
@@ -24,9 +24,3 @@ A hexahedron with points `p1`, `p2`, ..., `p8`.
 struct Hexahedron{Dim,T,V<:AbstractVector{Point{Dim,T}}} <: Polyhedron{Dim,T}
   vertices::V
 end
-
-function facets(hex::Hexahedron)
-  connec = connect.([(1,2,3,4),(5,6,7,8),(1,5,6,2),
-                     (2,6,7,3),(3,4,8,7),(1,5,8,4)], Quadrangle)
-  (materialize(c, hex.vertices) for c in connec)
-end

--- a/src/polytopes/pyramid.jl
+++ b/src/polytopes/pyramid.jl
@@ -28,10 +28,3 @@ A pyramid with points `p1`, `p2`, `p3`, `p4`, `p5`.
 struct Pyramid{Dim,T,V<:AbstractVector{Point{Dim,T}}} <: Polyhedron{Dim,T}
   vertices::V
 end
-
-function facets(pyr::Pyramid)
-  base = connect((1,2,3,4), Quadrangle)
-  side = connect.([(1,2,5),(2,3,5),(3,4,5),(4,1,5)], Triangle)
-  connec = [base; side]
-  (materialize(c, pyr.vertices) for c in connec)
-end

--- a/src/polytopes/quadrangle.jl
+++ b/src/polytopes/quadrangle.jl
@@ -22,8 +22,3 @@ A quadrangle with points `p1`, `p2`, `p3`, `p4`.
 struct Quadrangle{Dim,T,V<:AbstractVector{Point{Dim,T}}} <: Polygon{Dim,T}
   vertices::V
 end
-
-function facets(quad::Quadrangle)
-  connec = connect.([(1,2),(2,3),(3,4),(4,1)], Segment)
-  (materialize(c, quad.vertices) for c in connec)
-end

--- a/src/polytopes/tetrahedron.jl
+++ b/src/polytopes/tetrahedron.jl
@@ -30,8 +30,3 @@ A tetrahedron with points `p1`, `p2`, `p3`, `p4`.
 struct Tetrahedron{Dim,T,V<:AbstractVector{Point{Dim,T}}} <: Polyhedron{Dim,T}
   vertices::V
 end
-
-function facets(tetra::Tetrahedron)
-  connec = connect.([(1,2,3),(1,4,3),(1,4,2),(2,3,4)], Triangle)
-  (materialize(c, tetra.vertices) for c in connec)
-end

--- a/src/polytopes/triangle.jl
+++ b/src/polytopes/triangle.jl
@@ -22,8 +22,3 @@ A triangle with points `p1`, `p2`, `p3`.
 struct Triangle{Dim,T,V<:AbstractVector{Point{Dim,T}}} <: Polygon{Dim,T}
   vertices::V
 end
-
-function facets(tri::Triangle)
-  connec = connect.([(1,2), (2,3), (3,1)], Segment)
-  (materialize(c, tri.vertices) for c in connec)
-end


### PR DESCRIPTION
Rewrite of PR #13. Removes the implicit ordering defined for common polytopes, in favor of an explicit ordering that can be customized by subtyping from `OrderingConvention`. The previously implicit ordering is now explicit, as defined by the `GMSH` type.