### PR TITLE
Add RegularSampling method for a CylinderSurface + Cylinder

### DIFF
--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -129,8 +129,8 @@ function sample(::AbstractRNG, cyl::CylinderSurface{T},
   θrange = range(θmin, stop = θmax, length = sz[1])
 
   # Sampling points along the bottom and top circles
-  top_circle = [origin(cyl.top) + r * cos(θ) * cyl.top.u + r * sin(θ) * cyl.top.v for θ in θrange]
-  bot_circle = [origin(cyl.bot) + r * cos(θ) * cyl.bot.u + r * sin(θ) * cyl.bot.v for θ in θrange]
+  top_circle = [cyl.top(cos(θ), sin(θ)) for θ in θrange]
+  bot_circle = [cyl.bot(cos(θ), sin(θ)) for θ in θrange]
 
   # Iterator for sampling each point of each circle
   ivec(Segment(bot_circle[i], top_circle[i])(t) for i in 1:length(top_circle) for t in c_range)

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -112,7 +112,7 @@ function sample(::AbstractRNG, hex::Hexahedron{Dim,T},
 end
 
 
-function sample(::AbstractRNG, cyl::CylinderSurface{T}, 
+function sample(::AbstractRNG, cyl::CylinderSurface{T},
                 method::RegularSampling) where {T}
   # See http://www.songho.ca/opengl/gl_cylinder.html for a good introduction to this
   # computation.
@@ -123,15 +123,15 @@ function sample(::AbstractRNG, cyl::CylinderSurface{T},
   θmin, θmax = V(0), V(2π)
 
   # Number of circles used for sampling along the cylinder:
-  cyl_segment = Segment(origin(cyl.bot), origin(cyl.top))
-  c_range = sample(cyl_segment, RegularSampling(sz[2]))
+  c_range = range(V(0), V(1), length = sz[2])
 
   # Number of points sampling each circle:
   θrange = range(θmin, stop = θmax, length = sz[1])
 
-  # Function to sample points along a circle
-  sample_point(θ) = Vec{3,V}(r * cos(θ), r * sin(θ), 0)
+  # Sampling points along the bottom and top circles
+  top_circle = [origin(cyl.top) + r * cos(θ) * cyl.top.u + r * sin(θ) * cyl.top.v for θ in θrange]
+  bot_circle = [origin(cyl.bot) + r * cos(θ) * cyl.bot.u + r * sin(θ) * cyl.bot.v for θ in θrange]
 
   # Iterator for sampling each point of each circle
-  ivec(c + sample_point(θ) for θ in θrange, c in c_range)
+  ivec(Segment(bot_circle[i], top_circle[i])(t) for i in 1:length(top_circle) for t in c_range)
 end

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -135,7 +135,3 @@ function sample(::AbstractRNG, cyl::CylinderSurface{T},
   # Iterator for sampling each point of each circle
 Meshes.ivec(c + sample_point(θ) for θ in θrange, c in c_range)
 end
-
-function sample(::AbstractRNG, cyl::Cylinder{T}, method::RegularSampling) where {T}
-  sample(Random.GLOBAL_RNG, boundary(cyl), method)
-end

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -129,8 +129,8 @@ function sample(::AbstractRNG, cyl::CylinderSurface{T},
   θrange = range(θmin, stop = θmax, length = sz[1])
 
   # Sampling points along the bottom and top circles
-  top_circle = [cyl.top(cos(θ), sin(θ)) for θ in θrange]
-  bot_circle = [cyl.bot(cos(θ), sin(θ)) for θ in θrange]
+  top_circle = [cyl.top(r * cos(θ), r * sin(θ)) for θ in θrange]
+  bot_circle = [cyl.bot(r * cos(θ), r * sin(θ)) for θ in θrange]
 
   # Iterator for sampling each point of each circle
   ivec(Segment(bot_circle[i], top_circle[i])(t) for i in 1:length(top_circle) for t in c_range)

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -133,5 +133,5 @@ function sample(::AbstractRNG, cyl::CylinderSurface{T},
   sample_point(θ) = Vec{3,V}(r * cos(θ), r * sin(θ), 0)
 
   # Iterator for sampling each point of each circle
-Meshes.ivec(c + sample_point(θ) for θ in θrange, c in c_range)
+  ivec(c + sample_point(θ) for θ in θrange, c in c_range)
 end

--- a/test/neighborhoods.jl
+++ b/test/neighborhoods.jl
@@ -38,7 +38,7 @@
     @test evaluate(m, T[1,0], T[0,0]) != evaluate(m, T[0,1], T[0,0])
 
     # 3D simple test of default convention
-    m = metric(MetricBall(T.((1.0,0.5,0.5)), TaitBryanAngles(T(π/4),T(),T(0))))
+    m = metric(MetricBall(T.((1.0,0.5,0.5)), TaitBryanAngles(T(π/4),T(0),T(0))))
     @test evaluate(m, [1.,1.,0.], [0.,0.,0.]) ≈ √T(2)
     @test evaluate(m, [-1.,1.,0.], [0.,0.,0.]) ≈ √T(8)
   end


### PR DESCRIPTION
As discussed in #243, this is a PR to add a RegularSampling method for a CylinderSurface and for Cylinder (not sure this one is useful though?)

It needs a review before merging, I'm not sure of the implementation. 

What the implementation does is sampling a cylinder starting from the bottom to the top. It uses the cylinder radius and a segment between the top center and bottom center. We can sample with two values: the first one gives the number of sectors to divide the cylinder (nb of points around each circle) and the other one gives the number of circles along the segment. 

Hope this helps. Let me know if I can be of any further help.