### PR TITLE
point in segment method for 3d

### DIFF
--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -37,9 +37,9 @@ end
 function Base.in(p::Point{Dim,T}, s::Segment{Dim,T}) where {Dim,T}
   a, b = s.vertices
   if Dim == 2
-    zeros_compare = zero(T)
+    _0 = zero(T)
   elseif Dim == 3
-    zeros_compare = zeros(T, 3)
+    _0 = zeros(T, 3)
   else
     throw(ErrorException("not implemented"))
   end

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -45,6 +45,6 @@ function Base.in(p::Point{Dim,T}, s::Segment{Dim,T}) where {Dim,T}
   end
   # given collinear points (a, b, p), the point p intersects
   # segment ab if and only if vectors satisfy 0 ≤ ap ⋅ ab ≤ ||ab||²
-  iscollinear = isapprox((b - a) × (p - a), _0, atol = atol(T)^2)
+  iscollinear = isapprox((b - a) × (p - a), _0, atol=atol(T)^2)
   iscollinear && zero(T) ≤ (b - a) ⋅ (p - a) ≤ (b - a) ⋅ (b - a)
 end

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -39,7 +39,7 @@ function Base.in(p::Point{Dim,T}, s::Segment{Dim,T}) where {Dim,T}
   if Dim == 2
     _0 = zero(T)
   elseif Dim == 3
-    _0 = zeros(T, 3)
+    _0 = Vec{3,T}(0, 0, 0)
   else
     throw(ErrorException("not implemented"))
   end

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -41,3 +41,9 @@ function Base.in(p::Point{2,T}, s::Segment{2,T}) where {T}
   iscollinear = isapprox((b - a) × (p - a), zero(T), atol=atol(T)^2)
   iscollinear && zero(T) ≤ (b - a) ⋅ (p - a) ≤ (b - a) ⋅ (b - a)
 end
+
+function Base.in(p::Point{3,T}, s::Segment{3,T}) where {T}
+  a, b = s.vertices
+  iscollinear = isapprox((b - a) × (p - a), zeros(T, 3), atol = atol(T)^2)
+  iscollinear && zero(T) ≤ (b - a) ⋅ (p - a) ≤ (b - a) ⋅ (b - a)
+end

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -34,16 +34,17 @@ function (s::Segment)(t)
   a + t * (b - a)
 end
 
-function Base.in(p::Point{2,T}, s::Segment{2,T}) where {T}
+function Base.in(p::Point{Dim,T}, s::Segment{Dim,T}) where {Dim,T}
   a, b = s.vertices
+  if Dim == 2
+    zeros_compare = zero(T)
+  elseif Dim == 3
+    zeros_compare = zeros(T, 3)
+  else
+    throw(ErrorException("not implemented"))
+  end
   # given collinear points (a, b, p), the point p intersects
   # segment ab if and only if vectors satisfy 0 ≤ ap ⋅ ab ≤ ||ab||²
-  iscollinear = isapprox((b - a) × (p - a), zero(T), atol=atol(T)^2)
-  iscollinear && zero(T) ≤ (b - a) ⋅ (p - a) ≤ (b - a) ⋅ (b - a)
-end
-
-function Base.in(p::Point{3,T}, s::Segment{3,T}) where {T}
-  a, b = s.vertices
-  iscollinear = isapprox((b - a) × (p - a), zeros(T, 3), atol = atol(T)^2)
+  iscollinear = isapprox((b - a) × (p - a), zeros_compare, atol = atol(T)^2)
   iscollinear && zero(T) ≤ (b - a) ⋅ (p - a) ≤ (b - a) ⋅ (b - a)
 end

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -45,6 +45,6 @@ function Base.in(p::Point{Dim,T}, s::Segment{Dim,T}) where {Dim,T}
   end
   # given collinear points (a, b, p), the point p intersects
   # segment ab if and only if vectors satisfy 0 ≤ ap ⋅ ab ≤ ||ab||²
-  iscollinear = isapprox((b - a) × (p - a), zeros_compare, atol = atol(T)^2)
+  iscollinear = isapprox((b - a) × (p - a), _0, atol = atol(T)^2)
   iscollinear && zero(T) ≤ (b - a) ⋅ (p - a) ≤ (b - a) ⋅ (b - a)
 end

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -14,6 +14,7 @@
     @test all(p ∉ s for p in [P2(-0.1, -0.1), P2(1.1, 1.1), P2(1, 2)])
     @test_throws DomainError(T(1.2), "s(t) is not defined for t outside [0, 1].") s(T(1.2))
     @test_throws DomainError(T(-0.5), "s(t) is not defined for t outside [0, 1].") s(T(-0.5))
+
     # 3D space
     s = Segment(P3(0,0,0), P3(1,1,1))
     @test all(P3(x, x, x) ∈ s for x in 0:0.01:1)

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -14,8 +14,6 @@
     @test all(p ∉ s for p in [P2(-0.1, -0.1), P2(1.1, 1.1), P2(1, 2)])
     @test_throws DomainError(T(1.2), "s(t) is not defined for t outside [0, 1].") s(T(1.2))
     @test_throws DomainError(T(-0.5), "s(t) is not defined for t outside [0, 1].") s(T(-0.5))
-
-    # 3D space
     s = Segment(P3(0,0,0), P3(1,1,1))
     @test all(P3(x, x, x) ∈ s for x in 0:0.01:1)
     @test all(p ∉ s for p in [P3(-0.1, -0.1, -0.1), P3(1.1, 1.1, 1.1), P3(0.5, 0.5, 0.49)])

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -14,6 +14,10 @@
     @test all(p ∉ s for p in [P2(-0.1, -0.1), P2(1.1, 1.1), P2(1, 2)])
     @test_throws DomainError(T(1.2), "s(t) is not defined for t outside [0, 1].") s(T(1.2))
     @test_throws DomainError(T(-0.5), "s(t) is not defined for t outside [0, 1].") s(T(-0.5))
+    # 3D space
+    s = Segment(P3(0,0,0), P3(1,1,1))
+    @test all(P3(x, x, x) ∈ s for x in 0:0.01:1)
+    @test all(p ∉ s for p in [P3(-0.1, -0.1, -0.1), P3(1.1, 1.1, 1.1), P3(0.5, 0.5, 0.49)])
   end
 
   @testset "N-gons" begin


### PR DESCRIPTION
Fix #197 

Adding 3d method for Point `\in` a Segment. The method for 2d and 3d are quite similar. They could be put together as follows:

```julia
function Base.in(p::Union{Point{2,T},Point{3,T}}, s::Union{Segment{2,T},Segment{3,T}}) where {T}
  a, b = s.vertices
  # given collinear points (a, b, p), the point p intersects
  # segment ab if and only if vectors satisfy 0 ≤ ap ⋅ ab ≤ ||ab||²
  zeros_compare = embeddim(p) == 2 ? zero(T) : zeros(T, embeddim(p))
  iscollinear = isapprox((b - a) × (p - a), zeros_compare, atol = atol(T)^2)
  iscollinear && zero(T) ≤ (b - a) ⋅ (p - a) ≤ (b - a) ⋅ (b - a)
end
```
However, the Union definition is not adequate because it would allow calling the method for a `Point{2,T}` and a `Segment{3,T}` for example, which would be incorrect. Let me know if you prefer them to be separated as in the PR or if it would be better to use only one function like above (in case there is a better way of defining the first line).