### PR TITLE
add TouchingRayTriangle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 Manifest.toml
 .vscode
+*.code-workspace
 docs/build
 /.benchmarkci
 /benchmark/*.json

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -339,6 +339,7 @@ export
   TouchingRayBox,
   IntersectingSegmentTriangle,
   CrossingRayTriangle,
+  TouchingRayTriangle,
   CornerTouchingRayTriangle,
   CornerCrossingRayTriangle,
   EdgeCrossingRayTriangle,

--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -94,6 +94,7 @@ Type `IntersectionType` in a Julia session to see the full list.
 
   # ray-triangle intersection
   CrossingRayTriangle
+  TouchingRayTriangle
   CornerTouchingRayTriangle
   CornerCrossingRayTriangle
   EdgeCrossingRayTriangle

--- a/src/intersections/raytriangle.jl
+++ b/src/intersections/raytriangle.jl
@@ -8,10 +8,11 @@ Möller, T. & Trumbore, B., 1997.
 
 Cases
 1. CrossingRayTriangle - middle of ray intersects middle of triangle
-2. CornerTouchingRayTriangle - origin of ray intersects corner of triangle
-3. EdgeTouchingRayTriangle - origin of ray intersects edge of triangle
-4. EdgeCrossingRayTriangle - middle of ray intersects edge of triangle
-5. CornerCrossingRayTriangle - middle of ray intersects corner of triangle
+2. TouchingRayTriangle - origin of ray intersects middle of triangle
+3. CornerTouchingRayTriangle - origin of ray intersects corner of triangle
+4. EdgeTouchingRayTriangle - origin of ray intersects edge of triangle
+5. EdgeCrossingRayTriangle - middle of ray intersects edge of triangle
+6. CornerCrossingRayTriangle - middle of ray intersects corner of triangle
 =#
 function intersection(f, r::Ray{3,T}, t::Triangle{3,T}) where {T}
   vs = vertices(t)
@@ -56,13 +57,19 @@ function intersection(f, r::Ray{3,T}, t::Triangle{3,T}) where {T}
     return @IT NoIntersection nothing f
   end
 
+  # assemble barycentric weights
+  w = Vec(u, v, det - u - v)
+
   if any(isapprox.(o, vs, atol=atol(T)))
     return @IT CornerTouchingRayTriangle r(λ) f
   elseif isapprox(λ, zero(T), atol=atol(T))
-    return @IT EdgeTouchingRayTriangle r(λ) f
+    if all(w .> zero(T))
+      return @IT TouchingRayTriangle r(λ) f
+    else
+      return @IT EdgeTouchingRayTriangle r(λ) f
+    end
   end
 
-  w = Vec(u, v, det - u - v)
   if count(x -> isapprox(x, zero(T), atol=atol(T)), w) == 1
     return @IT EdgeCrossingRayTriangle r(λ) f
   elseif count(x -> isapprox(x, det, atol=atol(T)), w) == 1

--- a/src/intersections/raytriangle.jl
+++ b/src/intersections/raytriangle.jl
@@ -63,7 +63,7 @@ function intersection(f, r::Ray{3,T}, t::Triangle{3,T}) where {T}
   if any(isapprox.(o, vs, atol=atol(T)))
     return @IT CornerTouchingRayTriangle r(λ) f
   elseif isapprox(λ, zero(T), atol=atol(T))
-    if all(>(0), w)
+    if all(>(zero(T)), w)
       return @IT TouchingRayTriangle r(λ) f
     else
       return @IT EdgeTouchingRayTriangle r(λ) f

--- a/src/intersections/raytriangle.jl
+++ b/src/intersections/raytriangle.jl
@@ -63,7 +63,7 @@ function intersection(f, r::Ray{3,T}, t::Triangle{3,T}) where {T}
   if any(isapprox.(o, vs, atol=atol(T)))
     return @IT CornerTouchingRayTriangle r(λ) f
   elseif isapprox(λ, zero(T), atol=atol(T))
-    if all(w .> zero(T))
+    if all(>(0), w)
       return @IT TouchingRayTriangle r(λ) f
     else
       return @IT EdgeTouchingRayTriangle r(λ) f

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -654,6 +654,10 @@
     r = Ray(P3(0.2, 0.2, 1.0), V3(0.0, 0.0, -1.0))
     @test intersection(r, t) |> type == CrossingRayTriangle
     @test r ∩ t == P3(0.2, 0.2, 0.0)
+    # origin of ray intersects with middle of triangle
+    r = Ray(P3(0.2, 0.2, 0.0), V3(0.0, 0.0, -1.0))
+    @test intersection(r, t) |> type == TouchingRayTriangle
+    @test r ∩ t == P3(0.2, 0.2, 0.0)
     # Special case: the direction vector is not length enough to cross triangle
     r = Ray(P3(0.2, 0.2, 1.0), V3(0.0, 0.0, -0.00001))
     @test intersection(r, t) |> type == CrossingRayTriangle


### PR DESCRIPTION
Adds a case where the origin intersects the middle of a triangle to form a complete set of ray-triangle intersections as there are 3 possible things to intersects on the the triangle (vertex, edge, or middle) and 2 possible things to intersects on the ray (origin, ray itself / crossing) for a total of 6 combinations which we now have.