### PR TITLE
introduce _sampleweights for developers use

### DIFF
--- a/src/sampling/homogeneous.jl
+++ b/src/sampling/homogeneous.jl
@@ -3,10 +3,11 @@
 # ------------------------------------------------------------------
 
 """
-    HomogeneousSampling(size)
+    HomogeneousSampling(size, [weights])
 
 Generate sample of given `size` from geometric object
-according to a homogeneous density.
+according to a homogeneous density. Optionally, provide `weights`
+to specify custom sampling weights for the elements of a domain.
 """
 struct HomogeneousSampling{W} <: ContinuousSamplingMethod
   size::Int

--- a/src/sampling/homogeneous.jl
+++ b/src/sampling/homogeneous.jl
@@ -8,9 +8,9 @@
 Generate sample of given `size` from geometric object
 according to a homogeneous density.
 """
-struct HomogeneousSampling <: ContinuousSamplingMethod
+struct HomogeneousSampling{W} <: ContinuousSamplingMethod
   size::Int
-  weights::Union{AbstractVector, Nothing}
+  weights::W
 end
 
 HomogeneousSampling(size::Int) = HomogeneousSampling(size, nothing)

--- a/src/sampling/homogeneous.jl
+++ b/src/sampling/homogeneous.jl
@@ -12,11 +12,13 @@ struct HomogeneousSampling <: ContinuousSamplingMethod
   size::Int
 end
 
-function sample(rng::AbstractRNG, Ω::DomainOrData, method::HomogeneousSampling)
-  size = method.size
-  weights = measure.(Ω)
+sample(rng::AbstractRNG, Ω::DomainOrData, method::HomogeneousSampling) =
+  _sampleweights(rng, Ω, method::HomogeneousSampling, measure.(Ω))
 
-  # sample elements with weights proportial to measure
+function _sampleweights(rng::AbstractRNG, Ω::DomainOrData, method::HomogeneousSampling, weights::AbstractVector)
+  size = method.size
+
+  # sample elements with weights
   w = WeightedSampling(size, weights, replace=true)
 
   # within each element sample a single point

--- a/src/sampling/homogeneous.jl
+++ b/src/sampling/homogeneous.jl
@@ -10,13 +10,14 @@ according to a homogeneous density.
 """
 struct HomogeneousSampling <: ContinuousSamplingMethod
   size::Int
+  weights::Union{AbstractVector, Nothing}
 end
 
-sample(rng::AbstractRNG, Ω::DomainOrData, method::HomogeneousSampling) =
-  _sampleweights(rng, Ω, method::HomogeneousSampling, measure.(Ω))
+HomogeneousSampling(size::Int) = HomogeneousSampling(size, nothing)
 
-function _sampleweights(rng::AbstractRNG, Ω::DomainOrData, method::HomogeneousSampling, weights::AbstractVector)
+function sample(rng::AbstractRNG, Ω::DomainOrData, method::HomogeneousSampling)
   size = method.size
+  weights = isnothing(method.weights) ? measure.(Ω) : method.weights
 
   # sample elements with weights
   w = WeightedSampling(size, weights, replace=true)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -301,6 +301,9 @@
     ps = sample(mesh, HomogeneousSampling(400))
     @test first(ps) isa P2
     @test all(∈(mesh), ps)
+    ps = sample(mesh, HomogeneousSampling(400, 1:nelements(mesh))))
+    @test first(ps) isa P2
+    @test all(∈(mesh), ps)
   end
 
   @testset "MinDistanceSampling" begin

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -301,7 +301,7 @@
     ps = sample(mesh, HomogeneousSampling(400))
     @test first(ps) isa P2
     @test all(∈(mesh), ps)
-    ps = sample(mesh, HomogeneousSampling(400, 1:nelements(mesh))))
+    ps = sample(mesh, HomogeneousSampling(400, 1:nelements(mesh)))
     @test first(ps) isa P2
     @test all(∈(mesh), ps)
   end


### PR DESCRIPTION
Define `_sampleweights` to allow define custom `weights` as needed in `PointPatterns.jl`.