### PR TITLE
Simplify intersection between colinear segments

### DIFF
--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -41,7 +41,7 @@
 
     s1 = Segment(P2(1,2), P2(1,0))
     s2 = Segment(P2(1,0), P2(1,1))
-    @test s1 ∩ s2 == Segment(P2(1,1), P2(1,0))
+    @test s1 ∩ s2 == Segment(P2(1,0), P2(1,1))
 
     s1 = Segment(P2(0,0), P2(2,0))
     s2 = Segment(P2(-2,0), P2(-1,0))


### PR DESCRIPTION
First attempt to improve #54 

The previous implementation was unnecessarily complex. The new one should be much simpler to understand and to maintain.

There is a small difference of behavior compared to the previous implementation. Previously I was returning the segment with an orientation that matched the first segment of the intersection. Now I am always returning segments that are oriented toward the positive orthant. I think it is a reasonable default, what do you think?

cc: @Arkoniak