### PR TITLE
Remove Vec constructor for AbstractVector

### DIFF
--- a/src/collections.jl
+++ b/src/collections.jl
@@ -53,7 +53,7 @@ PointSet(coords::AbstractVector{TP}) where {TP<:Tuple} = PointSet(Point.(coords)
 PointSet(coords::Vararg{TP}) where {TP<:Tuple} = PointSet(collect(coords))
 PointSet(coords::AbstractVector{V}) where {V<:AbstractVector} = PointSet(Point.(coords))
 PointSet(coords::Vararg{V}) where {V<:AbstractVector} = PointSet(collect(coords))
-PointSet(coords::AbstractMatrix) = PointSet(Point.(eachcol(coords)))
+PointSet(coords::AbstractMatrix) = PointSet(Tuple.(eachcol(coords)))
 
 # constructor with iterator of points
 PointSet(points) = PointSet(collect(points))

--- a/src/intersections/lines.jl
+++ b/src/intersections/lines.jl
@@ -63,7 +63,8 @@ function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T},
 
   # calculate parameters of intersection or closest point
   if r ≥ 2
-    λ = A \ y
+    # λ = A \ y
+    λ = A \ SVector(y.coords)
   else # parallel or collinear
     λ = SVector(zero(T), zero(T))
   end

--- a/src/intersections/lines.jl
+++ b/src/intersections/lines.jl
@@ -48,7 +48,7 @@ calculated in order to identify the intersection type:
 function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T}, 
                              c::Point{Dim,T}, d::Point{Dim,T}) where {Dim,T}
   A = [(b - a) (c - d)]
-  y = SVector(c - a)
+  y = c - a
 
   # calculate the rank of the augmented matrix by checking
   # the zero entries of the diagonal of R

--- a/src/intersections/lines.jl
+++ b/src/intersections/lines.jl
@@ -48,7 +48,7 @@ calculated in order to identify the intersection type:
 function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T}, 
                              c::Point{Dim,T}, d::Point{Dim,T}) where {Dim,T}
   A = [(b - a) (c - d)]
-  y = c - a
+  y = SVector(c - a)
 
   # calculate the rank of the augmented matrix by checking
   # the zero entries of the diagonal of R
@@ -63,7 +63,7 @@ function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T},
 
   # calculate parameters of intersection or closest point
   if r ≥ 2
-    λ = A \ SVector(y.coords)
+    λ = A \ y
   else # parallel or collinear
     λ = SVector(zero(T), zero(T))
   end

--- a/src/intersections/lines.jl
+++ b/src/intersections/lines.jl
@@ -63,7 +63,6 @@ function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T},
 
   # calculate parameters of intersection or closest point
   if r ≥ 2
-    # λ = A \ y
     λ = A \ SVector(y.coords)
   else # parallel or collinear
     λ = SVector(zero(T), zero(T))

--- a/src/points.jl
+++ b/src/points.jl
@@ -5,10 +5,8 @@
 """
     Point(x₁, x₂, ..., xₙ)
     Point((x₁, x₂, ..., xₙ))
-    Point([x₁, x₂, ..., xₙ])
     Point{Dim,T}(x₁, x₂, ..., xₙ)
     Point{Dim,T}((x₁, x₂, ..., xₙ))
-    Point{Dim,T}([x₁, x₂, ..., xₙ])
 
 A point in `Dim`-dimensional space with coordinates of type `T`.
 

--- a/src/transforms/smoothing.jl
+++ b/src/transforms/smoothing.jl
@@ -55,7 +55,7 @@ function _smooth(points, L, n, λ, μ; revert=false)
   end
 
   # new points
-    Point.(Tuple.(eachrow(X)))
+  Point.(Tuple.(eachrow(X)))
 end
 
 """

--- a/src/transforms/smoothing.jl
+++ b/src/transforms/smoothing.jl
@@ -55,7 +55,7 @@ function _smooth(points, L, n, λ, μ; revert=false)
   end
 
   # new points
-  Point.(eachrow(X))
+    Point.(Tuple.(eachrow(X)))
 end
 
 """

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -5,10 +5,8 @@
 """
     Vec(x₁, x₂, ..., xₙ)
     Vec((x₁, x₂, ..., xₙ))
-    Vec([x₁, x₂, ..., xₙ])
     Vec{Dim,T}(x₁, x₂, ..., xₙ)
     Vec{Dim,T}((x₁, x₂, ..., xₙ))
