### PR TITLE
HomogeneousSampling for Box

### DIFF
--- a/src/sampling/homogeneous.jl
+++ b/src/sampling/homogeneous.jl
@@ -59,3 +59,7 @@ end
 function sample(rng::AbstractRNG, segment::Segment{Dim,T}, method::HomogeneousSampling) where {Dim,T}
   (segment(t) for t in rand(rng, T, method.size))
 end
+
+function sample(rng::AbstractRNG, box::Box{Dim,T}, method::HomogeneousSampling) where {Dim,T}
+  (box(rand(rng, T, Dim)...) for _ in 1:(method.size))
+end


### PR DESCRIPTION
The current behaviour discretizes the Box and sample inside each element. Now, it simply uses the `Box` interface.

This help with the implementation of `PointPatterns.jl`, so we do not need to define a specific sampling for `Box`.