### PR TITLE
fix typos

### DIFF
--- a/docs/src/assets/dark.scss
+++ b/docs/src/assets/dark.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-// The customizable varibles can be found here:
+// The customizable variables can be found here:
 // https://github.com/JuliaDocs/Documenter.jl/tree/master/assets/html/scss
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/
@@ -7,7 +7,7 @@
 
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
-// Thse define the template:
+// These define the template:
 $maincolor: rgb(78, 134, 151);   // main color of the org theme
 $secondcolor: rgb(197, 96, 255); // secondary color that serves as accents
                        // it is used as-is for links in light theme
@@ -136,7 +136,7 @@ html.theme--#{$themename} {
       background-color: darken-color($documenter-sidebar-background, 1);
       border-color: darken-color($documenter-sidebar-background, 2);
       margin-top: 1.0rem;
-      margin-bottom: 1.0rem; // adjust the margings between search and other elements
+      margin-bottom: 1.0rem; // adjust the margins between search and other elements
       &::placeholder {
         color: $mainwhite; // placeholder text color ("Search here...")
       }

--- a/docs/src/assets/light.scss
+++ b/docs/src/assets/light.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-// The customizable varibles can be found here:
+// The customizable variables can be found here:
 // https://github.com/JuliaDocs/Documenter.jl/tree/master/assets/html/scss
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/
@@ -105,7 +105,7 @@ $input-focus-border-color: $mainwhite;
     background-color: darken-color($documenter-sidebar-background, 1);
     border-color: darken-color($documenter-sidebar-background, 2);
     margin-top: 1.0rem;
-    margin-bottom: 1.0rem; // adjust the margings between search and other elements
+    margin-bottom: 1.0rem; // adjust the margins between search and other elements
     &::placeholder {
       color: $mainwhite; // placeholder text color ("Search here...")
     }

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -348,7 +348,7 @@ export
   radius,
   isisotropic,
 
-  # neighbordhood search
+  # neighborhood search
   NeighborSearchMethod,
   BoundedNeighborSearchMethod,
   BallSearch,

--- a/src/intersections/lines.jl
+++ b/src/intersections/lines.jl
@@ -40,7 +40,7 @@ and the rank `rₐ` of the augmented matrix `[A y⃗]` are
 calculated in order to identify the intersection type:
 
 - Intersection: r == rₐ == 2
-- Collinear: r == rₐ == 1
+- Colinear: r == rₐ == 1
 - No intersection: r != rₐ
   - No intersection and parallel:  r == 1, rₐ == 2
   - No intersection, skew lines: r == 2, rₐ == 3

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -79,7 +79,7 @@ The measure (or "mass") matrix of the `mesh`, i.e. a diagonal
 matrix with entries `Mᵢᵢ = 2Aᵢ` where `Aᵢ` is (one-third of) the
 sum of the areas of triangles sharing vertex `i`.
 
-The discrete cotagent Laplace-Beltrami operator can be written
+The discrete cotangent Laplace-Beltrami operator can be written
 as `Δ = M⁻¹L`. When solving systems of the form `Δu = f`, it
 is useful to write `Lu = Mf` and exploit the symmetry of `L`.
 """

--- a/src/neighborhoods/metricball.jl
+++ b/src/neighborhoods/metricball.jl
@@ -28,7 +28,7 @@ N-dimensional Euclidean ball with radius `1.0`:
 julia> euclidean = MetricBall(1.0)
 ```
 
-Axis-aligned 3D ellispoid with radii `(3.0, 2.0, 1.0)`:
+Axis-aligned 3D ellipsoid with radii `(3.0, 2.0, 1.0)`:
 
 ```julia
 julia> mahalanobis = MetricBall((3.0, 2.0, 1.0))

--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -6,7 +6,7 @@
     Polytope{K,Dim,T}
 
 We say that a geometry is a K-polytope when it is a collection of "flat" sides
-that constitue a `K`-dimensional subspace. They are called chain, polygon and
+that constitute a `K`-dimensional subspace. They are called chain, polygon and
 polyhedron respectively for 1D (`K=1`), 2D (`K=2`) and 3D (`K=3`) subspaces,
 embedded in a `Dim`-dimensional space. The parameter `K` is also known as the
 rank or parametric dimension of the polytope: https://en.wikipedia.org/wiki/Abstract_polytope.

--- a/src/sampling/mindistance.jl
+++ b/src/sampling/mindistance.jl
@@ -34,7 +34,7 @@ end
 MinDistanceSampling(α::T; ρ=T(0.65), δ=100, metric=Euclidean()) where {T} = MinDistanceSampling(α, ρ, δ, metric)
 
 function sample(rng::AbstractRNG, Ω::DomainOrData, method::MinDistanceSampling)
-  # retrive parameters
+  # retrieve parameters
   α = method.α
   ρ = method.ρ
   δ = method.δ

--- a/src/simplification/douglaspeucker.jl
+++ b/src/simplification/douglaspeucker.jl
@@ -6,7 +6,7 @@
     DouglasPeucker([ϵ]; min=3, max=typemax(Int), maxiter=10)
 
 Simplify geometries with Douglas-Peucker algorithm. The higher
-is the tolerance `ϵ`, the more agressive is the simplification.
+is the tolerance `ϵ`, the more aggressive is the simplification.
 
 If the tolerance `ϵ` is not provided, perform binary search until
 the number of vertices is between `min` and `max` or until the

--- a/src/simplification/selinger.jl
+++ b/src/simplification/selinger.jl
@@ -5,7 +5,7 @@
 """
     Selinger()
 
