### PR TITLE
Implementation of center() for Segment

### DIFF
--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -37,6 +37,8 @@ function (s::Segment)(t)
   a + t * (b - a)
 end
 
+center(s::Segment) = s(0.5)
+
 function Base.in(p::Point{Dim,T}, s::Segment{Dim,T}) where {Dim,T}
   # given collinear points (a, b, p), the point p intersects
   # segment ab if and only if vectors satisfy 0 ≤ ap ⋅ ab ≤ ||ab||²

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -44,6 +44,7 @@
     s = Segment(P3(0,0,0), P3(1,1,1))
     @test boundary(s) == PointSet([P3(0,0,0), P3(1,1,1)])
     @test perimeter(s) == zero(T)
+    @test center(s) == Point(0.5, 0.5, 0.5)
   end
 
   @testset "N-gons" begin


### PR DESCRIPTION
I observed that `center` (defined as `segment(t)` for `t=0.5`) does not preserve `T`.