### PR TITLE
empty collections

### DIFF
--- a/src/collections.jl
+++ b/src/collections.jl
@@ -8,7 +8,7 @@
 A collection of `items` (points or geometries) seen as a single domain.
 """
 struct Collection{Dim,T,I<:PointOrGeometry{Dim,T}} <: Domain{Dim,T}
-  items::Vector{I}
+    items::Union{Nothing,Vector{I}}
 end
 
 # constructor with iterator of items
@@ -20,7 +20,7 @@ Collection(items) = Collection(collect(items))
 
 element(c::Collection, ind::Int) = c.items[ind]
 
-nelements(c::Collection) = length(c.items)
+nelements(c::Collection) = isnothing(c.items) ? 0 : length(c.items)
 
 # ------------------------
 # SPECIAL CASE: POINT SET

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -12,6 +12,12 @@
     @test nelements(pset) == 100
     @test eltype(pset) <: P2
 
+    pset = PointSet{2,T}(nothing)
+    @test embeddim(pset) == 2
+    @test coordtype(pset) == T
+    @test nelements(pset) == 0
+    @test eltype(pset) <: P2
+
     pset = PointSet(rand(P3, 100))
     @test embeddim(pset) == 3
     @test coordtype(pset) == T
@@ -60,6 +66,12 @@
   end
 
   @testset "GeometrySet" begin
+    gset = GeometrySet{2,T,Geometry{2,T}}(nothing)
+    @test embeddim(gset) == 2
+    @test coordtype(gset) == T
+    @test nelements(gset) == 0
+    @test eltype(gset) <: P2
+
     s = Segment(P2(0, 0), P2(1, 1))
     t = Triangle(P2(0, 0), P2(1, 0), P2(0, 1))
     p = PolyArea(P2[(0, 0), (1, 0), (1, 1), (0, 1)])

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -70,7 +70,7 @@
     @test embeddim(gset) == 2
     @test coordtype(gset) == T
     @test nelements(gset) == 0
-    @test eltype(gset) <: P2
+    @test eltype(gset) <: Geometry{2, T}
 
     s = Segment(P2(0, 0), P2(1, 1))
     t = Triangle(P2(0, 0), P2(1, 0), P2(0, 1))


### PR DESCRIPTION
Allow empty collections to be able to define an empty pointset as possible output for samping in `PointPattern.jl` as mention in JuliaEarth/PointPatterns.jl/pull/32.