### PR TITLE
Use atan for angle computations

### DIFF
--- a/src/angles.jl
+++ b/src/angles.jl
@@ -8,7 +8,8 @@
 Angle ∠ABC between rays BA and BC.
 See https://en.wikipedia.org/wiki/Angle.
 
-Uses the two-argument form of `atan`. See https://en.wikipedia.org/wiki/Atan2.
+Uses the two-argument form of `atan`.
+See https://en.wikipedia.org/wiki/Atan2.
 
 ## Example
 

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -14,7 +14,7 @@ See https://en.wikipedia.org/wiki/Atan2.
 ## Example
 
 ```julia
-∠(Point(0,1), Point(0,0), Point(1,0)) == π/2
+∠(Point(1,0), Point(0,0), Point(0,1)) == π/2
 ```
 """
 function ∠(A::P, B::P, C::P) where {P<:Point{2}}

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -8,6 +8,8 @@
 Angle ∠ABC between rays BA and BC.
 See https://en.wikipedia.org/wiki/Angle.
 
+Uses the two-argument form of `atan`. See https://en.wikipedia.org/wiki/Atan2.
+
 ## Example
 
 ```julia

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -13,12 +13,6 @@ See https://en.wikipedia.org/wiki/Angle.
 ```julia
 ∠(Point(0,1), Point(0,0), Point(1,0)) == π/2
 ```
-
-## References
-
-* Balbes, R. and Siegel, J. 1990. [A robust method for calculating
-  the simplicity and orientation of planar polygons]
-  (https://www.sciencedirect.com/science/article/abs/pii/0167839691900198)
 """
 function ∠(A::P, B::P, C::P) where {P<:Point{2}}
   BA = A - B
@@ -27,16 +21,5 @@ function ∠(A::P, B::P, C::P) where {P<:Point{2}}
   cross = BA × BC
   inner = BA ⋅ BC
 
-  R = norm(cross) / (norm(BA) * norm(BC))
-
-  # Table 1 from Balbes, R. and Siegel, J. 1990.
-  if cross ≥ 0 && inner ≥ 0
-    asin(R)
-  elseif cross ≥ 0 && inner < 0
-    π - asin(R)
-  elseif cross < 0 && inner ≥ 0
-    -asin(R)
-  elseif cross < 0 && inner < 0
-    asin(R) - π
-  end
+  atan(cross, inner)
 end

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -79,7 +79,9 @@
     s2 = Segment(P2(3,0), P2(4,0))
     @test s1 ∩ s2 === s2 ∩ s1 === nothing
 
-    @test Segment(P2(2.,1.), P2(1.,2.)) ∩ Segment(P2(1.,0.), P2(1.,1.)) === nothing
+    s1 = Segment(P2(2,1), P2(1,2))
+    s2 = Segment(P2(1,0), P2(1,1))
+    @test s1 ∩ s2 === s2 ∩ s1 === nothing
   end
 
   @testset "Triangles" begin

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -78,6 +78,8 @@
     s1 = Segment(P2(0,0), P2(2,0))
     s2 = Segment(P2(3,0), P2(4,0))
     @test s1 ∩ s2 === s2 ∩ s1 === nothing
+
+    @test Segment(P2(2.,1.), P2(1.,2.)) ∩ Segment(P2(1.,0.), P2(1.,1.)) === nothing
   end
 
   @testset "Triangles" begin


### PR DESCRIPTION
This is a simpler alternative to the method from _Balbes, R. and Siegel, J. 1990_ for computing angles. It relies on the two-argument version of `atan`. Also tests and fixes #27 (including the spotted `DomainError` in simple precision).