### PR TITLE
more reliable and robust angle implementation

### DIFF
--- a/src/angles.jl
+++ b/src/angles.jl
@@ -56,7 +56,7 @@ end
 @inline norm2(u::V) where {V<:Vec} = sqrt(foldl(+, abs2.(u.coords)))
 @inline unitize(u::V) where {V<:Vec} = u.coords ./ norm2(u)
 
-@inline isnegangle(u::V, v::V) where {V<:Vec3) = false
+@inline isnegangle(u::V, v::V) where {V<:Vec3} = false
 @inline isnegangle(u::V, v::V) where {V<:Vec2} =
     u.coords[1] * v.coords[2] < u.coords[2] * v.coords[1]
 


### PR DESCRIPTION
This PR preserves the current naming and functionality (Vec2 angles are signed, Vec3 angles are not). There should be no internal conflicts.  This PR neither revamps the naming nor introduces another geometric function space.  Others are welcome to that.