### PR TITLE
Refactor distances between geometries | Part 2: closest_point

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -127,7 +127,7 @@ export
   centroid,
 
   # distances
-  mindistance,
+  closest_point, mindistance,
 
   # primitives
   Primitive,

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -15,7 +15,7 @@ using Random
 using IterTools: ivec
 using StatsBase: Weights
 using SpecialFunctions: gamma
-using Distances: PreMetric, Euclidean, Mahalanobis, evaluate
+using Distances: PreMetric, Euclidean, Mahalanobis, SqEuclidean, evaluate
 using ReferenceFrameRotations: angle_to_dcm
 using NearestNeighbors: KDTree, BallTree, knn, inrange
 
@@ -100,7 +100,7 @@ include("plotrecipes/cartesiangrids.jl")
 include("plotrecipes/mesh.jl")
 include("plotrecipes/partitions.jl")
 
-export 
+export
   # points
   Point, Point1, Point2, Point3, Point1f, Point2f, Point3f,
   embeddim, coordtype, coordinates,
@@ -125,6 +125,9 @@ export
   embeddim, paramdim, coordtype,
   measure, area, volume, boundary,
   centroid,
+
+  # distances
+  mindistance,
 
   # primitives
   Primitive,

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -1,6 +1,24 @@
 # ------------------------------------------------------------------
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
+
+"""
+    closest_point(m::PreMetric, g::Union{Geometry,Point}, p::Point)
+
+Returns the closest point in `g` to the point `p` as measured by the metric `m`.
+"""
+function closest_point end
+
+closest_point(::PreMetric, p::Point, ::Point) = p
+
+function closest_point(::Union{Euclidean,SqEuclidean}, l::Line, p::Point)
+    a, b = l(0), l(1)
+    u = p - a
+    v = b - a
+    α = (u ⋅ v) / (v ⋅ v)
+    l(α)
+end
+
 """
     mindistance(metric::PreMetric, g::Union{Geometry,Point}, p::Point)
 
@@ -9,19 +27,12 @@ measured by the `metric`.
 """
 function mindistance end
 
-# flip arguments to always have geometry be the first argument.
-mindistance(metric::PreMetric, p::Point, g::Geometry) = mindistance(metric, g, p)
-
-function mindistance(metric::Union{Euclidean,SqEuclidean}, l::Line, p::Point)
-    a, b = l(0), l(1)
-    u = p - a
-    v = b - a
-    α = (u ⋅ v) / (v ⋅ v)
-    metric(u, α * v)
-end
-
 mindistance(metric::PreMetric, p1::Point, p2::Point) =
     evaluate(metric, coordinates(p1), coordinates(p2))
+# flip arguments to always have geometry be the first argument.
+mindistance(metric::PreMetric, p::Point, g::Geometry) = mindistance(metric, g, p)
+mindistance(metric::PreMetric, g::Geometry, p::Point) =
+    mindistance(metric, closest_point(metric, g, p), p)
 
 @deprecate evaluate(d::PreMetric, g::Union{Geometry,Point}, p::Point) mindistance(d, g, p)
 @deprecate evaluate(d::PreMetric, p::Point, g::Geometry) mindistance(d, g, p)

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -1,27 +1,27 @@
 # ------------------------------------------------------------------
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
-
-# flip arguments so that points always come first
-evaluate(d::PreMetric, g::Geometry, p::Point) = evaluate(d, p, g)
-
 """
-    evaluate(Euclidean(), point, line)
+    mindistance(metric::PreMetric, g::Union{Geometry,Point}, p::Point)
 
-Evaluate the Euclidean distance between `point` and `line`.
+Returns the minimum distance between the the point `p` and the closest point in geometry `g` as
+measured by the `metric`.
 """
