### PR TITLE
Add `Ray` primitive

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -117,7 +117,7 @@ export
 
   # primitives
   Primitive,
-  Line, Box, Ball, Sphere, Cylinder,
+  Line, Ray, Box, Ball, Sphere, Cylinder,
   center, radius, height, sides,
   measure, diagonal,
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -13,6 +13,7 @@ See https://en.wikipedia.org/wiki/Geometric_primitive.
 abstract type Primitive{Dim,T} <: Geometry{Dim,T} end
 
 include("primitives/line.jl")
+include("primitives/ray.jl")
 include("primitives/box.jl")
 include("primitives/ball.jl")
 include("primitives/sphere.jl")

--- a/src/primitives/ray.jl
+++ b/src/primitives/ray.jl
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    Ray(p, v)
+
+A ray originating at point `p`, pointed in direction `v`.
+"""
+struct Ray{Dim,T} <: Primitive{Dim,T}
+    p::Point{Dim,T}
+    v::Vec{Dim,T}
+end
+
+paramdim(::Type{<:Ray}) = 1

--- a/src/primitives/ray.jl
+++ b/src/primitives/ray.jl
@@ -8,8 +8,8 @@
 A ray originating at point `p`, pointed in direction `v`.
 """
 struct Ray{Dim,T} <: Primitive{Dim,T}
-    p::Point{Dim,T}
-    v::Vec{Dim,T}
+  p::Point{Dim,T}
+  v::Vec{Dim,T}
 end
 
 paramdim(::Type{<:Ray}) = 1

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -4,6 +4,11 @@
     @test paramdim(l) == 1
   end
 
+  @testset "Rays" begin
+    r = Ray(P2(0,0), V2(1,1))
+    @test paramdim(r) == 1
+  end
+
   @testset "Boxes" begin
     b = Box(P2(0,0), P2(1,1))
     @test embeddim(b) == 2


### PR DESCRIPTION
`Ray(p::Point, v::Vec)` describes a ray originating at `p`, pointing in the direction given by `v`.