### PR TITLE
Use Bool field for representing closed Chain

### DIFF
--- a/src/polytopes/polyarea.jl
+++ b/src/polytopes/polyarea.jl
@@ -88,8 +88,8 @@ windingnumber(point::Point, p::PolyArea) =
   windingnumber(point, p.outer)
 
 function Base.unique!(p::PolyArea)
-  close!(unique!(open!(p.outer)))
-  hasholes(p) && foreach(c->close!(unique!(open!(c))), p.inners)
+  unique!(p.outer)
+  hasholes(p) && foreach(c->unique!(c), p.inners)
   p
 end
 

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -287,11 +287,6 @@
 
     # closing/opening chains
     c = Chain(P2[(1,1),(2,2),(3,3)])
-    close!(c)
-    @test c == Chain(P2[(1,1),(2,2),(3,3),(1,1)])
-    open!(c)
-    @test c == Chain(P2[(1,1),(2,2),(3,3)])
-    c = Chain(P2[(1,1),(2,2),(3,3)])
     @test close(c) == Chain(P2[(1,1),(2,2),(3,3),(1,1)])
     c = Chain(P2[(1,1),(2,2),(3,3),(1,1)])
     @test open(c) == Chain(P2[(1,1),(2,2),(3,3)])
@@ -448,7 +443,7 @@
     points = P2[(1,1),(2,2),(2,2),(3,3),(1,1)]
     poly   = PolyArea(points)
     unique!(poly)
-    @test first(chains(poly)) == Chain(points)
+    @test first(chains(poly)) == Chain(P2[(1,1),(2,2),(3,3),(1,1)])
 
     # unique and bridges
     poly = PolyArea(P2[(0,0),(1,0),(1,0),(1,1),(1,2),(0,2),(0,1),(0,1),(0,0)])


### PR DESCRIPTION
This PR contains the alternative approach to #411 that doesn’t make the open/closed property of the Chain part of its type and uses a boolean field instead.