### PR TITLE
Add comment about predicates being approximations

### DIFF
--- a/docs/src/predicates.md
+++ b/docs/src/predicates.md
@@ -14,7 +14,7 @@ This section lists predicates that can be used to check properties of geometric 
 both of themselves and relative to other geometric objects. 
 
 One important note to make is that these predicates are not necessarily exact. For example, rather than checking if
-a point `p` is exactly in a sphere of radius `r` centered at `c`, we check if `norm(p-c) < r` or if `s ≈ r` with an absolute tolerance depending on the point type, so `p` might
+a point `p` is exactly in a sphere of radius `r` centered at `c`, we check if `norm(p-c) < r` or if `norm(p -c) ≈ r` with an absolute tolerance depending on the point type, so `p` might
 be slightly outside the sphere but still considered as being inside. Exact arithmetic is expensive to apply and approximations are typically sufficient; exact predicates are available in [ExactPredicates.jl](https://github.com/lairez/ExactPredicates.jl) if you need them, although not with direct Meshes.jl support.
 
 ## isparametrized

--- a/docs/src/predicates.md
+++ b/docs/src/predicates.md
@@ -10,12 +10,18 @@ using Meshes # hide
 import WGLMakie as Mke # hide
 ```
 
-This section lists predicates that can be used to check properties of geometric objects, 
-both of themselves and relative to other geometric objects. 
+This section lists predicates that can be used to check properties of geometric
+objects, both of themselves and relative to other geometric objects. 
 
-One important note to make is that these predicates are not necessarily exact. For example, rather than checking if
-a point `p` is exactly in a sphere of radius `r` centered at `c`, we check if `norm(p-c) < r` or if `norm(p -c) ≈ r` with an absolute tolerance depending on the point type, so `p` might
-be slightly outside the sphere but still considered as being inside. Exact arithmetic is expensive to apply and approximations are typically sufficient; exact predicates are available in [ExactPredicates.jl](https://github.com/lairez/ExactPredicates.jl) if you need them, although not with direct Meshes.jl support.
+One important note to make is that these predicates are not necessarily exact.
+For example, rather than checking if a point `p` is exactly in a sphere of radius
+`r` centered at `c`, we check if `norm(p-c) ≈ r` with an absolute tolerance depending
+on the point type, so `p` might be slightly outside the sphere but still be considered
+as being inside.
+
+Exact arithmetic is expensive to apply and approximations are typically sufficient;
+exact predicates are available in [ExactPredicates.jl](https://github.com/lairez/ExactPredicates.jl)
+if you need them.
 
 ## isparametrized
 

--- a/docs/src/predicates.md
+++ b/docs/src/predicates.md
@@ -10,6 +10,13 @@ using Meshes # hide
 import WGLMakie as Mke # hide
 ```
 
+This section lists predicates that can be used to check properties of geometric objects, 
+both of themselves and relative to other geometric objects. 
+
+One important note to make is that these predicates are not necessarily exact. For example, rather than checking if
+a point `p` is exactly in a sphere of radius `r` centered at `c`, we check if `norm(p-c) < r` or if `s ≈ r` with an absolute tolerance depending on the point type, so `p` might
+be slightly outside the sphere but still considered as being inside. Exact arithmetic is expensive to apply and approximations are typically sufficient; exact predicates are available in [ExactPredicates.jl](https://github.com/lairez/ExactPredicates.jl) if you need them, although not with direct Meshes.jl support.
+
 ## isparametrized
 
 ```@docs


### PR DESCRIPTION
This PR adds a remark to the start of the predicates section that mentions that the predicates are approximations. I also link to ExactPredicates.jl just so that people know that exact predicates do exist in Julia if they do actually need them.