-    Vec{Dim,T}([x₁, x₂, ..., xₙ])
 
 A vector in `Dim`-dimensional space with coordinates of type `T`.
 

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -63,7 +63,19 @@ end
 Vec(coords...) = Vec(coords)
 Vec(coords::Tuple) = Vec(promote(coords...))
 Vec(coords::NTuple{Dim,T}) where {Dim,T} = Vec{Dim,T}(coords)
-Vec(coords::AbstractVector{T}) where {T} = Vec{length(coords),T}(coords)
+
+function Vec(coords::AbstractVector{T}) where {T}
+    n = length(coords)
+    if n == 1
+        Vec{1,T}(coords)
+    elseif n == 2
+        Vec{2,T}(coords)
+    elseif n == 3
+        Vec{3,T}(coords)
+    else
+        throw(ErrorException("not implemented"))
+    end
+end
 
 # StaticVector constructors
 Vec(coords::StaticVector{Dim,T}) where {Dim,T} = Vec{Dim,T}(coords)

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -55,6 +55,10 @@ function Vec{Dim,T}(coords::Tuple) where {Dim,T}
   checkdim(Vec{Dim,T}, coords)
   Vec{Dim,T}(NTuple{Dim,T}(coords))
 end
+function Vec{Dim,T}(coords::AbstractVector) where {Dim,T}
+  checkdim(Vec{Dim,T}, coords)
+  Vec{Dim,T}(NTuple{Dim,T}(coords))
+end
 
 Vec(coords...) = Vec(coords)
 Vec(coords::Tuple) = Vec(promote(coords...))

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -55,27 +55,10 @@ function Vec{Dim,T}(coords::Tuple) where {Dim,T}
   checkdim(Vec{Dim,T}, coords)
   Vec{Dim,T}(NTuple{Dim,T}(coords))
 end
-function Vec{Dim,T}(coords::AbstractVector) where {Dim,T}
-  checkdim(Vec{Dim,T}, coords)
-  Vec{Dim,T}(NTuple{Dim,T}(coords))
-end
 
 Vec(coords...) = Vec(coords)
 Vec(coords::Tuple) = Vec(promote(coords...))
 Vec(coords::NTuple{Dim,T}) where {Dim,T} = Vec{Dim,T}(coords)
-
-function Vec(coords::AbstractVector{T}) where {T}
-    n = length(coords)
-    if n == 1
-        Vec{1,T}(coords)
-    elseif n == 2
-        Vec{2,T}(coords)
-    elseif n == 3
-        Vec{3,T}(coords)
-    else
-        throw(ErrorException("not implemented"))
-    end
-end
 
 # StaticVector constructors
 Vec(coords::StaticVector{Dim,T}) where {Dim,T} = Vec{Dim,T}(coords)

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -22,16 +22,9 @@
     pset2 = PointSet(P3(1,2,3), P3(4,5,6))
     pset3 = PointSet([T.((1,2,3)), T.((4,5,6))])
     pset4 = PointSet(T.((1,2,3)), T.((4,5,6)))
-    # pset5 = PointSet([T[1,2,3], T[4,5,6]])
-    # pset6 = PointSet(T[1,2,3], T[4,5,6])
-    # pset7 = PointSet(T[1 4; 2 5; 3 6])
     pset5 = PointSet(T[1 4; 2 5; 3 6])
-    @test pset1 == pset2 == pset3 == pset4 ==
-          pset5
-          # pset5 == pset6 == pset7
-    for pset in [pset1, pset2, pset3, pset4,
-                pset5]
-                # pset5, pset6, pset7]
+    @test pset1 == pset2 == pset3 == pset4 == pset5
+    for pset in [pset1, pset2, pset3, pset4, pset5]
       @test embeddim(pset) == 3
       @test coordtype(pset) == T
       @test nelements(pset) == 2

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -22,13 +22,16 @@
     pset2 = PointSet(P3(1,2,3), P3(4,5,6))
     pset3 = PointSet([T.((1,2,3)), T.((4,5,6))])
     pset4 = PointSet(T.((1,2,3)), T.((4,5,6)))
-    pset5 = PointSet([T[1,2,3], T[4,5,6]])
-    pset6 = PointSet(T[1,2,3], T[4,5,6])
-    pset7 = PointSet(T[1 4; 2 5; 3 6])
+    # pset5 = PointSet([T[1,2,3], T[4,5,6]])
+    # pset6 = PointSet(T[1,2,3], T[4,5,6])
+    # pset7 = PointSet(T[1 4; 2 5; 3 6])
+    pset5 = PointSet(T[1 4; 2 5; 3 6])
     @test pset1 == pset2 == pset3 == pset4 ==
