### PR TITLE
Add function dropunits

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,7 +90,7 @@ end
 """
     dropunits(T)
 
-Gets the dimensionless memory type representation of a variable or type.
+Returns the unitless type of a (unitful) type or value. See Unitful.jl.
 i.e. `dropunits(1u"mm") == Int`
 """
 dropunits(T) = typeof(one(T))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -86,3 +86,11 @@ function proj2D(points::AbstractVector{Point{3,T}}) where {T}
   v = U[:,2]
   [Point(z⋅u, z⋅v) for z in eachcol(Z)]
 end
+
+"""
+    dropunits(T)
+
+Gets the dimensionless memory type representation of a variable or type.
+i.e. `dropunits(1u"mm") == Int`
+"""
+dropunits(T) = typeof(one(T))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,4 +93,4 @@ end
 Returns the unitless type of a (unitful) type or value. See Unitful.jl.
 i.e. `dropunits(1u"mm") == Int`
 """
-dropunits(T) = typeof(one(T))
+dropunits(v) = typeof(one(v))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -15,6 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 GR = "=0.59.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,9 @@ using CircularArrays
 using StaticArrays
 using SparseArrays
 using PlyIO
+using Unitful
 using Test, Random, Plots
 using ReferenceTests, ImageIO
-using Unitful
 
 # workaround GR warnings
 ENV["GKSwstype"] = "100"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using SparseArrays
 using PlyIO
 using Test, Random, Plots
 using ReferenceTests, ImageIO
+using Unitful
 
 # workaround GR warnings
 ENV["GKSwstype"] = "100"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -15,4 +15,7 @@
   @test sideof(p1, c) == :INSIDE
   @test sideof(p2, c) == :OUTSIDE
   @test sideof(p3, c) == :INSIDE
+
+  @test Meshes.dropunits(1.0u"mm") === Float64
+  @test Meshes.dropunits(typeof(1.0u"mm")) === Float64
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -16,6 +16,11 @@
   @test sideof(p2, c) == :OUTSIDE
   @test sideof(p3, c) == :INSIDE
 
-  @test Meshes.dropunits(1.0u"mm") === Float64
-  @test Meshes.dropunits(typeof(1.0u"mm")) === Float64
+  # drop units from unitful value and type
+  @test Meshes.dropunits(1.0u"mm") == Float64
+  @test Meshes.dropunits(typeof(1.0u"mm")) == Float64
+  
+  # return the same type in case of no units
+  @test Meshes.dropunits(1.0) == Float64
+  @test Meshes.dropunits(Float64) == Float64
 end


### PR DESCRIPTION
I added `dropunits` function and its tests as [we discussed](https://github.com/JuliaGeometry/Meshes.jl/pull/255).

We had some differences of opinion before. But in general, it is consistent to construct a dropunits function for getting unitless scalars. Hence this PR.

Sorry for [the PR](https://github.com/JuliaGeometry/Meshes.jl/pull/255) that was turned off by mistake.