### PR TITLE
Mesh cleaning utilities

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -92,6 +92,9 @@ include("hulls.jl")
 # transforms
 include("transforms.jl")
 
+# cleaning
+include("cleaning.jl")
+
 export
   # points
   Point,
@@ -385,6 +388,9 @@ export
   RotateCoords,
 
   # tolerances
-  atol
+  atol,
+
+  # cleaning
+  clean
 
 end # module

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -391,6 +391,7 @@ export
   atol,
 
   # cleaning
-  clean
+  clean,
+  gather
 
 end # module

--- a/src/cleaning.jl
+++ b/src/cleaning.jl
@@ -1,0 +1,9 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+# ----------------
+# IMPLEMENTATIONS
+# ----------------
+
+include("cleaning/clean.jl")

--- a/src/cleaning.jl
+++ b/src/cleaning.jl
@@ -7,3 +7,4 @@
 # ----------------
 
 include("cleaning/clean.jl")
+include("cleaning/gather.jl")

--- a/src/cleaning/clean.jl
+++ b/src/cleaning/clean.jl
@@ -1,0 +1,43 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    clean(mesh)
+
+Remove the unused vertices of `mesh`.
+"""
+function clean(mesh)
+  # get the faces of the mesh
+  topo = convert(HalfEdgeTopology, topology(mesh))
+  ∂₂₀ = Boundary{2,0}(topo)
+  nfaces = nelements(topo)
+
+  # vector to store the indices of the used vertices
+  used = Vector{Int}(undef, 0)
+
+  # dictionary to map the old indices to the new indices
+  newindices = Dict{Int,Int}()
+
+  # vector to store the connectivities of the cleaned mesh
+  connectivities = Vector{Connectivity}(undef, 0)
+
+  # l=length(used) will be incremented
+  l = 0
+
+  # iterate over faces
+  for f in 1:nfaces
+    face = ∂₂₀(f)
+    for index in face
+      if !in(index, used)
+        push!(used, index)
+        l = l + 1
+        newindices[index] = l
+      end
+    end
+    connectivity = connect(tuple([newindices[i] for i in face]...))
+    push!(connectivities, connectivity)
+  end
+
+  SimpleMesh(vertices(mesh)[used], connectivities)
+end

--- a/src/cleaning/gather.jl
+++ b/src/cleaning/gather.jl
@@ -1,0 +1,60 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    gather(mesh)
+
+Merge the duplicated vertices of `mesh`.
+"""
+function gather(mesh)
+  # get mesh vertices
+  points = vertices(mesh)
+  npoints = length(points)
+
+  # vector indicating the duplicated vertices
+  duplicated = fill(false, npoints)
+
+  # dictionary to map the old indices to the new indices
+  newindices = Dict{Int,Int}()
+
+  # initialize new indices
+  newindex = 1
+
+  # iterate over vertices
+  for index in 1:(npoints-1)
+    if !duplicated[index]
+      tail = points[(index+1):npoints]
+      duplicates = index .+ findall(==(points[index]), tail)
+      duplicated[duplicates] .= true
+      push!(duplicates, index)
+      for i in duplicates
+        newindices[i] = newindex
+      end
+      newindex = newindex + 1
+    end
+  end
+
+  # if the last vertex is not a duplicate, add it to the dictionary
+  if !haskey(newindices, npoints)
+    newindices[npoints] = newindex
+  end
+
+  # get the faces
+  topo = convert(HalfEdgeTopology, topology(mesh))
+  ∂₂₀ = Boundary{2,0}(topo)
+  nfaces = nelements(topo)
+
+  # vector to store the connectivities
+  connectivities = Vector{Connectivity}(undef, 0)
+
+  # iterate over the faces
+  for f in 1:nfaces
+    face = ∂₂₀(f)
+    toconnect = [newindices[i] for i in face]
+    connectivity = connect(tuple(toconnect...))
+    push!(connectivities, connectivity)
+  end
+
+  SimpleMesh(points[.!duplicated], connectivities)
+end

--- a/test/cleaning.jl
+++ b/test/cleaning.jl
@@ -14,4 +14,24 @@
     # number of faces has not changed
     @test nelements(cmesh) == 4
   end
+
+  @testset "Merging of duplicated vertices" begin
+    # make a tetrahedron with duplicated vertices
+    p1 = P3(0, 1, 1)
+    p2 = P3(-1, 2, 3)
+    p3 = P3(0, 3, 2)
+    p4 = P3(2, 2, 2)
+    points = [p1, p2, p3, p3, p2, p4, p4, p2, p1, p1, p3, p4]
+    triangles = [(1, 2, 3), (4, 5, 6), (7, 8, 9), (10, 11, 12)]
+    mesh = SimpleMesh(points, connect.(triangles, Triangle))
+
+    # merge the duplicated vertices
+    cmesh = gather(mesh)
+
+    # the new mesh has four vertices
+    @test nvertices(cmesh) == 4
+
+    # the new mesh has four faces
+    @test nelements(cmesh) == 4
+  end
 end

--- a/test/cleaning.jl
+++ b/test/cleaning.jl
@@ -1,0 +1,17 @@
+@testset "Cleaning" begin
+  @testset "Removal of unused vertices" begin
+    points = P3[(0, 0, 0), (0, 0, 1), (5, 5, 5), (0, 1, 0), (1, 0, 0)]
+    triangles = [(1, 2, 4), (1, 2, 5), (1, 4, 5), (2, 4, 5)] # point 3 is not used
+    mesh = SimpleMesh(points, connect.(triangles, Triangle))
+    cmesh = clean(mesh)
+    newpoints = vertices(cmesh)
+
+    # only point 3 has been removed
+    @test nvertices(cmesh) == 4
+    @test points[3] ∉ newpoints
+    @test all(points[[1,2,4,5]] .∈ (newpoints,))
+
+    # number of faces has not changed
+    @test nelements(cmesh) == 4
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,7 +98,8 @@ testfiles = [
   "boundingboxes.jl",
   "hulls.jl",
   "transforms.jl",
-  "utils.jl"
+  "utils.jl",
+  "cleaning.jl"
 ]
 
 # --------------------------------


### PR DESCRIPTION
I propose two functions for mesh cleaning:

- `clean(mesh)` to remove the unused vertices - provided in this PR
- `gather(mesh)` to merge the duplicated vertices - not in this PR

The `clean(mesh)` function is used for the clipping.