### PR TITLE
bugfix: Clamp_intersection_for_ray

### DIFF
--- a/src/intersections/triangles.jl
+++ b/src/intersections/triangles.jl
@@ -184,5 +184,7 @@ function intersecttype(f::Function, r::Ray{3,T}, t::Triangle{3,T}) where {T}
     return NoIntersection() |> f
   end
 
+  λ = clamp(λ, zero(T), typemax(T))
+
   return IntersectingRayTriangle(r(λ)) |> f
 end


### PR DESCRIPTION
Fix the following bug.

```julia
r = Ray{3, Float32}(Point(74.36276f0, 258.75034f0, 192.42824f0), Float32[-0.84186256, 1.2225211, 0.89258564])
t = Triangle(Point(65.95474f0, 279.9684f0, 196.2091f0), Point(116.79f0, 216.8979f0, 191.9003f0), Point(42.91149f0, 240.2835f0, 178.7415f0))
r \cap t
```