-function evaluate(::Euclidean, p::Point, l::Line)
-  a, b = l(0), l(1)
-  u = p - a
-  v = b - a
-  α = (u ⋅ v) / (v ⋅ v)
-  norm(u - α*v)
+function mindistance end
+
+# flip arguments to always have geometry be the first argument.
+mindistance(metric::PreMetric, p::Point, g::Geometry) = mindistance(metric, g, p)
+
+function mindistance(metric::Union{Euclidean,SqEuclidean}, l::Line, p::Point)
+    a, b = l(0), l(1)
+    u = p - a
+    v = b - a
+    α = (u ⋅ v) / (v ⋅ v)
+    metric(u, α * v)
 end
 
-"""
-    evaluate(::PreMetric, point1, point2)
+mindistance(metric::PreMetric, p1::Point, p2::Point) =
+    evaluate(metric, coordinates(p1), coordinates(p2))
 
-Evaluate pre-metric between coordinates of `point2` and `point2`.
-"""
-evaluate(d::PreMetric, p1::Point, p2::Point) =
-  evaluate(d, coordinates(p1), coordinates(p2))
+@deprecate evaluate(d::PreMetric, g::Union{Geometry,Point}, p::Point) mindistance(d, g, p)
+@deprecate evaluate(d::PreMetric, p::Point, g::Geometry) mindistance(d, g, p)

