### PR TITLE
Remove `SVector` in `Polytope` constructors

### DIFF
--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -27,7 +27,7 @@ have (K-1)-polytopes in common. See https://en.wikipedia.org/wiki/Polytope.
 """
 abstract type Polytope{K,Dim,T} <: Geometry{Dim,T} end
 
-(::Type{PL})(vertices::Vararg{P}) where {PL<:Polytope,P<:Point} = PL(SVector(vertices))
+(::Type{PL})(vertices::Vararg{P}) where {PL<:Polytope,P<:Point} = PL(collect(vertices))
 (::Type{PL})(vertices::AbstractVector{TP}) where {PL<:Polytope,TP<:Tuple} = PL(Point.(vertices))
 (::Type{PL})(vertices::Vararg{TP}) where {PL<:Polytope,TP<:Tuple} = PL(collect(vertices))
 

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -366,9 +366,9 @@
     @test intersection(r₂, s₈) |> type == OverlappingRaySegment # CASE 4
     @test r₂ ∩ s₈ === s₈ ∩ r₂ === s₈
     @test intersection(r₂, s₉) |> type == OverlappingRaySegment # CASE 4
-    @test r₂ ∩ s₉ === s₉ ∩ r₂ === Segment(origin(r₂), s₉(1))
+    @test r₂ ∩ s₉ == s₉ ∩ r₂ == Segment(origin(r₂), s₉(1))
     @test intersection(r₂, s₁₀) |> type == OverlappingRaySegment # CASE 4
-    @test r₂ ∩ s₁₀ === s₁₀ ∩ r₂ === Segment(origin(r₂), s₁₀(0))
+    @test r₂ ∩ s₁₀ == s₁₀ ∩ r₂ == Segment(origin(r₂), s₁₀(0))
     @test intersection(r₂, s₁₁) |> type == CornerTouchingRaySegment # CASE 3
     @test r₂ ∩ s₁₁ ≈ s₁₁ ∩ r₂ ≈ origin(r₂)
     @test intersection(r₂, s₁₂) |> type == CornerTouchingRaySegment # CASE 3
@@ -403,7 +403,7 @@
 
     s₄ = Segment(P3(0,0,0), P3(2,4,6))
     @test intersection(r₁, s₄) |> type === OverlappingRaySegment # CASE 4
-    @test r₁ ∩ s₄ === s₄ ∩ r₁ === Segment(P3(1,2,3), P3(2,4,6))
+    @test r₁ ∩ s₄ == s₄ ∩ r₁ == Segment(P3(1,2,3), P3(2,4,6))
 
     s₅ = Segment(P3(0,0,0), P3(0.5, 1, 1.5))
     @test intersection(r₁, s₅) |> type === NoIntersection # CASE 5


### PR DESCRIPTION
fix #336 

Origin:
|Test Summary:       | Pass | Total |    Time|
| ----------------- | ------ | -------- | ------ |
|Meshes.jl (Float32) | 4015 |  4015 | 1m33.1s |
|Test Summary:       | Pass | Total  | Time |
|Meshes.jl (Float64) | 4017 |  4017 | 50.1s |

New:
|Test Summary:       | Pass | Total |    Time |
| ----------------- | ------ | -------- | ------ |
| Meshes.jl (Float32) | 4015  | 4015 | 1m32.1s |
|Test Summary:       | Pass | Total |  Time |
Meshes.jl (Float64) | 4017  | 4017 | 49.3s |