-          pset5 == pset6 == pset7
+          pset5
+          # pset5 == pset6 == pset7
     for pset in [pset1, pset2, pset3, pset4,
-                pset5, pset6, pset7]
+                pset5]
+                # pset5, pset6, pset7]
       @test embeddim(pset) == 3
       @test coordtype(pset) == T
       @test nelements(pset) == 2

--- a/test/points.jl
+++ b/test/points.jl
@@ -73,7 +73,6 @@
 
   @test_throws DimensionMismatch Point{2,T}(1)
   @test_throws DimensionMismatch Point{3,T}((2,3))
-  # @test_throws DimensionMismatch Point{-3,T}([4,5,6])
   @test_throws DimensionMismatch Point{-3,T}((4,5,6))
 
   # There are 2 cases that throw a MethodError instead of a DimensionMismatch:
@@ -84,11 +83,9 @@
   # check that input of mixed coordinate types is allowed and works as expected
   @test Point(1, .2) == Point{2,Float64}(1., .2)
   @test Point((3., 4)) == Point{2,Float64}(3., 4.)
-  # @test Point([5., 6., 7]) == Point{3,Float64}(5., 6., 7.)
   @test Point((5., 6., 7)) == Point{3,Float64}(5., 6., 7.)
   @test Point{2,T}(8, 9.) == Point{2,T}((8., 9.))
   @test Point{2,T}((-1., -2)) == Point{2,T}((-1, -2))
-  # @test Point{4,T}([0, -1., +2, -4.]) == Point{4,T}((0f0, -1f0, +2f0, -4f0))
   @test Point{4,T}((0, -1., +2, -4.)) == Point{4,T}((0f0, -1f0, +2f0, -4f0))
 
   # Integer coordinates converted to Float64

--- a/test/points.jl
+++ b/test/points.jl
@@ -54,26 +54,39 @@
   @test P2(1, 2) ≈ P2(1 + eps(T), T(2))
   @test P3(1, 2, 3) ≈ P3(1 + eps(T), T(2), T(3))
 
-  @test embeddim(Point([1])) == 1
-  @test coordtype(Point([1])) == Float64
-  @test coordtype(Point([1.])) == Float64
+  # @test embeddim(Point([1])) == 1
+  # @test coordtype(Point([1])) == Float64
+  # @test coordtype(Point([1.])) == Float64
+  @test embeddim(Point((1,))) == 1
+  @test coordtype(Point((1,))) == Float64
+  @test coordtype(Point((1.,))) == Float64
 
-  @test embeddim(Point([1,2])) == 2
-  @test coordtype(Point([1,2])) == Float64
-  @test coordtype(Point([1.,2.])) == Float64
+  # @test embeddim(Point([1,2])) == 2
+  # @test coordtype(Point([1,2])) == Float64
+  # @test coordtype(Point([1.,2.])) == Float64
+  @test embeddim(Point((1,2))) == 2
+  @test coordtype(Point((1,2))) == Float64
+  @test coordtype(Point((1.,2.))) == Float64
 
-  @test embeddim(Point([1,2,3])) == 3
-  @test coordtype(Point([1,2,3])) == Float64
-  @test coordtype(Point([1.,2.,3.])) == Float64
+  # @test embeddim(Point([1,2,3])) == 3
+  # @test coordtype(Point([1,2,3])) == Float64
+  # @test coordtype(Point([1.,2.,3.])) == Float64
+  @test embeddim(Point((1,2,3))) == 3
+  @test coordtype(Point((1,2,3))) == Float64
+  @test coordtype(Point((1.,2.,3.))) == Float64
 
   # check all 1D Point constructors, because those tend to make trouble
-  @test Point(1) == Point((1,)) == Point([1])
-  @test Point{1,T}(-2) == Point{1,T}((-2,)) == Point{1,T}([-2])
-  @test Point{1,T}(0) == Point{1,T}((0,)) == Point{1,T}([0])
+  # @test Point(1) == Point((1,)) == Point([1])
+  # @test Point{1,T}(-2) == Point{1,T}((-2,)) == Point{1,T}([-2])
+  # @test Point{1,T}(0) == Point{1,T}((0,)) == Point{1,T}([0])
+  @test Point(1) == Point((1,))
+  @test Point{1,T}(-2) == Point{1,T}((-2,))
+  @test Point{1,T}(0) == Point{1,T}((0,))
 
   @test_throws DimensionMismatch Point{2,T}(1)
   @test_throws DimensionMismatch Point{3,T}((2,3))
