### PR TITLE
Invalidate adjacent ears after pop in FIST (fix #65)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Meshes"
 uuid = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 authors = ["Júlio Hoffimann and contributors"]
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/discretization/fist.jl
+++ b/src/discretization/fist.jl
@@ -50,8 +50,13 @@ function discretize(polyarea::PolyArea, ::FIST)
       𝒫 = Chain(points[inds])
       n = nvertices(𝒫)
       # 3. update 𝒬 near clipped ear
-      update_adjacent_ear!(𝒬, 𝒫, i-1, n)
-      update_adjacent_ear!(𝒬, 𝒫, i, n)
+      for j in (i-1, i)
+        if isear(𝒫, j)
+          𝒬 = 𝒬 ∪ [mod1(j,n)]
+        else
+          𝒬 = setdiff(𝒬, [mod1(j,n)])
+        end
+      end
       clipped = true
     elseif clipped # recompute all ears
       𝒬 = ears(𝒫)
@@ -141,16 +146,4 @@ function isearccw(𝒫::Chain{Dim,T}, i) where {Dim,T}
   incones = incone(i-1, i+1) && incone(i+1, i-1)
 
   isconvex && !intersects && incones
-end
-
-function update_adjacent_ear!(𝒬, 𝒫, i, n)
-  if !isear(𝒫, i)
-    ind = findfirst(==(i), 𝒬)
-    !isnothing(ind) && deleteat!(𝒬, ind)
-  else
-    if mod1(i,n) ∉ 𝒬
-      ind = something(findfirst(>(mod1(i,n)), 𝒬), 1)
-      insert!(𝒬, ind, mod1(i,n))
-    end
-  end
 end

--- a/src/discretization/fist.jl
+++ b/src/discretization/fist.jl
@@ -50,8 +50,8 @@ function discretize(polyarea::PolyArea, ::FIST)
       𝒫 = Chain(points[inds])
       n = nvertices(𝒫)
       # 3. update 𝒬 near clipped ear
-      isear(𝒫, i)   && (𝒬 = 𝒬 ∪ [mod1(i,n)])
-      isear(𝒫, i+1) && (𝒬 = 𝒬 ∪ [mod1(i+1,n)])
+      update_adjacent_ear!(𝒬, 𝒫, i-1, n)
+      update_adjacent_ear!(𝒬, 𝒫, i, n)
       clipped = true
     elseif clipped # recompute all ears
       𝒬 = ears(𝒫)
@@ -141,4 +141,16 @@ function isearccw(𝒫::Chain{Dim,T}, i) where {Dim,T}
   incones = incone(i-1, i+1) && incone(i+1, i-1)
 
   isconvex && !intersects && incones
+end
+
+function update_adjacent_ear!(𝒬, 𝒫, i, n)
+  if !isear(𝒫, i)
+    ind = findfirst(==(i), 𝒬)
+    !isnothing(ind) && deleteat!(𝒬, ind)
+  else
+    if mod1(i,n) ∉ 𝒬
+      ind = something(findfirst(>(mod1(i,n)), 𝒬), 1)
+      insert!(𝒬, ind, mod1(i,n))
+    end
+  end
 end

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -1,4 +1,13 @@
 @testset "Discretization" begin
+  function is_fully_connected(mesh::UnstructuredMesh)
+    inds = 1:length(vertices(mesh))
+    connected = Iterators.flatten(getproperty.(mesh.connec, :list))
+    all(inds .== sort(unique(connected)))
+  end
+  function has_same_vertices(𝒫::PolyArea, mesh::UnstructuredMesh)
+    Set(vcat(vertices.(chains(𝒫))...)) == Set(vertices(mesh))
+  end
+
   @testset "FIST" begin
     𝒫 = Chain(P2[(0,0),(1,0),(1,1),(2,1),(2,2),(1,2),(0,0)])
     @test Meshes.ears(𝒫) == [2,4,5]
@@ -30,95 +39,46 @@
     @test Meshes.ears(𝒫) == [1,3,5,6,8,10,12,14]
 
     points = P2[(0,0),(1,0),(1,1),(2,1),(2,2),(1,2),(0,0)]
-    connec = connect.([(4,5,6),(3,4,6),(3,6,1),(1,2,3)], Triangle)
-    target = UnstructuredMesh(points[1:end-1], connec)
     𝒫 = PolyArea(points)
     mesh = discretize(𝒫, FIST())
-    @test mesh == target
+    @test is_fully_connected(mesh)
+    @test has_same_vertices(𝒫, mesh)
+    @test nelements(mesh) == nvertices(𝒫) - 2
 
-    poly = readpoly(joinpath(datadir, "poly1.line"))
-    points = P2.(coordinates.(vertices(first(chains(poly)))))
-    connec = connect.([(26,27,28), (26,28,29), (23,24,25),
-                       (23,25,26), (23,26,29), (23,29,30),
-                       (21,22,23), (20,21,23), (16,17,18),
-                       (16,18,19), (19,20,23), (19,23,30),
-                       (13,14,15), (15,16,19), (11,12,13),
-                       (13,15,19), (13,19,30), (8,9,10),
-                       (7,8,10), (6,7,10), (4,5,6),
-                       (4,6,10), (4,10,11), (11,13,30),
-                       (11,30,1), (3,4,11), (3,11,1),
-                       (1,2,3)], Triangle)
-    target = UnstructuredMesh(points, connec)
-    𝒫 = PolyArea([points; points[1]])
+    𝒫 = readpoly(joinpath(datadir, "poly1.line"))
     mesh = discretize(𝒫, FIST())
-    @test mesh == target
+    @test is_fully_connected(mesh)
+    @test has_same_vertices(𝒫, mesh)
+    @test nelements(mesh) == nvertices(𝒫) - 2
 
-    poly = readpoly(joinpath(datadir, "poly2.line"))
-    points = P2.(coordinates.(vertices(first(chains(poly)))))
-    connec = connect.([(28, 29, 30), (24, 25, 26), (23, 24, 26),
-                       (22, 23, 26), (21, 22, 26), (21, 26, 27),
-                       (21, 27, 28), (19, 20, 21), (19, 21, 28),
-                       (19, 28, 30), (18, 19, 30), (15, 16, 17),
-                       (17, 18, 30), (17, 30, 1), (17, 1, 2),
-                       (14, 15, 17), (14, 17, 2), (11, 12, 13),
-                       (13, 14, 2), (10, 11, 13), (9, 10, 13),
-                       (8, 9, 13), (8, 13, 2), (7, 8, 2),
-                       (6, 7, 2), (3, 4, 5), (5, 6, 2),
-                       (2, 3, 5)], Triangle)
-    target = UnstructuredMesh(points, connec)
-    𝒫 = PolyArea([points; points[1]])
+    𝒫 = readpoly(joinpath(datadir, "poly2.line"))
     mesh = discretize(𝒫, FIST())
-    @test mesh == target
+    @test is_fully_connected(mesh)
+    @test has_same_vertices(𝒫, mesh)
+    @test nelements(mesh) == nvertices(𝒫) - 2
 
-    poly = readpoly(joinpath(datadir, "poly3.line"))
-    points = P2.(coordinates.(vertices(first(chains(poly)))))
-    connec = connect.([(28, 29, 30), (26, 27, 28), (24, 25, 26),
-                       (23, 24, 26), (23, 26, 28), (21, 22, 23),
-                       (21, 23, 28), (21, 28, 30), (19, 20, 21),
-                       (19, 21, 30), (19, 30, 1), (15, 16, 17),
-                       (12, 13, 14), (14, 15, 17), (12, 14, 17),
-                       (10, 11, 12), (9, 10, 12), (8, 9, 12),
-                       (5, 6, 7), (4, 5, 7), (3, 4, 7),
-                       (7, 8, 12), (18, 19, 1), (3, 7, 12),
-                       (12, 17, 18), (18, 1, 2), (18, 2, 3),
-                       (3, 12, 18)], Triangle)
-    target = UnstructuredMesh(points, connec)
-    𝒫 = PolyArea([points; points[1]])
+    𝒫 = readpoly(joinpath(datadir, "poly3.line"))
     mesh = discretize(𝒫, FIST())
-    @test mesh == target
+    @test is_fully_connected(mesh)
+    @test has_same_vertices(𝒫, mesh)
+    @test nelements(mesh) == nvertices(𝒫) - 2
 
-    poly = readpoly(joinpath(datadir, "poly4.line"))
-    points = P2.(coordinates.(vertices(first(chains(poly)))))
-    connec = connect.([(24, 25, 26), (23, 24, 26), (23, 26, 27),
-                       (23, 27, 28), (20, 21, 22), (22, 23, 28),
-                       (22, 28, 29), (22, 29, 30), (17, 18, 19),
-                       (16, 17, 19), (15, 16, 19), (13, 14, 15),
-                       (13, 15, 19), (13, 19, 20), (20, 22, 30),
-                       (11, 12, 13), (11, 13, 20), (11, 20, 30),
-                       (11, 30, 1), (6, 7, 8), (6, 8, 9),
-                       (6, 9, 10), (10, 11, 1), (10, 1, 2),
-                       (4, 5, 6), (4, 6, 10), (4, 10, 2),
-                       (2, 3, 4)], Triangle)
-    target = UnstructuredMesh(points, connec)
-    𝒫 = PolyArea([points; points[1]])
+    𝒫 = readpoly(joinpath(datadir, "poly4.line"))
     mesh = discretize(𝒫, FIST())
-    @test mesh == target
+    @test is_fully_connected(mesh)
+    @test has_same_vertices(𝒫, mesh)
+    @test nelements(mesh) == nvertices(𝒫) - 2
 
-    poly = readpoly(joinpath(datadir, "poly5.line"))
-    points = P2.(coordinates.(vertices(first(chains(poly)))))
-    connec = connect.([(25, 26, 27), (24, 25, 27), (23, 24, 27),
-                       (23, 27, 28), (23, 28, 29), (19, 20, 21),
-                       (18, 19, 21), (17, 18, 21), (15, 16, 17),
-                       (12, 13, 14), (7, 8, 9), (6, 7, 9),
-                       (6, 9, 10), (4, 5, 6), (2, 3, 4),
-                       (2, 4, 6), (1, 2, 6), (30, 1, 6),
-                       (22, 23, 29), (22, 29, 30), (11, 12, 14),
-                       (10, 11, 14), (10, 14, 15), (10, 15, 17),
-                       (6, 10, 17), (6, 17, 21), (6, 21, 22),
-                       (6, 22, 30)], Triangle)
-    target = UnstructuredMesh(points, connec)
-    𝒫 = PolyArea([points; points[1]])
+    𝒫 = readpoly(joinpath(datadir, "poly5.line"))
     mesh = discretize(𝒫, FIST())
-    @test mesh == target
+    @test is_fully_connected(mesh)
+    @test has_same_vertices(𝒫, mesh)
+    @test nelements(mesh) == nvertices(𝒫) - 2
+
+    𝒫 = readpoly(joinpath(datadir, "smooth1.line"))
+    mesh = discretize(𝒫, FIST())
+    @test is_fully_connected(mesh)
+    @test has_same_vertices(𝒫, mesh)
+    @test nelements(mesh) == nvertices(𝒫) - 2
   end
 end

--- a/test/partitioning.jl
+++ b/test/partitioning.jl
@@ -85,6 +85,20 @@
     p = partition(grid, BlockPartition(T(5),T(2)))
     @test length(p) == 12
     @test Set(nelements.(p)) == Set([5,10])
+
+    grid = CartesianGrid{T}(50, 50, 50)
+
+    p = partition(grid, BlockPartition(T(1.), T(1.), T(1.), neighbors = false))
+    @test length(p) == 125000
+    @test Set(nelements.(p)) == Set(1)
+    @test metadata(p) == Dict{Any,Any}()
+
+    p = partition(grid, BlockPartition(T(5.), T(5.), T(5.), neighbors = true))
+    @test length(p) == 1000
+    @test Set(nelements.(p)) == Set(125)
+    n = metadata(p)[:neighbors]
+    @test length(n) == length(p)
+    @test all(0 .< length.(n) .< 27) 
   end
 
   @testset "BisectPointPartition" begin


### PR DESCRIPTION
The bug was a missing update step for the ears list. Adjacent ears were not discarded after one was popped.
I will update the tests tomorrow.