### PR TITLE
implement Base.in for Cylinder

### DIFF
--- a/src/primitives/cylinder.jl
+++ b/src/primitives/cylinder.jl
@@ -63,12 +63,14 @@ measure(c::Cylinder) = norm(origin(c.bot) - origin(c.top)) * c.radius^2 * pi
 volume(c::Cylinder) = measure(c)
 
 function Base.in(p::Point{3}, c::Cylinder)
-  bot = origin(c.bot)
-  top = origin(c.top)
-  axis = top - bot
+  b = origin(c.bot)
+  t = origin(c.top)
+  axis = t - b
+
   # test if lies between bottom-top planes of the cylinder
-  dot(p-bot, axis) ≥ 0 || return false
-  dot(p-top, axis) ≤ 0 || return false
+  (p-b) ⋅ axis ≥ 0 || return false
+  (p-t) ⋅ axis ≤ 0 || return false
+  
   # test if lies inside the curvature surface of the cylinder
-  return norm((p-bot) × axis) / norm(axis) ≤ c.radius
+  norm((p-b) × axis) / norm(axis) ≤ c.radius
 end

--- a/src/primitives/cylinder.jl
+++ b/src/primitives/cylinder.jl
@@ -66,8 +66,7 @@ function Base.in(p::Point{3}, c::Cylinder)
   b = origin(c.bot)
   t = origin(c.top)
   a = t - b
-
-  (p-b) ⋅ a ≥ 0 || return false
-  (p-t) ⋅ a ≤ 0 || return false
-  norm((p-b) × a) / norm(a) ≤ c.radius
+  (p - b) ⋅ a ≥ 0 || return false
+  (p - t) ⋅ a ≤ 0 || return false
+  norm((p - b) × a) / norm(a) ≤ c.radius
 end

--- a/src/primitives/cylinder.jl
+++ b/src/primitives/cylinder.jl
@@ -67,7 +67,6 @@ function Base.in(p::Point{3}, c::Cylinder)
   t = origin(c.top)
   a = t - b
 
-  # test if lies between bottom-top planes of the cylinder
   (p-b) ⋅ a ≥ 0 || return false
   (p-t) ⋅ a ≤ 0 || return false
   norm((p-b) × a) / norm(a) ≤ c.radius

--- a/src/primitives/cylinder.jl
+++ b/src/primitives/cylinder.jl
@@ -65,12 +65,10 @@ volume(c::Cylinder) = measure(c)
 function Base.in(p::Point{3}, c::Cylinder)
   b = origin(c.bot)
   t = origin(c.top)
-  axis = t - b
+  a = t - b
 
   # test if lies between bottom-top planes of the cylinder
-  (p-b) ⋅ axis ≥ 0 || return false
-  (p-t) ⋅ axis ≤ 0 || return false
-  
-  # test if lies inside the curvature surface of the cylinder
-  norm((p-b) × axis) / norm(axis) ≤ c.radius
+  (p-b) ⋅ a ≥ 0 || return false
+  (p-t) ⋅ a ≤ 0 || return false
+  norm((p-b) × a) / norm(a) ≤ c.radius
 end

--- a/src/primitives/cylinder.jl
+++ b/src/primitives/cylinder.jl
@@ -61,3 +61,14 @@ boundary(c::Cylinder) = CylinderSurface(c.radius, c.bot, c.top)
 measure(c::Cylinder) = norm(origin(c.bot) - origin(c.top)) * c.radius^2 * pi
 
 volume(c::Cylinder) = measure(c)
+
+function Base.in(p::Point{3}, c::Cylinder)
+  bot = origin(c.bot)
+  top = origin(c.top)
+  axis = top - bot
+  # test if lies between bottom-top planes of the cylinder
+  dot(p-bot, axis) ≥ 0 || return false
+  dot(p-top, axis) ≤ 0 || return false
+  # test if lies inside the curvature surface of the cylinder
+  return norm((p-bot) × axis) / norm(axis) ≤ c.radius
+end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -338,6 +338,10 @@
     @test isconvex(c)
     @test !isright(c)
     @test measure(c) == volume(c) ≈ T(5)^2 * pi * T(3)*sqrt(T(3))
+    @test P3(1,2,3) ∈ c
+    @test P3(4,5,6) ∈ c
+    @test P3(0.99,1.99,2.99) ∉ c
+    @test P3(4.01,5.01,6.01) ∉ c
 
     c = Cylinder(1.0)
     @test coordtype(c) == Float64
@@ -356,6 +360,14 @@
     @test isright(c)
     @test boundary(c) == CylinderSurface(T(1), Segment(P3(0,0,0), P3(0,0,1)))
     @test measure(c) == volume(c) ≈ pi 
+    @test P3(0,0,0) ∈ c
+    @test P3(0,0,1) ∈ c
+    @test P3(1,0,0) ∈ c
+    @test P3(0,1,0) ∈ c
+    @test P3(cosd(60),sind(60),0.5) ∈ c
+    @test P3(0,0,-0.001) ∉ c
+    @test P3(0,0,1.001) ∉ c
+    @test P3(1,1,1) ∉ c
   end
 
   @testset "CylinderSurface" begin


### PR DESCRIPTION
I noticed that `Base.in` is not implemented for the cylinder type, so I've done it. Hope the implementation is clear. I can add comments, change names, etc. if needed.
I also added some tests, but I'm not sure how thorough the tests should be.