### PR TITLE
More useful constructor interface

### DIFF
--- a/src/points.jl
+++ b/src/points.jl
@@ -26,6 +26,7 @@ end
 
 # convenience constructors
 Point{Dim,T}(coords...) where {Dim,T} = Point{Dim,T}(SVector{Dim,T}(coords...))
+Point{Dim,T}(p::Point) where {Dim,T} = Point{Dim,T}(p.coords)
 Point(coords::SVector{Dim,T}) where {Dim,T} = Point{Dim,T}(coords)
 Point(coords::AbstractVector{T}) where {T} = Point{length(coords),T}(coords)
 Point(coords...) = Point(SVector(coords...))

--- a/src/points.jl
+++ b/src/points.jl
@@ -27,6 +27,7 @@ end
 # convenience constructors
 Point{Dim,T}(coords...) where {Dim,T} = Point{Dim,T}(SVector{Dim,T}(coords...))
 Point{Dim,T}(p::Point) where {Dim,T} = Point{Dim,T}(p.coords)
+Point(p::Point) = Point(p.coords)
 Point(coords::SVector{Dim,T}) where {Dim,T} = Point{Dim,T}(coords)
 Point(coords::AbstractVector{T}) where {T} = Point{length(coords),T}(coords)
 Point(coords...) = Point(SVector(coords...))

--- a/src/points.jl
+++ b/src/points.jl
@@ -31,6 +31,9 @@ Point(coords::SVector{Dim,T}) where {Dim,T} = Point{Dim,T}(coords)
 Point(coords::AbstractVector{T}) where {T} = Point{length(coords),T}(coords)
 Point(coords...) = Point(SVector(coords...))
 
+# promote rule for Point
+Base.promote_rule(::Type{Point{Dim,T}}, ::Type{Point{Dim,S}}) where {Dim, T, S} = Point{Dim, promote_type(T,S)}
+
 # coordinate type conversions
 Base.convert(::Type{Point{Dim,T}}, coords) where {Dim,T} = Point{Dim,T}(coords)
 Base.convert(::Type{Point{Dim,T}}, p::Point) where {Dim,T} = Point{Dim,T}(p.coords)

--- a/src/primitives/line.jl
+++ b/src/primitives/line.jl
@@ -15,6 +15,7 @@ struct Line{Dim,T} <: Primitive{Dim,T}
 end
 
 Line(a::Tuple, b::Tuple) = Line(Point(a), Point(b))
+Line(a,b) = Line(promote(a,b)...)
 
 paramdim(::Type{<:Line}) = 1
 


### PR DESCRIPTION
This PR provides more useful constructor interface for `Point` and `Line`.

# `Point` constructor
## Before this PR
```julia
julia> Point{3,Float64}(Point(1,2,3))
ERROR: DimensionMismatch("No precise constructor for StaticArrays.SVector{3, Float64} found. Length of input was 1.")
Stacktrace:
 [1] StaticArrays.SVector{3, Float64}(x::Tuple{Tuple{Tuple{Tuple{Point{3, Int64}}}}})
   @ StaticArrays ~/.julia/packages/StaticArrays/rdb0l/src/convert.jl:1
 [2] StaticArray (repeats 4 times)
   @ ~/.julia/packages/StaticArrays/rdb0l/src/convert.jl:4 [inlined]
 [3] Point3(coords::Point{3, Int64})
   @ Meshes ~/.julia/dev/Meshes/src/points.jl:28
 [4] top-level scope
   @ REPL[2]:1

julia> Point(Point(1,2))
Point(Point(1, 2),)
```

## After this PR
```julia
julia> Point{3,Float64}(Point(1,2,3))
Point(1.0, 2.0, 3.0)

julia> Point(Point(1,2,3))
Point(1, 2, 3)
```

## Discussion
This behavior is same as `StaticArrays.SVector`.
```julia
julia> SVector{3,Float64}(SVector(1,2,3))
3-element SVector{3, Float64} with indices SOneTo(3):
 1.0
 2.0
 3.0

julia> SVector(SVector(1,2,3))
3-element SVector{3, Int64} with indices SOneTo(3):
 1
 2
 3
```

# `Line` constructor
## Before this PR
```julia
julia> Line(Point(1,2),Point(2.0,3.0))
ERROR: MethodError: no method matching Line(::Point{2, Int64}, ::Point2)
Closest candidates are:
  Line(::Point{Dim, T}, ::Point{Dim, T}) where {Dim, T} at /home/hyrodium/.julia/dev/Meshes/src/primitives/line.jl:13
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
```

## After this PR
```julia
julia> Line(Point(1,2),Point(2.0,3.0))
Line{2, Float64}(Point(1.0, 2.0), Point(2.0, 3.0))
```