### PR TITLE
Fix `Plane` with a normal.

### DIFF
--- a/src/primitives/plane.jl
+++ b/src/primitives/plane.jl
@@ -19,24 +19,22 @@ struct Plane{T} <: Primitive{3,T}
   v::Vec{3,T}
 end
 
+# D. S. Lopes, M. T. Silva, and J. A. Ambrósio, “Tangent vectors to a 3-D surface normal: A geometric tool to find orthogonal vectors based on the Householder transformation,” Computer-Aided Design, vol. 45, no. 3, pp. 683–694, Mar. 2013, doi: 10.1016/j.cad.2012.11.003.
+function HouseholderOrthogonalization(n)
+    n̄ = norm(n)
+    h1 = max(n[1]-n̄,n[1]+n̄)
+    h2 = n[2]
+    h3 = n[3]
+    h = SVector(h1,h2,h3)
+    H = I - 2h*transpose(h)/(transpose(h)*h)
+    t = H[1:3,2]
+    b = H[1:3,3]
+    t,b
+end
+
 function Plane{T}(p::Point{3,T}, n::Vec{3,T}) where {T}
-  # origin of coordinate system
-  o = Vec{3,T}(zero(T), zero(T), zero(T))
-
-  uv = Vec{3,T}[]
-  for i in 1:3
-    # subtract projection of Euclidean basis onto normal
-    e = Vec{3,T}(ntuple(j -> j == i ? one(T) : zero(T), 3))
-    v = e - (e⋅n)/(n⋅n) * n
-
-    # check if it is a valid vector
-    isapprox(v, o, atol=atol(T)) || push!(uv, v)
-
-    # we need two vectors
-    length(uv) == 2 && break
-  end
-
-  Plane{T}(p, uv[1], uv[2])
+  u, v = HouseholderOrthogonalization(n)
+  Plane{T}(p, u, v)
 end
 
 Plane(p::Point{3,T}, n::Vec{3,T}) where {T} = Plane{T}(p, n)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -58,13 +58,16 @@
     @test normal(p) == Vec(0, 0, 1)
     @test isnothing(boundary(p))
 
-    p = Plane(P3(0, 0, 0), V3(0, 0, 1))
-    @test p(T(1), T(0)) == P3(1, 0, 0)
-    @test p(T(0), T(1)) == P3(0, 1, 0)
+    n = V3(1, 1, 0)
+    p = Plane(P3(0, 0, 0), n)
+    @test abs(p.u⋅p.v) < eps(T)
+    @test abs(p.u⋅n) < eps(T)
+    @test abs(p.v⋅n) < eps(T)
 
     p1 = Plane(P3(0, 0, 0), V3(1, 0, 0), V3(0, 1, 0))
     p2 = Plane(P3(0, 0, 0), V3(0, 0, 1))
-    @test p1 == p2
+    @test abs(p1.u⋅normal(p2)) < eps(T)
+    @test abs(p1.v⋅normal(p2)) < eps(T)
   end
 
   @testset "Bezier curves" begin


### PR DESCRIPTION
Previously, this give wrong tangent vectors:
```julia
julia> n = Vec3(1.0, 1.0, 0.0)
3-element StaticArraysCore.SVector{3, Float64} with indices SOneTo(3):
 1.0
 1.0
 0.0

julia> (;p,u,v) = Plane(Point(1, 0, 0), n)
Plane{Float64}(Point(1.0, 0.0, 0.0), [0.5, -0.5, 0.0], [-0.5, 0.5, 0.0])
```
This PR uses the [Householder orthogonalization method](https://doi.org/10.1016/j.cad.2012.11.003) to compute orthonormal tangent vectors from a `Plane`'s normal.

The tests are also changed to check for the orthogonal conditions instead of the computed vectors.