### PR TITLE
Add Laplacian Smoothing Filter

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -74,3 +74,40 @@ viz(fig[1,1], mesh)
 viz(fig[2,1], smesh)
 fig
 ```
+
+## LaplacianSmoothing
+
+```@docs
+LaplacianSmoothing
+```
+
+```@example transforms
+using PlyIO
+
+# helper function to read *.ply files
+function readply(fname)
+  ply = load_ply(fname)
+  x = ply["vertex"]["x"]
+  y = ply["vertex"]["y"]
+  z = ply["vertex"]["z"]
+  points = Point3.(x, y, z)
+  connec = [connect(Tuple(c.+1)) for c in ply["face"]["vertex_indices"]]
+  SimpleMesh(points, connec)
+end
+
+# download mesh from the web
+file = download(
+  "https://raw.githubusercontent.com/juliohm/JuliaCon2021/master/data/beethoven.ply"
+)
+
+# read mesh from disk
+mesh = readply(file)
+
+# smooth mesh with 30 iterations
+smesh = mesh |> TaubinSmoothing(30)
+
+fig = Mke.Figure(resolution = (800, 1200))
+viz(fig[1,1], mesh)
+viz(fig[2,1], smesh)
+fig
+```

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -385,6 +385,7 @@ export
   StatelessGeometricTransform,
   StdCoords,
   TaubinSmoothing,
+  LaplacianSmoothing,
 
   # tolerances
   atol

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -95,3 +95,4 @@ reapply(transform::StatelessGeometricTransform, object, cache) =
 
 include("transforms/stdcoords.jl")
 include("transforms/taubin.jl")
+include("transforms/laplacian.jl")

--- a/src/transforms/laplacian.jl
+++ b/src/transforms/laplacian.jl
@@ -1,0 +1,61 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    LaplacianSmoothing(n; λ=0.5)
+
+Perform `n` iterations of Laplacian smoothing with parameter `λ`.
+
+## References
+
+* Sorkine, O. 2005. [Laplacian Mesh Processing]
+  (http://dx.doi.org/10.2312/egst.20051044)
+"""
+struct LaplacianSmoothing{T} <: StatelessGeometricTransform
+  n::Int
+  λ::T
+
+  function LaplacianSmoothing{T}(n, λ) where {T}
+    new(n, λ)
+  end
+end
+
+function LaplacianSmoothing(n; λ=0.5)
+  LaplacianSmoothing{typeof(λ)}(n, λ)
+end
+
+isrevertible(::Type{<:LaplacianSmoothing}) = true
+
+preprocess(::LaplacianSmoothing, mesh) =
+  laplacematrix(mesh, weights=:uniform)
+
+function applypoint(transform::LaplacianSmoothing, points, prep)
+  n = transform.n
+  λ = transform.λ
+  L = prep
+  _laplacian(points, L, n, λ), L
+end
+
+function revertpoint(transform::LaplacianSmoothing, newpoints, pcache)
+  n = transform.n
+  λ = transform.λ
+  L = pcache
+  _laplacian(newpoints, L, n, λ, revert=true)
+end
+
+function _laplacian(points, L, n, λ; revert=false)
+  # matrix with coordinates (nvertices x ndims)
+  X = reduce(hcat, coordinates.(points)) |> transpose
+
+  # choose between apply and revert mode
+  λ₁ = revert ? -λ : λ
+
+  # Laplace updates
+  for _ in 1:n
+    X = X + λ₁*L*X
+  end
+
+  # new points
+  Point.(eachrow(X))
+end

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -33,4 +33,16 @@
     @test nelements(smesh) == nelements(mesh)
     @test topology(smesh) == topology(mesh)
   end
+
+  @testset "LaplacianSmoothing" begin
+    trans = LaplacianSmoothing(30)
+    @test TB.isrevertible(trans)
+
+    # smoothing doesn't change the topology
+    mesh  = readply(T, joinpath(datadir,"beethoven.ply"))
+    smesh = trans(mesh)
+    @test nvertices(smesh) == nvertices(mesh)
+    @test nelements(smesh) == nelements(mesh)
+    @test topology(smesh) == topology(mesh)
+  end
 end


### PR DESCRIPTION
Hello devs,

This is an implementation suggestion for the Laplacian Smoothing Filter. In practice this filter is just a special case of the Taubin filter with `\mu=0`. However, having `\lambda > \mu` is not allowed in the Taubin filter, as written in Taubin's original work, and correctly enforced by this package. Therefore, it is not possible to use the Taubin filter to 'fallback' to the laplacian filter with the current implementation of this package.

The proposed filter is simply a mimicked version of the existing Taubin filter, but simplified for `\mu=0`. Another implementation option would be to try to re-use Taubin's implementation, but given that the code is so small, I thought this would be clearer and more extensible.

I am currently using this code for a research project.

Thanks!