### PR TITLE
Fix `Torus` sampling

### DIFF
--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -191,7 +191,7 @@ function sample(::AbstractRNG, torus::Torus{T},
 
   c = center(torus)
   n⃗ = normal(torus)
-  M = uvrotation(n⃗, Vec(0, 0, 1))
+  M = uvrotation(n⃗, Vec{3,T}(0, 0, 1))
 
   r⃗(u, v) = Vec{3,T}(kxy * cos(u), kxy * sin(u), kz * sin(v)) / (R - r*cos(v))
 


### PR DESCRIPTION
This PR fixes type promotion in `Torus` sampling:
master:
```julia
julia> torus = Torus(Point3f(0, 0, 0), Vec3f(1, 0, 0), 2, 1)
Torus{Float32}(Point(0.0f0, 0.0f0, 0.0f0), Float32[1.0, 0.0, 0.0], 2.0f0, 1.0f0)

julia> collect(sample(torus, RegularSampling(3, 3)))
9-element Vector{Point3}:
 Point(5.047356288478966e-8, 8.74227694680485e-8, 1.0)
 Point(5.047356321785656e-8, -0.866025447845459, -0.4999999701976776)
 ⋮
 Point(1.0000000000000002, -1.732050895690918, -0.999999940395355)
 Point(1.0000000000000002, 1.732050895690918, -0.999999940395355)
```
This PR:
```julia
julia> torus = Torus(Point3f(0, 0, 0), Vec3f(1, 0, 0), 2, 1)
Torus{Float32}(Point(0.0f0, 0.0f0, 0.0f0), Float32[1.0, 0.0, 0.0], 2.0f0, 1.0f0)

julia> collect(sample(torus, RegularSampling(3, 3)))
9-element Vector{Point3f}:
 Point(5.047356f-8, 8.742276f-8, 0.99999994f0)
 Point(5.047356f-8, -0.8660254f0, -0.49999994f0)
 ⋮
 Point(0.99999994f0, -1.7320508f0, -0.9999999f0)
 Point(0.99999994f0, 1.7320508f0, -0.9999999f0)
```