### PR TITLE
fix rotation of cylinder axis.

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -16,7 +16,7 @@ using IterTools: ivec
 using StatsBase: Weights
 using SpecialFunctions: gamma
 using Distances: PreMetric, Euclidean, Mahalanobis, evaluate
-using ReferenceFrameRotations: EulerAngles, EulerAngleAxis, DCM
+using ReferenceFrameRotations: EulerAngles, DCM
 using NearestNeighbors: KDTree, BallTree, knn, inrange
 
 # import categorical arrays as a temporary solution for plot recipes

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -118,8 +118,8 @@ function sample(::AbstractRNG, cylsurf::CylinderSurface{T},
   l  = norm(d₃)
   d₃ /= l
   d₁, d₂ = householderbasis(d₃)
-  R = transpose([d₁;;d₂;;d₃])
-  
+  R = transpose([d₁ d₂ d₃])
+
   # new normals of planes in new rotated system
   nᵦ = R * normal(b)
   nₜ = R * normal(t)

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -113,7 +113,6 @@ function sample(::AbstractRNG, cylsurf::CylinderSurface{T},
   zrange = range(zmin, stop=zmax,    length=sz[2])
 
   # rotation to align z axis with cylinder axis
-  e₃ = Vec{3,V}(0, 0, 1)
   d₃  = a(1) - a(0)
   l  = norm(d₃)
   d₃ /= l

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -114,12 +114,12 @@ function sample(::AbstractRNG, cylsurf::CylinderSurface{T},
 
   # rotation to align z axis with cylinder axis
   e₃ = Vec{3,V}(0, 0, 1)
-  d  = a(1) - a(0)
-  l  = norm(d)
-  θ  = ∠(d, e₃)
-  w  = d × e₃
-  R  = convert(DCM, EulerAngleAxis(-θ, w))
-
+  d₃  = a(1) - a(0)
+  l  = norm(d₃)
+  d₃ /= l
+  d₁, d₂ = householderbasis(d₃)
+  R = transpose([d₁;;d₂;;d₃])
+  
   # new normals of planes in new rotated system
   nᵦ = R * normal(b)
   nₜ = R * normal(t)


### PR DESCRIPTION
The rotation matrix of the cylinder axis, which is needed for `sample`, is wrong in some cases.
For example,
```julia
p1 = Meshes.Point3([0, 0.0, 0.7714704084729095])
p2 = Meshes.Point3([-0.7337119591070445, 1, 0.23839746687551142])
s = Meshes.Segment(p1,p2)
cyl = Meshes.Cylinder(0.03,s)
MeshViz.viz(cyl)
```
gives
![image](https://user-images.githubusercontent.com/88961633/183856461-8b1ae417-a958-4a37-95da-6eabf32cad80.png)

This PR uses `householderbasis` to compute the rotation matrix, with which the above code now gives
![image](https://user-images.githubusercontent.com/88961633/183857296-badf792d-e9a7-4bd2-9841-fdc40be3e8b0.png)
