### PR TITLE
Adjust benchmark test

### DIFF
--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1270,7 +1270,7 @@
     b2 = Box(P2(2, 2), P2(5, 5))
     @test hasintersect(b1, b2)
     @test hasintersect(b2, b1)
-    @test @elapsed(hasintersect(b1, b2)) < 10e-6
+    @test @elapsed(hasintersect(b1, b2)) < 5e-5
     @test @allocated(hasintersect(b1, b2)) < 100
 
     # partial application


### PR DESCRIPTION
Motivation: This particular test was crashing sometimes on some GitHub CI virtual machines.

![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/799aeb14-7ee1-4d38-a7fd-67171bce2680)