-  @test_throws DimensionMismatch Point{-3,T}([4,5,6])
+  # @test_throws DimensionMismatch Point{-3,T}([4,5,6])
+  @test_throws DimensionMismatch Point{-3,T}((4,5,6))
 
   # There are 2 cases that throw a MethodError instead of a DimensionMismatch:
   # `Point{1,T}((2,3))` because it tries to take the tuple as a whole and convert to T and:
@@ -83,10 +96,12 @@
   # check that input of mixed coordinate types is allowed and works as expected
   @test Point(1, .2) == Point{2,Float64}(1., .2)
   @test Point((3., 4)) == Point{2,Float64}(3., 4.)
-  @test Point([5., 6., 7]) == Point{3,Float64}(5., 6., 7.)
+  # @test Point([5., 6., 7]) == Point{3,Float64}(5., 6., 7.)
+  @test Point((5., 6., 7)) == Point{3,Float64}(5., 6., 7.)
   @test Point{2,T}(8, 9.) == Point{2,T}((8., 9.))
   @test Point{2,T}((-1., -2)) == Point{2,T}((-1, -2))
-  @test Point{4,T}([0, -1., +2, -4.]) == Point{4,T}((0f0, -1f0, +2f0, -4f0))
+  # @test Point{4,T}([0, -1., +2, -4.]) == Point{4,T}((0f0, -1f0, +2f0, -4f0))
+  @test Point{4,T}((0, -1., +2, -4.)) == Point{4,T}((0f0, -1f0, +2f0, -4f0))
 
   # Integer coordinates converted to Float64
   @test coordtype(Point(1)) == Float64

--- a/test/points.jl
+++ b/test/points.jl
@@ -54,31 +54,19 @@
   @test P2(1, 2) ≈ P2(1 + eps(T), T(2))
   @test P3(1, 2, 3) ≈ P3(1 + eps(T), T(2), T(3))
 
-  # @test embeddim(Point([1])) == 1
-  # @test coordtype(Point([1])) == Float64
-  # @test coordtype(Point([1.])) == Float64
   @test embeddim(Point((1,))) == 1
   @test coordtype(Point((1,))) == Float64
   @test coordtype(Point((1.,))) == Float64
 
-  # @test embeddim(Point([1,2])) == 2
-  # @test coordtype(Point([1,2])) == Float64
-  # @test coordtype(Point([1.,2.])) == Float64
   @test embeddim(Point((1,2))) == 2
   @test coordtype(Point((1,2))) == Float64
   @test coordtype(Point((1.,2.))) == Float64
 
-  # @test embeddim(Point([1,2,3])) == 3
-  # @test coordtype(Point([1,2,3])) == Float64
-  # @test coordtype(Point([1.,2.,3.])) == Float64
   @test embeddim(Point((1,2,3))) == 3
   @test coordtype(Point((1,2,3))) == Float64
   @test coordtype(Point((1.,2.,3.))) == Float64
 
   # check all 1D Point constructors, because those tend to make trouble
-  # @test Point(1) == Point((1,)) == Point([1])
-  # @test Point{1,T}(-2) == Point{1,T}((-2,)) == Point{1,T}([-2])
-  # @test Point{1,T}(0) == Point{1,T}((0,)) == Point{1,T}([0])
   @test Point(1) == Point((1,))
   @test Point{1,T}(-2) == Point{1,T}((-2,))
   @test Point{1,T}(0) == Point{1,T}((0,))

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -424,7 +424,8 @@
       0.0  0.2  0.2  0.4  0.4  0.6  0.6  0.8  0.8  0.6  0.4  0.2  0.0  1.0  1.0  0.0
       0.0  0.2  0.4  0.4  0.2  0.2  0.4  0.4  0.2  0.2  0.2  0.2  0.0  0.0  1.0  1.0
     ]
-    @test vertices(chain) == Point.(eachcol(target))
+    # @test vertices(chain) == Point.(eachcol(target))
+    @test vertices(chain) == Point.(NTuple{2, T}.(eachcol(target)))
 
     # test uniqueness
     points = P2[(1,1),(2,2),(2,2),(3,3),(1,1)]

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -424,7 +424,6 @@
       0.0  0.2  0.2  0.4  0.4  0.6  0.6  0.8  0.8  0.6  0.4  0.2  0.0  1.0  1.0  0.0
       0.0  0.2  0.4  0.4  0.2  0.2  0.4  0.4  0.2  0.2  0.2  0.2  0.0  0.0  1.0  1.0
     ]
