### PR TITLE
Regular sampling 

### DIFF
--- a/src/primitives/ball.jl
+++ b/src/primitives/ball.jl
@@ -38,11 +38,11 @@ area(b::Ball{2}) = measure(b)
 
 volume(b::Ball{3}) = measure(b)
 
-function Base.in(p::Point, b::Ball)
-  x = coordinates(p)
-  c = coordinates(b.center)
+function Base.in(p::Point{Dim,T}, b::Ball{Dim,T}) where {Dim,T}
+  c = b.center
   r = b.radius
-  sum(abs2, x - c) ≤ r^2
+  s = norm(p - c)
+  s < r || isapprox(s, r, atol = atol(T))
 end
 
 boundary(b::Ball) = Sphere(b.center, b.radius)

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -56,7 +56,7 @@ function sample(::AbstractRNG, ball::Ball{Dim,T}, method::RegularSampling) where
   # reuse samples on the boundary
   points = sample(Sphere(c, r), RegularSampling(sz[1:(Dim - 1)]))
 
-  scale(p, s) = Point(s * coordinates(p))
+  scale(p, s) = c + s * (p - c)
 
   ivec(scale(p, s) for p in points, s in srange)
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -258,9 +258,17 @@
     @test b(T(0), T(0)) ≈ P2(0, 0)
     @test b(T(1), T(0)) ≈ P2(2, 0)
 
+    b = Ball(P2(7, 7), T(1.5))
+    ps = b.(1, rand(T, 100))
+    all(∈(b), ps)
+
     b = Ball(P3(0, 0, 0), T(2))
     @test b(T(0), T(0), T(0)) ≈ P3(0, 0, 0)
     @test b(T(1), T(0), T(0)) ≈ P3(0, 0, 2)
+
+    b = Ball(P3(7, 7, 7), T(1.5))
+    ps = b.(1, rand(T, 100), rand(T, 100))
+    all(∈(b), ps)
   end
 
   @testset "Sphere" begin

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -114,6 +114,27 @@
       @test p ≈ t
     end
 
+    b = Ball(P2(10, 10), T(2))
+    ps = sample(b, RegularSampling(4, 3))
+    @test all(∈(b), ps)
+    ts = P2[
+      (11.0, 10.0),
+      (10.0, 11.0),
+      (9.0, 10.0),
+      (10.0, 9.0),
+      (11.5, 10.0),
+      (10.0, 11.5),
+      (8.5, 10.0),
+      (10.0, 8.5),
+      (12.0, 10.0),
+      (10.0, 12.0),
+      (8.0, 10.0),
+      (10.0, 8.0)
+    ]
+    for (p, t) in zip(ps, ts)
+        @test p ≈ t
+    end
+
     b = Ball(P3(0, 0, 0), T(2))
     ps = sample(b, RegularSampling(3, 2, 3))
     ts = P3[
@@ -139,6 +160,10 @@
     for (p, t) in zip(ps, ts)
       @test p ≈ t
     end
+
+    b = Ball(P3(10, 10, 10), T(2))
+    ps = sample(b, RegularSampling(3, 2, 3))
+    @test all(∈(b), ps)
 
     # cylinder surface with parallel planes
     c = CylinderSurface(Plane(P3(0, 0, 0), V3(0, 0, 1)), Plane(P3(0, 0, 1), V3(0, 0, 1)), T(1))


### PR DESCRIPTION
Fix #426.

However further discussion is required to tidy up our regular sampling implementation.

@juliohm, as you can see the issue can be easily fixed by defining an adequate scaling for points. However, we do not use the `Ball` interface and only rely on sampling over a `Sphere`. Is this adequate, or would it be better to have the implementation for `Ball` independent of `Sphere`?