### PR TITLE
Fix duplicate method warning

### DIFF
--- a/src/viewing.jl
+++ b/src/viewing.jl
@@ -61,7 +61,7 @@ end
 # convert from Cartesian to linear indices if needed
 @traitfn _linear(domain::D, inds) where {D; IsGrid{D}} =
   vec(LinearIndices(size(domain))[inds])
-@traitfn _linear(::D, inds) where {D; !IsGrid{D}} = inds
+@traitfn _linear(domain::D, inds) where {D; !IsGrid{D}} = inds
 
 """
     viewindices(domain, geometry)


### PR DESCRIPTION
Fixes #53 

As per the comment in the SimpleTraits README, negated trait functions must use the same argument
names in order to avoid duplicate definitions:

  > Long story short: define the two methods of a trait and its negation using the same argument
  > names and no warning should be issued.