### PR TITLE
add sphere constructor given Point

### DIFF
--- a/src/primitives/sphere.jl
+++ b/src/primitives/sphere.jl
@@ -15,6 +15,7 @@ struct Sphere{Dim,T} <: Primitive{Dim,T}
 end
 
 Sphere(center::Point{Dim,T}, radius) where {Dim,T} = Sphere(center, T(radius))
+
 Sphere(center::Tuple, radius) = Sphere(Point(center), radius)
 
 """

--- a/src/primitives/sphere.jl
+++ b/src/primitives/sphere.jl
@@ -14,6 +14,7 @@ struct Sphere{Dim,T} <: Primitive{Dim,T}
   radius::T
 end
 
+Sphere(center::Point{Dim,T}, radius) where {Dim,T} = Sphere(center, T(radius))
 Sphere(center::Tuple, radius) = Sphere(Point(center), radius)
 
 """

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -167,7 +167,7 @@
   end
 
   @testset "Sphere" begin
-    s  = Sphere(P3(0,0,0), T(1))
+    s = Sphere(P3(0,0,0), T(1))
     @test embeddim(s) == 3
     @test paramdim(s) == 2
     @test coordtype(s) == T

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -167,7 +167,7 @@
   end
 
   @testset "Sphere" begin
-    s = Sphere(P3(0,0,0), T(1))
+    s  = Sphere(P3(0,0,0), T(1))
     @test embeddim(s) == 3
     @test paramdim(s) == 2
     @test coordtype(s) == T
@@ -176,6 +176,11 @@
     @test extrema(s) == (P3(-1,-1,-1), P3(1,1,1))
     @test !isconvex(s)
     @test isnothing(boundary(s))
+
+    # Sphere constructor works with both float and integer radius
+    s  = Sphere(P3(1,2,3), T(4))
+    si = Sphere(P3(1,2,3), 4)
+    @test s == si
 
     s = Sphere(P2(0,0), T(2))
     @test measure(s) ≈ 2π*2


### PR DESCRIPTION
Adding another constructor to Sphere so that it can accept integer arguments.

When given a Point as the first argument to the constructor, this version tries to convert the provided radius to the element type associated to the given Point.