--- a/src/simplification/douglaspeucker.jl
+++ b/src/simplification/douglaspeucker.jl
@@ -34,7 +34,7 @@ function simplify(v::AbstractVector{Point{Dim,T}},
   # find vertex with maximum distance
   imax, dmax = 0, zero(T)
   for i in 2:length(v)-1
-    d = evaluate(Euclidean(), v[i], Line(first(v), last(v)))
+    d = mindistance(Euclidean(), v[i], Line(first(v), last(v)))
     if d > dmax
       imax = i
       dmax = d

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -1,13 +1,16 @@
 @testset "Distances" begin
   p = P2(0, 1)
   l = Line(P2(0, 0), P2(1, 0))
-  @test evaluate(Euclidean(), p, l) == T(1)
-  @test evaluate(Euclidean(), l, p) == T(1)
+  @test (@test_deprecated evaluate(Euclidean(), p, l)) == T(1)
+  @test (@test_deprecated evaluate(Euclidean(), l, p)) == T(1)
+  @test mindistance(Euclidean(), l, p) == mindistance(Euclidean(), p, l) == T(1)
 
   p1, p2 = P2(1, 0), P2(0, 1)
-  @test evaluate(Chebyshev(), p1, p2) == T(1)
+  @test (@test_deprecated evaluate(Chebyshev(), p1, p2)) == T(1)
+  @test mindistance(Chebyshev(), p1, p2) == T(1)
 
   p = P2(68, 259)
   l = Line(P2(68, 260), P2(69, 261))
-  @test evaluate(Euclidean(), p, l) ≤ T(0.8)
+  @test (@test_deprecated evaluate(Euclidean(), p, l)) ≤ T(0.8)
+  @test mindistance(Euclidean(), l, p) == mindistance(Euclidean(), p, l) ≤ T(0.8)
 end

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -1,16 +1,18 @@
 @testset "Distances" begin
-  p = P2(0, 1)
-  l = Line(P2(0, 0), P2(1, 0))
-  @test (@test_deprecated evaluate(Euclidean(), p, l)) == T(1)
-  @test (@test_deprecated evaluate(Euclidean(), l, p)) == T(1)
-  @test mindistance(Euclidean(), l, p) == mindistance(Euclidean(), p, l) == T(1)
+    p = P2(0, 1)
+    l = Line(P2(0, 0), P2(1, 0))
+    for metric in (Euclidean(), SqEuclidean())
+        @test (@test_deprecated evaluate(metric, p, l)) == T(1)
+        @test (@test_deprecated evaluate(metric, l, p)) == T(1)
+        @test mindistance(metric, l, p) == mindistance(metric, p, l) == T(1)
+    end
 
-  p1, p2 = P2(1, 0), P2(0, 1)
-  @test (@test_deprecated evaluate(Chebyshev(), p1, p2)) == T(1)
-  @test mindistance(Chebyshev(), p1, p2) == T(1)
+    p1, p2 = P2(1, 0), P2(0, 1)
+    @test (@test_deprecated evaluate(Chebyshev(), p1, p2)) == T(1)
+    @test mindistance(Chebyshev(), p1, p2) == T(1)
 
-  p = P2(68, 259)
-  l = Line(P2(68, 260), P2(69, 261))
-  @test (@test_deprecated evaluate(Euclidean(), p, l)) ≤ T(0.8)
-  @test mindistance(Euclidean(), l, p) == mindistance(Euclidean(), p, l) ≤ T(0.8)
+    p = P2(68, 259)
+    l = Line(P2(68, 260), P2(69, 261))
+    @test (@test_deprecated evaluate(Euclidean(), p, l)) ≤ T(0.8)
+    @test mindistance(Euclidean(), l, p) == mindistance(Euclidean(), p, l) ≤ T(0.8)
 end

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -1,18 +1,32 @@
 @testset "Distances" begin
-    p = P2(0, 1)
-    l = Line(P2(0, 0), P2(1, 0))
-    for metric in (Euclidean(), SqEuclidean())
-        @test (@test_deprecated evaluate(metric, p, l)) == T(1)
-        @test (@test_deprecated evaluate(metric, l, p)) == T(1)
-        @test mindistance(metric, l, p) == mindistance(metric, p, l) == T(1)
+    @testset "mindistance" begin
+        p = P2(0, 1)
+        l = Line(P2(0, 0), P2(1, 0))
+        for metric in (Euclidean(), SqEuclidean())
+            @test (@test_deprecated evaluate(metric, p, l)) == T(1)
+            @test (@test_deprecated evaluate(metric, l, p)) == T(1)
+            @test mindistance(metric, l, p) == mindistance(metric, p, l) == T(1)
+        end
+
+        p1, p2 = P2(1, 0), P2(0, 1)
+        @test (@test_deprecated evaluate(Chebyshev(), p1, p2)) == T(1)
+        @test mindistance(Chebyshev(), p1, p2) == T(1)
+
+        p = P2(68, 259)
+        l = Line(P2(68, 260), P2(69, 261))
+        @test (@test_deprecated evaluate(Euclidean(), p, l)) ≤ T(0.8)
+        @test mindistance(Euclidean(), l, p) == mindistance(Euclidean(), p, l) ≤ T(0.8)
     end
 
-    p1, p2 = P2(1, 0), P2(0, 1)
-    @test (@test_deprecated evaluate(Chebyshev(), p1, p2)) == T(1)
-    @test mindistance(Chebyshev(), p1, p2) == T(1)
+    @testset "closest_point" begin
+        p = P2(0, 1)
+        l = Line(P2(0, 0), P2(1, 0))
 
-    p = P2(68, 259)
-    l = Line(P2(68, 260), P2(69, 261))
-    @test (@test_deprecated evaluate(Euclidean(), p, l)) ≤ T(0.8)
-    @test mindistance(Euclidean(), l, p) == mindistance(Euclidean(), p, l) ≤ T(0.8)
+        for metric in (Euclidean(), SqEuclidean())
+            @test closest_point(metric, l, p) == P2(0, 0)
+            @test closest_point(metric, l, l.a) == l.a
+            @test closest_point(metric, l, l.b) == l.b
+            @test_throws MethodError closest_point(metric, p, l)
+        end
+    end
 end


### PR DESCRIPTION
This is the second out of a sequence of PR's to address #98.

This PR is **based on #112**. Thus, in order to properly view the changes introduced here, it may make sense to diff against that branch.

This PR introduces

- `closest_point(metric, g, p)` to compute the closest point in a geometry `g` to a given point `p`.
- alters `mindistance` to use the `closest_point` to compute the minimum distance