### PR TITLE
Specify broadcast behavior for Point #239

### DIFF
--- a/src/points.jl
+++ b/src/points.jl
@@ -60,8 +60,8 @@ const Point1f = Point{1,Float32}
 const Point2f = Point{2,Float32}
 const Point3f = Point{3,Float32}
 
-# Enable broadcasting behavior for Point
-Base.Broadcast.broadcastable(p::Point) = Ref(p)
+# enable broadcasting behavior for Point
+Broadcast.broadcastable(p::Point) = Ref(p)
 
 """
     embeddim(point)

--- a/src/points.jl
+++ b/src/points.jl
@@ -60,6 +60,9 @@ const Point1f = Point{1,Float32}
 const Point2f = Point{2,Float32}
 const Point3f = Point{3,Float32}
 
+# Enable broadcasting behavior for Point
+Base.Broadcast.broadcastable(p::Point) = Ref(p)
+
 """
     embeddim(point)
 

--- a/src/points.jl
+++ b/src/points.jl
@@ -60,7 +60,7 @@ const Point1f = Point{1,Float32}
 const Point2f = Point{2,Float32}
 const Point3f = Point{3,Float32}
 
-# enable broadcasting behavior for Point
+# broadcast behavior
 Broadcast.broadcastable(p::Point) = Ref(p)
 
 """

--- a/test/points.jl
+++ b/test/points.jl
@@ -110,4 +110,8 @@
   # measure of points is zero
   @test measure(P2(1, 2)) == zero(T)
   @test measure(P3(1, 2, 3)) == zero(T)
+  
+  # check broadcasting works as expected
+  @test P2(2, 2) .- [P2(2, 3), P2(3, 1)] == [[0., -1.], [-1., 1.]]
+  @test P3(2, 2, 2) .- [P3(2, 3, 1), P3(3, 1, 4)] == [[0., -1., 1.], [-1., 1., -2.]]
 end


### PR DESCRIPTION
Previously, you could not subtract a single Point from an array of Points using broadcasting. This PR fixes that (Issue #239).