-Simplify geometries with Selinger algorithm, which attemps to
+Simplify geometries with Selinger algorithm, which attempts to
 minimize the number of vertices and the deviation of vertices
 to the resulting segments.
 

--- a/src/topologies/halfedge.jl
+++ b/src/topologies/halfedge.jl
@@ -49,7 +49,7 @@ half-edges constructed from a vector of connectivity
 `elements` or from a vector of pairs of `halfedges`.
 
 The option `sort` can be used to sort the elements in
-adjacent-first order in case of incosistent orientation
+adjacent-first order in case of inconsistent orientation
 (i.e. mix of clockwise and counter-clockwise).
 
 ## Examples

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -276,7 +276,7 @@
     @test intersection(s1, s12) |> type == CornerTouchingSegments
     @test s1 ∩ s12 ≈ P3(1.0, 0.0, 0.0)
 
-    # precission test
+    # precision test
     s1 = Segment(P2(2.0, 2.0), P2(3.0, 1.0))
     s2 = Segment(P2(2.12505, 1.87503), P2(50000.0, 30000.0))
     s3 = Segment(P2(2.125005, 1.875003), P2(50000.0, 30000.0))

--- a/test/mesh.jl
+++ b/test/mesh.jl
@@ -68,7 +68,7 @@
           P3[(0, 0, 0), (5, 0, 0), (5, 5, 0), (0, 5, 0), (0, 0, 5), (5, 0, 5), (5, 5, 5), (0, 5, 5)]
     @test all(centroid(grid, i) == centroid(grid[i]) for i in 1:nelements(grid))
 
-    # contructor with offset
+    # constructor with offset
     grid = CartesianGrid((10, 10), T.((1.0, 1.0)), T.((1.0, 1.0)), (2, 2))
     @test embeddim(grid) == 2
     @test coordtype(grid) == T

--- a/test/topologies.jl
+++ b/test/topologies.jl
@@ -469,7 +469,7 @@
     @test n[3] != e[3]
     @test n[4] != e[4]
 
-    # more challenging case with incosistent orientation
+    # more challenging case with inconsistent orientation
     e = connect.([(4, 1, 5), (2, 6, 4), (3, 5, 6), (4, 5, 6)])
     t = HalfEdgeTopology(e)
     n = collect(elements(t))

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -74,7 +74,7 @@
   end
 
   @testset "Repair{7}" begin
-    # mesh with incosistent orientation
+    # mesh with inconsistent orientation
     points = rand(P3, 6)
     connec = connect.([(1, 2, 3), (3, 4, 2), (4, 3, 5), (6, 3, 1)])
     mesh = SimpleMesh(points, connec)


### PR DESCRIPTION
@juliohm

Regrettably, I overlooked in GeoStats `#272` the typo `varibles` in docs/src/assets/*.scss.

Should spelling be standardised using American English?

```
$ grep -nr Collinear Meshes.jl | wc -l
1
$ grep -nr colinear Meshes.jl | wc -l
7
$ ed -s Meshes.jl/src/intersections/lines.jl <<<'27,47p'
"""
    intersectparameters(a, b, c, d)

Compute the parameters `λ₁` and `λ₂` of the lines
`a + λ₁ ⋅ v⃗₁`, with `v⃗₁ = b - a` and
`c + λ₂ ⋅ v⃗₂`, with `v⃗₂ = d - c` spanned by the input
points `a`, `b` resp. `c`, `d` such that to yield line
points with minimal distance or the intersection point
(if lines intersect).

Furthermore, the ranks `r` of the matrix of the linear
system `A ⋅ λ⃗ = y⃗`, with `A = [v⃗₁ -v⃗₂], y⃗ = c - a`
and the rank `rₐ` of the augmented matrix `[A y⃗]` are
calculated in order to identify the intersection type:

- Intersection: r == rₐ == 2
- Collinear: r == rₐ == 1
- No intersection: r != rₐ
  - No intersection and parallel:  r == 1, rₐ == 2
  - No intersection, skew lines: r == 2, rₐ == 3
"""
$ 
```