### PR TITLE
more mathful intersection

### DIFF
--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -51,8 +51,8 @@ function intersecttype(f::Function, r::Ray{Dim,T}, b::Box{Dim,T}) where {Dim,T}
   lo, up = coordinates.(extrema(b))
   orig = coordinates(origin(r))
 
-  tmin = zero(T)
-  tmax = typemax(T)
+  tmin = zero(T) / oneunit(T)
+  tmax = typemax(T) / oneunit(T)
 
   # check for intersection with slabs along with each axis
   for i in 1:Dim
@@ -60,7 +60,7 @@ function intersecttype(f::Function, r::Ray{Dim,T}, b::Box{Dim,T}) where {Dim,T}
     imax = (up[i] - orig[i]) * invdir[i]
 
     # swap variables if necessary
-    invdir[i] < zero(T) && ((imin, imax) = (imax, imin))
+    invdir[i] < (zero(T) / oneunit(T)^2) && ((imin, imax) = (imax, imin))
 
     # the ray is on a face of the box, avoid NaN
     (isnan(imin) || isnan(imax)) && continue

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -60,7 +60,7 @@ function intersecttype(f::Function, r::Ray{Dim,T}, b::Box{Dim,T}) where {Dim,T}
     imax = (up[i] - orig[i]) * invdir[i]
 
     # swap variables if necessary
-    invdir[i] < zero(T)^3 && ((imin, imax) = (imax, imin))
+    invdir[i] < zero(eltype(invdir)) && ((imin, imax) = (imax, imin))
 
     # the ray is on a face of the box, avoid NaN
     (isnan(imin) || isnan(imax)) && continue

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -60,7 +60,7 @@ function intersecttype(f::Function, r::Ray{Dim,T}, b::Box{Dim,T}) where {Dim,T}
     imax = (up[i] - orig[i]) * invdir[i]
 
     # swap variables if necessary
-    invdir[i] < (zero(T) / oneunit(T)^2) && ((imin, imax) = (imax, imin))
+    invdir[i] < zero(T)^3 && ((imin, imax) = (imax, imin))
 
     # the ray is on a face of the box, avoid NaN
     (isnan(imin) || isnan(imax)) && continue

--- a/src/intersections/triangles.jl
+++ b/src/intersections/triangles.jl
@@ -152,21 +152,21 @@ function intersecttype(f::Function, r::Ray{3,T}, t::Triangle{3,T}) where {T}
   det = e₁ ⋅ p
 
   # keep det > 0, modify T accordingly
-  if det > atol(T)
+  if det > atol(T) * oneunit(T)^2
     τ = o - vs[1]
   else
     τ = vs[1] - o
     det = -det
   end
 
-  if det < atol(T)
+  if det < atol(T) * oneunit(T)^2
     # This ray is parallel to the plane of the triangle.
     return NoIntersection() |> f
   end
 
   # calculate u parameter and test bounds
   u = τ ⋅ p
-  if u < -atol(T) || u > det
+  if u < -atol(T) * oneunit(T)^2 || u > det
     return NoIntersection() |> f
   end
 
@@ -174,17 +174,17 @@ function intersecttype(f::Function, r::Ray{3,T}, t::Triangle{3,T}) where {T}
 
   # calculate v parameter and test bounds
   v = d ⋅ q
-  if v < -atol(T) || u + v > det
+  if v < -atol(T) * oneunit(T)^2 || u + v > det
     return NoIntersection() |> f
   end
 
   λ = (e₂ ⋅ q) * (one(T) / det)
 
-  if λ < -atol(T)
+  if λ < -atol(T) / oneunit(T)
     return NoIntersection() |> f
   end
 
-  λ = clamp(λ, zero(T), typemax(T))
+  λ = clamp(λ, zero(T) / oneunit(T), typemax(T) / oneunit(T))
 
   return IntersectingRayTriangle(r(λ)) |> f
 end

--- a/src/intersections/triangles.jl
+++ b/src/intersections/triangles.jl
@@ -152,21 +152,21 @@ function intersecttype(f::Function, r::Ray{3,T}, t::Triangle{3,T}) where {T}
   det = e₁ ⋅ p
 
   # keep det > 0, modify T accordingly
-  if det > atol(T) * oneunit(T)^2
+  if det > atol(typeof(det))
     τ = o - vs[1]
   else
     τ = vs[1] - o
     det = -det
   end
 
-  if det < atol(T) * oneunit(T)^2
+  if det < atol(typeof(det))
     # This ray is parallel to the plane of the triangle.
     return NoIntersection() |> f
   end
 
   # calculate u parameter and test bounds
   u = τ ⋅ p
-  if u < -atol(T) * oneunit(T)^2 || u > det
+  if u < -atol(typeof(u)) || u > det
     return NoIntersection() |> f
   end
 
@@ -174,17 +174,17 @@ function intersecttype(f::Function, r::Ray{3,T}, t::Triangle{3,T}) where {T}
 
   # calculate v parameter and test bounds
   v = d ⋅ q
-  if v < -atol(T) * oneunit(T)^2 || u + v > det
+  if v < -atol(typeof(v)) || u + v > det
     return NoIntersection() |> f
   end
 
   λ = (e₂ ⋅ q) * (one(T) / det)
 
-  if λ < -atol(T) / oneunit(T)
+  if λ < -atol(typeof(λ))
     return NoIntersection() |> f
   end
 
-  λ = clamp(λ, zero(T) / oneunit(T), typemax(T) / oneunit(T))
+  λ = clamp(λ, zero(typeof(λ)), typemax(typeof(λ)))
 
   return IntersectingRayTriangle(r(λ)) |> f
 end

--- a/src/polytopes/ngon.jl
+++ b/src/polytopes/ngon.jl
@@ -129,10 +129,10 @@ function Base.in(p::Point{3,T}, t::Triangle{3,T}) where {T}
   (λ₂ ≥ zero(T)) && (λ₃ ≥ zero(T)) && ((λ₂ + λ₃) ≤ one(T))
 end
 
-function normal(t::Triangle{3})
+function normal(t::Triangle{3,T}) where {T}
   a, b, c = t.vertices
   n = (b - a) × (c - a)
-  n / norm(n)
+  n / norm(n) * oneunit(T)
 end
 
 function (t::Triangle)(u::T, v::T) where {T}


### PR DESCRIPTION
Although the original code behaves correctly on integers and floating point numbers, its handling of units is imperfect. For a number without a unit, comparing its reciprocal with itself is nothing. Occasionally dropping a unit will not have any effect. Anyway, there is no unit.

But for the quantity containing units, the performance of one and oneunit is different. We should ensure that the unit in the calculation process is always correct. Although it seems that dividing by a oneunit is a useless operation, it ensures that t as an interpolation ratio is a dimensionless number, and it also ensures that there will be no dimension mismatch when comparing with invdir.

The improved code passed the test in Unitful's Dimensional Number, but because it did not want to introduce additional dependencies, it was not included in the unit test.