### PR TITLE
Remove type instability for PolyArea

### DIFF
--- a/src/polytopes/polyarea.jl
+++ b/src/polytopes/polyarea.jl
@@ -54,8 +54,8 @@ struct PolyArea{Dim,T,C<:Chain{Dim,T}} <: Polygon{Dim,T}
   end
 end
 
-PolyArea(outer::C, inners=[]; fix=true) where {Dim,T,C<:Chain{Dim,T}} =
-  PolyArea{Dim,T,Chain{Dim,T}}(outer, inners, fix)
+PolyArea(outer::C, inners=C[]; fix=true) where {Dim,T,V,C<:Chain{Dim,T,V}} =
+  PolyArea{Dim,T,Chain{Dim,T,V}}(outer, inners, fix)
 
 PolyArea(outer::AbstractVector{P}, inners=[]; fix=true) where {P<:Point} =
   PolyArea(Chain(outer), [Chain(inner) for inner in inners]; fix=fix)

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -320,6 +320,10 @@
     @test P2(0.75,0.25) ∉ poly
     @test P2(0.75,0.75) ∈ poly
 
+    point = P2(0.5,0.5)
+    bytes = @allocated point ∈ poly
+    @test bytes == 0
+
     # area
     outer = P2[(0,0),(1,0),(1,1),(0,1),(0,0)]
     hole1 = P2[(0.2,0.2),(0.4,0.2),(0.4,0.4),(0.2,0.4),(0.2,0.2)]

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -319,7 +319,6 @@
     @test P2(0.25,0.25) ∉ poly
     @test P2(0.75,0.25) ∉ poly
     @test P2(0.75,0.75) ∈ poly
-
     point = P2(0.5,0.5)
     bytes = @allocated point ∈ poly
     @test bytes == 0


### PR DESCRIPTION
A missing type constructor in PolyArea made it unable to infer the `Chain` type parameter `V`.