### PR TITLE
halfedgetopology: fix edge4pair dict

### DIFF
--- a/src/topologies/halfedge.jl
+++ b/src/topologies/halfedge.jl
@@ -114,8 +114,8 @@ function HalfEdgeTopology(halves::AbstractVector{Tuple{HalfEdge,HalfEdge}})
   edge4pair = Dict{Tuple{Int,Int},Int}()
   for (i, (h₁, h₂)) in enumerate(ordered)
     u, v = h₁.head, h₂.head
-    edge4pair[(u, v)] = i
-    edge4pair[(v, u)] = i
+    edge4pair[(u, v)] = i * 2
+    edge4pair[(v, u)] = i * 2
   end
 
   HalfEdgeTopology(halfedges, half4elem, half4vert, edge4pair)


### PR DESCRIPTION
It looks like the values of edge4pair are currently wrong. The reason is that the iteration is being done over the `ordered` array instead of the `halfedges` and therefore the wrong index is being used.

This is breaking Coboundary usage.

```
edgeRef = Coboundary{0,1}(halfedgetopology)(1)
edge = halfedgetopology.halfedges[edgesRef[1]] # does not work
edge = halfedgetopology.halfedges[2 * edgesRef[1]] # now it works
```

edit: closing this as I analyzed the rest of the code and I think this is by design. I will open an issue to clarify, thanks!