### PR TITLE
Fix type error for custom type discretization

### DIFF
--- a/src/discretization/regular.jl
+++ b/src/discretization/regular.jl
@@ -57,7 +57,8 @@ function discretize(sphere::Sphere{3,T},
   # add north and south poles
   c = center(sphere)
   r = radius(sphere)
-  e⃗ = Vec{3,T}(0, 0, 1)
+  V = T <: AbstractFloat ? T : Float64
+  e⃗ = Vec{3,V}(0, 0, 1)
   push!(points, c + r*e⃗)
   push!(points, c - r*e⃗)
 

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -64,7 +64,7 @@ function sample(::AbstractRNG, sphere::Sphere{3,T},
   θrange = range(θmin+δθ, stop=θmax-δθ, length=sz[1])
   φrange = range(φmin, stop=φmax-δφ, length=sz[2])
 
-  r⃗(θ, φ) = Vec{3,V}(r*sin(θ)*cos(φ), r*sin(θ)*sin(φ), r*cos(θ))
+  r⃗(θ, φ) = Vec{3,T}(r*sin(θ)*cos(φ), r*sin(θ)*sin(φ), r*cos(θ))
 
   ivec(c + r⃗(θ, φ) for θ in θrange, φ in φrange)
 end


### PR DESCRIPTION
The following code can not run before fixing.

```julia
using Meshes
using Uniftul

sphere = Sphere((0.0u"cm", 0.0u"cm", 0.0u"cm"), 0.5u"cm")
mesh = triangulate(discretize(sphere, RegularDiscretization(100)))
```