-    # @test vertices(chain) == Point.(eachcol(target))
     @test vertices(chain) == Point.(NTuple{2, T}.(eachcol(target)))
 
     # test uniqueness

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -424,7 +424,7 @@
       0.0  0.2  0.2  0.4  0.4  0.6  0.6  0.8  0.8  0.6  0.4  0.2  0.0  1.0  1.0  0.0
       0.0  0.2  0.4  0.4  0.2  0.2  0.4  0.4  0.2  0.2  0.2  0.2  0.0  0.0  1.0  1.0
     ]
-    @test vertices(chain) == Point.(NTuple{2, T}.(eachcol(target)))
+    @test vertices(chain) == Point.(Tuple.(eachcol(target)))
 
     # test uniqueness
     points = P2[(1,1),(2,2),(2,2),(3,3),(1,1)]

--- a/test/vectors.jl
+++ b/test/vectors.jl
@@ -21,26 +21,11 @@
   @test eltype(Vec2f((1, 1))) == Float32
   @test eltype(Vec3f((1, 1, 1))) == Float32
 
-  # # vector constructors
-  # @test eltype(Vec([1, 1])) == Float64
-  # @test eltype(Vec([1.0, 1.0])) == Float64
-  # @test eltype(Vec([1.0f0, 1.0f0])) == Float32
-  # @test eltype(Vec1([1])) == Float64
-  # @test eltype(Vec2([1, 1])) == Float64
-  # @test eltype(Vec3([1, 1, 1])) == Float64
-  # @test eltype(Vec1f([1])) == Float32
-  # @test eltype(Vec2f([1, 1])) == Float32
-  # @test eltype(Vec3f([1, 1, 1])) == Float32  
-
   # parametric constructors 
   @test eltype(Vec{2,T}(1, 1)) == T
   @test eltype(Vec{2,T}((1, 1))) == T
-  # @test eltype(Vec{2,T}([1, 1])) == T
 
   # check all 1D Vec constructors, because those tend to make trouble
-  # @test Vec(1) == Vec((1,)) == Vec([1])
-  # @test Vec{1,T}(0) == Vec{1,T}((0,)) == Vec{1,T}([0])
-  # @test Vec{1,T}(-2) == Vec{1,T}((-2,)) == Vec{1,T}([-2])
   @test Vec(1) == Vec((1,))
   @test Vec{1,T}(0) == Vec{1,T}((0,))
   @test Vec{1,T}(-2) == Vec{1,T}((-2,))
@@ -48,11 +33,9 @@
   # check that input of mixed coordinate types is allowed and works as expected
   @test Vec(1, 0.2) == Vec{2,Float64}(1.0, 0.2)
   @test Vec((3.0, 4)) == Vec{2,Float64}(3.0, 4.0)
-  # @test Vec([5.0, 6.0, 7]) == Vec{3,Float64}(5.0, 6.0, 7.0)
   @test Vec((5.0, 6.0, 7)) == Vec{3,Float64}(5.0, 6.0, 7.0)
   @test Vec{2,T}(8, 9.0) == Vec{2,T}((8.0, 9.0))
   @test Vec{2,T}((-1.0, -2)) == Vec{2,T}((-1, -2.0))
-  # @test Vec{4,T}([0, -1.0, +2, -4.0]) == Vec{4,T}((0.0f0, -1.0f0, +2.0f0, -4.0f0))
   @test Vec{4,T}((0, -1.0, +2, -4.0)) == Vec{4,T}((0.0f0, -1.0f0, +2.0f0, -4.0f0))
 
   # Integer coordinates converted to Float64
@@ -66,6 +49,5 @@
   # throws
   @test_throws DimensionMismatch Vec{2,T}(1)
   @test_throws DimensionMismatch Vec{3,T}((2, 3))
-  # @test_throws DimensionMismatch Vec{-3,T}([4, 5, 6])
   @test_throws DimensionMismatch Vec{-3,T}((4, 5, 6))
 end

--- a/test/vectors.jl
+++ b/test/vectors.jl
@@ -21,34 +21,39 @@
   @test eltype(Vec2f((1, 1))) == Float32
   @test eltype(Vec3f((1, 1, 1))) == Float32
 
