### PR TITLE
Add more SimpleMesh examples to docs

### DIFF
--- a/docs/src/meshes.md
+++ b/docs/src/meshes.md
@@ -118,3 +118,21 @@ topo = convert(HalfEdgeTopology, topology(mesh))
 # show n-gons that share edge 3
 𝒞₁₂(3)
 ```
+
+```@example meshes
+
+function f(X)
+
+    return (X[1], X[2], X[1]^2 - X[2]^2)
+
+end
+
+
+x = LinRange(-1,1,20)
+y = LinRange(-1,1,50)
+grid = RectilinearGrid(x, y)
+new_coordinates = map(Point∘f, coordinates.(vertices(grid)))
+
+new_mesh = SimpleMesh(new_coordinates, topology(grid))
+
+```

--- a/src/mesh/simplemesh.jl
+++ b/src/mesh/simplemesh.jl
@@ -16,7 +16,6 @@ represent the elements of the mesh.
 
 ## Examples
 
-
 ```julia
 julia> points = [(0,0),(1,0),(1,1)]
 julia> connec = [connect((1,2,3))]

--- a/src/mesh/simplemesh.jl
+++ b/src/mesh/simplemesh.jl
@@ -16,6 +16,7 @@ represent the elements of the mesh.
 
 ## Examples
 
+
 ```julia
 julia> points = [(0,0),(1,0),(1,1)]
 julia> connec = [connect((1,2,3))]
@@ -24,6 +25,40 @@ julia> mesh   = SimpleMesh(points, connec)
 
 See also [`Topology`](@ref), [`GridTopology`](@ref),
 [`HalfEdgeTopology`](@ref), [`SimpleTopology`](@ref).
+
+
+We can construct standard parametric surfaces from simpler meshes
+
+
+```julia
+function ϕ(u,v)
+
+  x = 5/4*(1 - v/2π )*cos(2v)*(1 + cos(u)) + cos(2*v)
+  y = 5/4*(1 - v/2π )*sin(2v)*(1 + cos(u)) + sin(2*v)
+  z = 10*v/2π +5/4*(1 - v/2π )*sin(u) + 15
+  return x,y,z
+
+end
+
+# Parametric Space
+us = LinRange(0,2π,10)[1:end-1] #this component is periodic
+vs = LinRange(0,π,40)
+
+periodic = (false, true)
+vertex = [(Point∘ϕ)(u,v)...) for u in us for v in vs]
+topo = GridTopology( (length(vs)-1 , length(us)-1) .+ periodic, periodic)
+mesh = SimpleMesh(vertex, topo)
+viz(mesh, showfacets = true)
+```
+
+We can also use it to construct meshes from more complicated meshes
+
+```julia
+f(p) = p + rand(3) * 0.25
+mesh_noisy = SimpleMesh([(Point∘f)(p) for p in coordinates.(vertices(mesh))], topology(mesh) )
+viz(mesh_noisy)
+```
+
 
 ### Notes
 

--- a/src/topologies/grid.jl
+++ b/src/topologies/grid.jl
@@ -14,7 +14,7 @@ to aperiodic dimensions.
 ```julia
 julia> GridTopology((10,20)) # 10x20 elements in a grid
 julia> GridTopology((10,20), (true,false)) # cylinder topology
-julia> GridTopology((10,20), (true,true)) # sphere topology
+julia> GridTopology((10,20), (true,true)) # torus topology
 ```
 """
 struct GridTopology{D} <: Topology


### PR DESCRIPTION
Added simple example to the docs
Fixed error in topology docs (doubly periodic topology corresponds to a torus, not a sphere)