### PR TITLE
Remove "join_lines_based_on_source" option

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -5,7 +5,6 @@ always_use_return = false
 whitespace_typedefs = false
 whitespace_in_kwargs = false
 whitespace_ops_in_indices = true
-join_lines_based_on_source = true
 remove_extra_newlines = true
 trailing_comma = false
 normalize_line_endings = "unix"


### PR DESCRIPTION
This option can generate codes with incorrect syntax, as noted in PR #418.