-  # vector constructors
-  @test eltype(Vec([1, 1])) == Float64
-  @test eltype(Vec([1.0, 1.0])) == Float64
-  @test eltype(Vec([1.0f0, 1.0f0])) == Float32
-  @test eltype(Vec1([1])) == Float64
-  @test eltype(Vec2([1, 1])) == Float64
-  @test eltype(Vec3([1, 1, 1])) == Float64
-  @test eltype(Vec1f([1])) == Float32
-  @test eltype(Vec2f([1, 1])) == Float32
-  @test eltype(Vec3f([1, 1, 1])) == Float32  
+  # # vector constructors
+  # @test eltype(Vec([1, 1])) == Float64
+  # @test eltype(Vec([1.0, 1.0])) == Float64
+  # @test eltype(Vec([1.0f0, 1.0f0])) == Float32
+  # @test eltype(Vec1([1])) == Float64
+  # @test eltype(Vec2([1, 1])) == Float64
+  # @test eltype(Vec3([1, 1, 1])) == Float64
+  # @test eltype(Vec1f([1])) == Float32
+  # @test eltype(Vec2f([1, 1])) == Float32
+  # @test eltype(Vec3f([1, 1, 1])) == Float32  
 
   # parametric constructors 
   @test eltype(Vec{2,T}(1, 1)) == T
   @test eltype(Vec{2,T}((1, 1))) == T
-  @test eltype(Vec{2,T}([1, 1])) == T
+  # @test eltype(Vec{2,T}([1, 1])) == T
 
   # check all 1D Vec constructors, because those tend to make trouble
-  @test Vec(1) == Vec((1,)) == Vec([1])
-  @test Vec{1,T}(0) == Vec{1,T}((0,)) == Vec{1,T}([0])
-  @test Vec{1,T}(-2) == Vec{1,T}((-2,)) == Vec{1,T}([-2])
+  # @test Vec(1) == Vec((1,)) == Vec([1])
+  # @test Vec{1,T}(0) == Vec{1,T}((0,)) == Vec{1,T}([0])
+  # @test Vec{1,T}(-2) == Vec{1,T}((-2,)) == Vec{1,T}([-2])
+  @test Vec(1) == Vec((1,))
+  @test Vec{1,T}(0) == Vec{1,T}((0,))
+  @test Vec{1,T}(-2) == Vec{1,T}((-2,))
 
   # check that input of mixed coordinate types is allowed and works as expected
   @test Vec(1, 0.2) == Vec{2,Float64}(1.0, 0.2)
   @test Vec((3.0, 4)) == Vec{2,Float64}(3.0, 4.0)
-  @test Vec([5.0, 6.0, 7]) == Vec{3,Float64}(5.0, 6.0, 7.0)
+  # @test Vec([5.0, 6.0, 7]) == Vec{3,Float64}(5.0, 6.0, 7.0)
+  @test Vec((5.0, 6.0, 7)) == Vec{3,Float64}(5.0, 6.0, 7.0)
   @test Vec{2,T}(8, 9.0) == Vec{2,T}((8.0, 9.0))
   @test Vec{2,T}((-1.0, -2)) == Vec{2,T}((-1, -2.0))
-  @test Vec{4,T}([0, -1.0, +2, -4.0]) == Vec{4,T}((0.0f0, -1.0f0, +2.0f0, -4.0f0))
+  # @test Vec{4,T}([0, -1.0, +2, -4.0]) == Vec{4,T}((0.0f0, -1.0f0, +2.0f0, -4.0f0))
+  @test Vec{4,T}((0, -1.0, +2, -4.0)) == Vec{4,T}((0.0f0, -1.0f0, +2.0f0, -4.0f0))
 
   # Integer coordinates converted to Float64
   @test eltype(Vec(1)) == Float64
@@ -61,5 +66,6 @@
   # throws
   @test_throws DimensionMismatch Vec{2,T}(1)
   @test_throws DimensionMismatch Vec{3,T}((2, 3))
-  @test_throws DimensionMismatch Vec{-3,T}([4, 5, 6])
+  # @test_throws DimensionMismatch Vec{-3,T}([4, 5, 6])
+  @test_throws DimensionMismatch Vec{-3,T}((4, 5, 6))
 end


### PR DESCRIPTION
Fixes #398 and it is related to JuliaEarth/GeoTables.jl#13. We decided to remove `Vec` constructor over `AbstractVector` because it is not type-stable. The same approach is taken by `StaticArrays.jl`. 

It is just a initial PR to show that we can get rid of the constructor for `AbstractVector`, some improvements need to be done.