### PR TITLE
Implement Ray-Plane intersection type and algorithm

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -335,6 +335,9 @@ export
   CrossingSegmentPlane,
   TouchingSegmentPlane,
   OverlappingSegmentPlane,
+  CrossingRayPlane,
+  TouchingRayPlane,
+  OverlappingRayPlane,
   NoIntersection,
 
   # intersections

--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -99,6 +99,11 @@ Type `IntersectionType` in a Julia session to see the full list.
   CrossingSegmentPlane
   TouchingSegmentPlane
   OverlappingSegmentPlane
+
+  # ray-plane intersection
+  CrossingRayPlane
+  TouchingRayPlane
+  OverlappingRayPlane
 end
 
 """
@@ -149,6 +154,7 @@ include("intersections/rayline.jl")
 include("intersections/linesegment.jl")
 include("intersections/raybox.jl")
 include("intersections/segmentplane.jl")
+include("intersections/rayplane.jl")
 include("intersections/segmenttriangle.jl")
 include("intersections/raytriangle.jl")
 include("intersections/geompolygon.jl")

--- a/src/intersections/rayplane.jl
+++ b/src/intersections/rayplane.jl
@@ -12,9 +12,9 @@ function Meshes.intersection(f, r::Ray{3,T}, p::Plane{T}) where {T}
   # calculate components
   ln = direction(r) ⋅ n
   
-  # if ln is zero, the segment is parallel to the plane
+  # if ln is zero, the ray is parallel to the plane
   if isapprox(ln, zero(T), atol=atol(T))
-    # if the numerator is zero, the segment is coincident
+    # if the numerator is zero, the ray is coincident
     if isapprox(coordinates(pₒ - origin(r)) ⋅ n, zero(T), atol=atol(T))
       return @IT OverlappingRayPlane r f
     else

--- a/src/intersections/rayplane.jl
+++ b/src/intersections/rayplane.jl
@@ -5,7 +5,7 @@
 #=
 (https://en.wikipedia.org/wiki/Line-plane_intersection)
 =#
-function Meshes.intersection(f, r::Ray{3,T}, p::Plane{T}) where {T}
+function intersection(f, r::Ray{3,T}, p::Plane{T}) where {T}
   pₒ = coordinates(origin(p))
   n  = normal(p)
   

--- a/src/intersections/rayplane.jl
+++ b/src/intersections/rayplane.jl
@@ -1,0 +1,39 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+#=
+(https://en.wikipedia.org/wiki/Line-plane_intersection)
+=#
+function Meshes.intersection(f, r::Ray{3,T}, p::Plane{T}) where {T}
+    pₒ = coordinates(origin(p))
+    n  = normal(p)
+    
+    # calculate components
+    ln = r.v ⋅ n
+  
+    # if ln is zero, the segment is parallel to the plane
+    if isapprox(ln, zero(T), atol=atol(T))
+        # if the numerator is zero, the segment is coincident
+        if isapprox(coordinates(pₒ - r.p) ⋅ n, zero(T), atol=atol(T))
+            return @IT OverlappingRayPlane r f
+        else
+            return @IT NoIntersection nothing f
+        end
+    else
+        # calculate the ray parameter
+        λ = -(n ⋅ coordinates(r.p - pₒ)) / ln
+
+        # if λ is approximately 0, set as so to prevent any domain errors
+        if isapprox(λ, zero(T), atol=atol(T))
+        return @IT TouchingRayPlane r(zero(T)) f
+        end
+
+        # if λ is out of bounds for the ray, then there is no intersection
+        if (λ < zero(T))
+            return @IT NoIntersection nothing f
+        else
+            return @IT CrossingRayPlane r(λ) f
+        end
+    end
+end

--- a/src/intersections/rayplane.jl
+++ b/src/intersections/rayplane.jl
@@ -6,34 +6,34 @@
 (https://en.wikipedia.org/wiki/Line-plane_intersection)
 =#
 function Meshes.intersection(f, r::Ray{3,T}, p::Plane{T}) where {T}
-    pₒ = coordinates(origin(p))
-    n  = normal(p)
-    
-    # calculate components
-    ln = r.v ⋅ n
+  pₒ = coordinates(origin(p))
+  n  = normal(p)
   
-    # if ln is zero, the segment is parallel to the plane
-    if isapprox(ln, zero(T), atol=atol(T))
-        # if the numerator is zero, the segment is coincident
-        if isapprox(coordinates(pₒ - r.p) ⋅ n, zero(T), atol=atol(T))
-            return @IT OverlappingRayPlane r f
-        else
-            return @IT NoIntersection nothing f
-        end
+  # calculate components
+  ln = direction(r) ⋅ n
+  
+  # if ln is zero, the segment is parallel to the plane
+  if isapprox(ln, zero(T), atol=atol(T))
+    # if the numerator is zero, the segment is coincident
+    if isapprox(coordinates(pₒ - origin(r)) ⋅ n, zero(T), atol=atol(T))
+      return @IT OverlappingRayPlane r f
     else
-        # calculate the ray parameter
-        λ = -(n ⋅ coordinates(r.p - pₒ)) / ln
-
-        # if λ is approximately 0, set as so to prevent any domain errors
-        if isapprox(λ, zero(T), atol=atol(T))
-        return @IT TouchingRayPlane r(zero(T)) f
-        end
-
-        # if λ is out of bounds for the ray, then there is no intersection
-        if (λ < zero(T))
-            return @IT NoIntersection nothing f
-        else
-            return @IT CrossingRayPlane r(λ) f
-        end
+      return @IT NoIntersection nothing f
     end
+  else
+    # calculate the ray parameter
+    λ = -(n ⋅ coordinates(origin(r) - pₒ)) / ln
+
+    # if λ is approximately 0, set as so to prevent any domain errors
+    if isapprox(λ, zero(T), atol=atol(T))
+      return @IT TouchingRayPlane r(zero(T)) f
+    end
+
+    # if λ is out of bounds for the ray, then there is no intersection
+    if (λ < zero(T))
+      return @IT NoIntersection nothing f
+    else
+      return @IT CrossingRayPlane r(λ) f
+    end
+  end
 end

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -820,6 +820,46 @@
     @inferred someornone(s, p)
   end
 
+  @testset "RayPlanes" begin
+    p = Plane(P3(0, 0, 1), V3(1, 0, 0), V3(0, 1, 0))
+
+    # intersecting ray and plane
+    r = Ray(P3(0, 0, 0), V3(0, 2, 2))
+    @test intersection(r, p) |> type == CrossingRayPlane
+    @test r ∩ p == P3(0, 1, 1)
+
+    # intersecting ray and plane with λ ≈ 0
+    r = Ray(P3(0, 0, 1), V3(0, 2, 1))
+    @test intersection(r, p) |> type == TouchingRayPlane
+    @test r ∩ p == P3(0, 0, 1)
+
+    # intersecting ray and plane with λ ≈ 1 (only case where Ray different to Segment)
+    r = Ray(P3(0, 0, 2), V3(0, 2, -1))
+    @test intersection(r, p) |> type == CrossingRayPlane
+    @test r ∩ p == P3(0, 2, 1)
+
+    # ray contained within plane
+    r = Ray(P3(0, 0, 1), V3(0, -2, 0))
+    @test intersection(r, p) |> type == OverlappingRayPlane
+    @test r ∩ p == r
+
+    # ray below plane, non-intersecting
+    r = Ray(P3(0, 0, 0), V3(0, -2, -2))
+    @test intersection(r, p) |> type == NoIntersection
+    @test isnothing(r ∩ p)
+
+    # ray parallel to plane, offset, non-intersecting
+    r = Ray(P3(0, 0, -1), V3(0, -2, -1))
+    @test intersection(r, p) |> type == NoIntersection
+    @test isnothing(r ∩ p)
+
+    # plane as first argument
+    p = Plane(P3(0, 0, 1), V3(1, 0, 0), V3(0, 1, 0))
+    r = Ray(P3(0, 0, 0), V3(0, 2, 2))
+    @test intersection(p, r) |> type == CrossingRayPlane
+    @test r ∩ p == p ∩ r == P3(0, 1, 1)
+  end
+
   @testset "Boxes" begin
     b1 = Box(P2(0,0), P2(1,1))
     b2 = Box(P2(0.5,0.5), P2(2,2))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -849,7 +849,7 @@
     @test isnothing(r ∩ p)
 
     # ray parallel to plane, offset, non-intersecting
-    r = Ray(P3(0, 0, -1), V3(0, -2, -1))
+    r = Ray(P3(0, 0, -1), V3(0, -2, 0))
     @test intersection(r, p) |> type == NoIntersection
     @test isnothing(r ∩ p)
 


### PR DESCRIPTION
Added appropriate types for Ray-Plane intersections, mostly taken from Segment-Plane intersections. Same tests added and used too, main difference is that rays extend past λ=1.