### PR TITLE
Define function to get specific vertex of polytope

### DIFF
--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -39,11 +39,24 @@ Return the parametric dimension or rank of the polytope.
 paramdim(::Type{<:Polytope{K}}) where {K} = K
 
 """
+    vertex(polytope, ind)
+
+Return the vertex of a `polytope` at index `ind`.
+"""
+vertex(p::Polytope, ind) = vertices(p)[ind]
+
+"""
     vertices(polytope)
 
 Return the vertices of a `polytope`.
 """
-vertices(p::Polytope) = p.vertices
+function vertices(p::Polytope)
+  if hasfield(typeof(p), :vertices)
+    p.vertices
+  else
+    collect(vertex(p, ind) for ind in 1:nvertices(p))
+  end
+end
 
 """
     nvertices(polytope)

--- a/src/primitives/box.jl
+++ b/src/primitives/box.jl
@@ -47,32 +47,23 @@ diagonal(b::Box) = norm(b.max - b.min)
 
 sides(b::Box) = Tuple(b.max - b.min)
 
-vertices(b::Box{1}) = [b.min, b.max]
+nvertices(b::Box{Dim}) where Dim = 2^Dim
 
-function vertices(b::Box{2})
-  A = coordinates(b.min)
-  B = coordinates(b.max)
-  Point.([
-    (A[1], A[2]),
-    (B[1], A[2]),
-    (B[1], B[2]),
-    (A[1], B[2]),
-  ])
-end
+vertices(b::Box) = collect(vertex(b, ind) for ind in 1:nvertices(b))
 
-function vertices(b::Box{3})
-  A = coordinates(b.min)
-  B = coordinates(b.max)
-  Point.([
-    (A[1], A[2], A[3]),
-    (B[1], A[2], A[3]),
-    (B[1], B[2], A[3]),
-    (A[1], B[2], A[3]),
-    (A[1], A[2], B[3]),
-    (B[1], A[2], B[3]),
-    (B[1], B[2], B[3]),
-    (A[1], B[2], B[3]),
-  ])
+function vertex(b::Box{Dim}, ind) where Dim
+  1 <= ind <= nvertices(b) ||
+    throw(ArgumentError("attempted to access vertex $ind of $(typeof(b))"))
+  xmin, xmax = coordinates.(extrema(b))
+  ind -= 1 # zero-based index
+  coords = ntuple(Dim) do d
+    low = iszero(ind & (1 << (d-1)))
+    if d == 1 && !iszero(ind & 2)
+      low = !low
+    end
+    low ? xmin[d] : xmax[d]
+  end
+  Point(coords)
 end
 
 function boundary(b::Box{2})


### PR DESCRIPTION
As discussed in #406, this defines a new function to get a specific vertex of a polytope. It also implements the `vertices` function of the Box in terms of this new function, generalizing it to N dimensions.

A few open questions:
- Maybe it is better to leave the implementation of `vertices(polytope)` as it was? The new implementation would allow new polytopes to automatically get the implementation of `vertices` if they define `vertex` and `nvertices` and should not have any runtime overhead since the conditional can be resolved at compile-time, but has circular dependencies if those two methods are not defined.
- For the Box, I think it would be cleaner to define the vertex order to consistently switch between the lower and upper boundary along the first dimension, i.e. remove the conditional at lines 61–63 (e.g. [(0,0),(1,0),(0,1),(1,1)] in 2D). This would require a small change in the `boundary` function. However, I’m not sure if there is any other code that relies on the order of the box vertices, so maybe it’s better to keep the order as it is?
- Is there a reason that the Box is classified as a primitive instead of a polytope?