### PR TITLE
Add benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,24 @@
+name: Run benchmarks
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  Benchmark:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run benchmark')
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Install dependencies
+        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+      - name: Run benchmarks
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
+      - name: Post results
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 Manifest.toml
 .vscode
 docs/build
+/.benchmarkci
+/benchmark/*.json

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,17 @@
+using BenchmarkTools
+using BenchmarkTools: tune!, allocs,
+      prettytime, time, prettymemory, memory, generate_benchmark_definition,
+      Parameters, benchmarkable_parts, collectvars, warmup, Trial
+
+include("utils.jl")
+
+SUITE = BenchmarkGroup()
+
+include("points.jl")
+
+t = @elapsed using Meshes
+println("Julia version is $VERSION")
+println(string("Meshes.jl loading time: \e[33;1;1m$t\e[m seconds"))
+println()
+println("Benchmarking Meshes.jl...")
+println()

--- a/benchmark/points.jl
+++ b/benchmark/points.jl
@@ -1,0 +1,8 @@
+SUITE["points"] = BenchmarkGroup(["microbenchmark", "points"]) # add tags for eventual filtering
+
+add_benchmark!(SUITE["points"], [
+  :(Point(0., 1.)),
+  :(Point([0., 1.])),
+  :(Point([0., 1])),
+  :(Point(0., convert(Float64, 1))),
+])

--- a/benchmark/utils.jl
+++ b/benchmark/utils.jl
@@ -1,0 +1,57 @@
+"""
+Non-macro adaptation from `BenchmarkTools.@benchmarkable`.
+"""
+function benchmarkable(ex, params = [])
+  core, setup, teardown, _ = benchmarkable_parts([:(Ref($ex)[])])
+
+  # extract any variable bindings shared between the core and setup expressions
+  setup_vars = isa(setup, Expr) ? collectvars(setup) : []
+  core_vars = isa(core, Expr) ? collectvars(core) : []
+  out_vars = filter(in(setup_vars), core_vars)
+
+  # generate the benchmark definition
+  bench = generate_benchmark_definition(
+    @__MODULE__,
+    out_vars,
+    setup_vars,
+    core,
+    setup,
+    teardown,
+    Parameters(; params...),
+  )
+end
+
+function add_benchmark!(group::BenchmarkGroup, ex::Expr)
+  group[string(ex)] = benchmarkable(ex)
+end
+
+function add_benchmark!(group::BenchmarkGroup, exs)
+  add_benchmark!.(Ref(group), exs)
+  group
+end
+
+function display_trial(trial::Trial)
+  trialallocs = allocs(trial)
+  trialmin = minimum(trial)
+
+  println(
+    "\e[33;1;1m",
+    prettytime(time(trial)),
+    "\e[m (", trialallocs , " allocation",
+    trialallocs == 1 ? "" : "s", ": ",
+    prettymemory(memory(trial)), ")",
+  )
+end
+
+function display_group(group::BenchmarkGroup)
+    nchars_left = maximum(length, keys(group.data))
+    foreach(group.data) do (str, val)
+      if val isa Trial
+        print(' '^2, rpad(str, nchars_left), " :  ")
+        display_trial(val)
+      else
+        println("\e[34;1;1m", str, "\e[m")
+        display_group(val)
+      end
+    end
+end


### PR DESCRIPTION
Remake of #41.

To see an up to date example of the introduced GitHub Action for benchmarks, see [this fake PR](https://github.com/serenity4/Meshes.jl/pull/3). It uses `postjudge` from [BenchmarkCI](https://github.com/tkf/BenchmarkCI.jl) to create a comment every time a commit is pushed onto a PR labeled "run benchmark".

The CI infrastructure is no longer a WIP and is ready to be merged. Only 4 benchmarks are currently present, I suggest we merge this PR and then add more benchmarks if desired on other PRs.