### PR TITLE
Add segments function for chains

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -128,7 +128,7 @@ export
   Chain, PolyArea,
   vertices, nvertices,
   faces, facets,
-  windingnumber, chains,
+  windingnumber, chains, segments,
   isclosed, issimple, hasholes,
   angles, innerangles, close!, open!,
   orientation, bridge,

--- a/src/polytopes/chain.jl
+++ b/src/polytopes/chain.jl
@@ -39,9 +39,9 @@ end
 Return the segments linking consecutive points of the `chain`.
 """
 function segments(c::Chain)
-  vs = vertices(c)
+  vs = c.vertices
   n = length(vs)
-  [Segment(view(vs, [i,i+1])) for i in 1:n-1]
+  (Segment(view(vs, [i,i+1])) for i in 1:n-1)
 end
 
 """
@@ -63,7 +63,7 @@ intersect at end points.
 """
 function issimple(c::Chain)
   vs = c.vertices
-  ss = segments(c)
+  ss = collect(segments(c))
   for i in 1:length(ss)
     for j in i+1:length(ss)
       I = intersecttype(ss[i], ss[j])

--- a/src/polytopes/chain.jl
+++ b/src/polytopes/chain.jl
@@ -63,7 +63,7 @@ intersect at end points.
 """
 function issimple(c::Chain)
   vs = c.vertices
-  ss = [Segment(view(vs, [i,i+1])) for i in 1:length(vs)-1]
+  ss = segments(c)
   for i in 1:length(ss)
     for j in i+1:length(ss)
       I = intersecttype(ss[i], ss[j])

--- a/src/polytopes/chain.jl
+++ b/src/polytopes/chain.jl
@@ -41,9 +41,7 @@ Return the segments linking consecutive points of the `chain`.
 function segments(c::Chain)
   vs = vertices(c)
   n = length(vs)
-  map(1:(n-1), 2:n) do (i, j)
-    Segment(vs[i], vs[j])
-  end
+  [Segment(vs[i,i+1]) for i in 1:n-1]
 end
 
 """

--- a/src/polytopes/chain.jl
+++ b/src/polytopes/chain.jl
@@ -41,7 +41,7 @@ Return the segments linking consecutive points of the `chain`.
 function segments(c::Chain)
   vs = vertices(c)
   n = length(vs)
-  [Segment(vs[i,i+1]) for i in 1:n-1]
+  [Segment(view(vs, [i,i+1])) for i in 1:n-1]
 end
 
 """

--- a/src/polytopes/chain.jl
+++ b/src/polytopes/chain.jl
@@ -34,6 +34,19 @@ function vertices(c::Chain)
 end
 
 """
+    segments(chain)
+
+Return the segments linking consecutive points of the `chain`.
+"""
+function segments(c::Chain)
+  vs = vertices(c)
+  n = length(vs)
+  map(1:(n-1), 2:n) do (i, j)
+    Segment(vs[i], vs[j])
+  end
+end
+
+"""
     isclosed(chain)
 
 Tells whether or not the chain is closed.

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -135,7 +135,10 @@
   @testset "Chains" begin
     # segments
     c = Chain(P2[(1,1),(2,2),(3,3)])
-    @test segments(c) == [Segment(P2(1,1),P2(2,2)),Segment(P2(2,2),P2(3,3))]
+    @test collect(segments(c)) == [Segment(P2(1,1),P2(2,2)),Segment(P2(2,2),P2(3,3))]
+
+    c = Chain(P2[(1,1),(2,2),(3,3),(1,1)])
+    @test collect(segments(c)) == [Segment(P2(1,1),P2(2,2)),Segment(P2(2,2),P2(3,3)),Segment(P2(3,3),P2(1,1))]
 
     # unique vertices
     c = Chain(P2[(1,1),(2,2),(2,2),(3,3)])

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -133,6 +133,10 @@
   end
 
   @testset "Chains" begin
+    # segments
+    c = Chain(P2[(1,1),(2,2),(3,3)])
+    @test segments(c) == [Segment(P2(1,1),P2(2,2)),Segment(P2(2,2),P2(3,3))]
+
     # unique vertices
     c = Chain(P2[(1,1),(2,2),(2,2),(3,3)])
     @test unique(c) == Chain(P2[(1,1),(2,2),(3,3)])


### PR DESCRIPTION
This PR adds a utility function that returns all the consecutive segments of a `Chain` object.