### PR TITLE
Fix CircularVector broadcasting with manual collect

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CategoricalArrays = "0.10"
-CircularArrays = "~1.1"
+CircularArrays = "1.3"
 Distances = "0.10"
 IterTools = "1.3"
 IteratorInterfaceExtensions = "1.0"

--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -193,7 +193,7 @@ function bridge(p::Polygon{Dim,T}; width=zero(T)) where {Dim,T}
   end
 
   # retrieve chains as vectors of coordinates
-  pchains = [coordinates.(vertices(c)) for c in chains(p)]
+  pchains = [coordinates.(collect(vertices(c))) for c in chains(p)]
 
   # sort vertices lexicographically
   coords  = [coord for pchain in pchains for coord in pchain]

--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -193,7 +193,7 @@ function bridge(p::Polygon{Dim,T}; width=zero(T)) where {Dim,T}
   end
 
   # retrieve chains as vectors of coordinates
-  pchains = [coordinates.(vertices(c).data) for c in chains(p)]
+  pchains = [coordinates.(parent(vertices(c))) for c in chains(p)]
 
   # sort vertices lexicographically
   coords  = [coord for pchain in pchains for coord in pchain]

--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -193,7 +193,7 @@ function bridge(p::Polygon{Dim,T}; width=zero(T)) where {Dim,T}
   end
 
   # retrieve chains as vectors of coordinates
-  pchains = [coordinates.(collect(vertices(c))) for c in chains(p)]
+  pchains = [coordinates.(vertices(c).data) for c in chains(p)]
 
   # sort vertices lexicographically
   coords  = [coord for pchain in pchains for coord in pchain]

--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -193,7 +193,7 @@ function bridge(p::Polygon{Dim,T}; width=zero(T)) where {Dim,T}
   end
 
   # retrieve chains as vectors of coordinates
-  pchains = [coordinates.(parent(vertices(c))) for c in chains(p)]
+  pchains = [coordinates.(vertices(open!(c))) for c in chains(p)]
 
   # sort vertices lexicographically
   coords  = [coord for pchain in pchains for coord in pchain]

--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -193,7 +193,7 @@ function bridge(p::Polygon{Dim,T}; width=zero(T)) where {Dim,T}
   end
 
   # retrieve chains as vectors of coordinates
-  pchains = [coordinates.(vertices(open!(c))) for c in chains(p)]
+  pchains = [coordinates.(vertices(open(c))) for c in chains(p)]
 
   # sort vertices lexicographically
   coords  = [coord for pchain in pchains for coord in pchain]


### PR DESCRIPTION
Takes care of fixing the breakage introduced in CircularArrays.jl.