### PR TITLE
Clarify current use of signed angles

### DIFF
--- a/src/angles.jl
+++ b/src/angles.jl
@@ -8,7 +8,8 @@
 Angle ∠ABC between rays BA and BC.
 See https://en.wikipedia.org/wiki/Angle.
 
-Uses the two-argument form of `atan` returning value in range [-π, π].
+Uses the two-argument form of `atan` returning value in range [-π, π]
+in 2D and [0, π] in 3D.
 See https://en.wikipedia.org/wiki/Atan2.
 
 ## Examples
@@ -26,7 +27,8 @@ See https://en.wikipedia.org/wiki/Atan2.
 Angle between vectors u and v.
 See https://en.wikipedia.org/wiki/Angle.
 
-Uses the two-argument form of `atan` returning value in range [-π, π].
+Uses the two-argument form of `atan` returning value in range [-π, π]
+in 2D and [0, π] in 3D.
 See https://en.wikipedia.org/wiki/Atan2.
 
 ## Examples

--- a/src/polytopes/chain.jl
+++ b/src/polytopes/chain.jl
@@ -137,7 +137,7 @@ See https://en.wikipedia.org/wiki/Winding_number.
   the simplicity and orientation of planar polygons]
   (https://www.sciencedirect.com/science/article/abs/pii/0167839691900198)
 """
-function windingnumber(p::Point{Dim,T}, c::Chain{Dim,T}) where {Dim,T}
+function windingnumber(p::Point{2,T}, c::Chain{2,T}) where {T}
   vₒ, vs = p, c.vertices
   ∑ = sum(∠(vs[i], vₒ, vs[i+1]) for i in 1:length(vs)-1)
   ∑ / T(2π)
@@ -172,7 +172,7 @@ Default method is `WindingOrientation()`.
 """
 orientation(c::Chain) = orientation(c, WindingOrientation())
 
-function orientation(c::Chain{Dim,T}, ::WindingOrientation) where {Dim,T}
+function orientation(c::Chain{2,T}, ::WindingOrientation) where {T}
   # pick any segment
   x1, x2 = c.vertices[1:2]
   x̄ = centroid(Segment(x1, x2))
@@ -180,7 +180,7 @@ function orientation(c::Chain{Dim,T}, ::WindingOrientation) where {Dim,T}
   isapprox(w, T(π), atol=atol(T)) ? :CCW : :CW
 end
 
-function orientation(c::Chain{Dim,T}, ::TriangleOrientation) where {Dim,T}
+function orientation(c::Chain{2,T}, ::TriangleOrientation) where {T}
   v = vertices(c)
   Δ(i) = signarea(v[1], v[i], v[i+1])
   a = mapreduce(Δ, +, 2:length(v)-1)
@@ -314,7 +314,7 @@ Return inner angles of the *closed* `chain`. Inner
 angles are always positive, and unlike `angles`
 they can be greater than `π`.
 """
-function innerangles(c::Chain{Dim,T}) where {Dim,T}
+function innerangles(c::Chain{2,T}) where {T}
   @assert isclosed(c) "Inner angles only defined for closed chains"
 
   # correct sign of angles in case orientation is CW


### PR DESCRIPTION
Currently, signed angles are only returned in 2D. While #396 has sparked a discussion on various aspects of the `angle` function, this PR aims just to clarify the current situation: In 3D, unsigned angles in [0,π] are returned and the functions that rely on signed angles only work in 2D. This partially addresses #405, where `isconvex` in 3D should now return an error instead of wrong results. Further improvements will be discussed in #409.