### PR TITLE
Refactor `io_lines` helper function

### DIFF
--- a/src/domains.jl
+++ b/src/domains.jl
@@ -124,15 +124,7 @@ Base.show(io::IO, domain::Domain) = summary(io, domain)
 function Base.show(io::IO, ::MIME"text/plain", domain::Domain)
   summary(io, domain)
   println(io)
-  N = nelements(domain)
-  I, J = N > 10 ? (5, N - 4) : (N - 1, N)
-  lines = [
-    ["├─ $(domain[i])" for i in 1:I]
-    (N > 10 ? ["⋮"] : String[])
-    ["├─ $(domain[i])" for i in J:(N - 1)]
-    "└─ $(domain[N])"
-  ]
-  join(io, lines, "\n")
+  printelms(io, domain)
 end
 
 # ----------------

--- a/src/ioutils.jl
+++ b/src/ioutils.jl
@@ -11,21 +11,28 @@ function prettyname(T::Type)
   replace(name, r".+\." => "")
 end
 
-# helper function to print a large iterator
+# helper function to print a large indexable collection
 # in multiple lines with a given tabulation
-function io_lines(itr, tab="")
-  vec = collect(itr)
-  N = length(vec)
+function printelms(io::IO, elms, tab="")
+  N = length(elms)
   I, J = N > 10 ? (5, N - 4) : (N - 1, N)
-  lines = [
-    ["$(tab)├─ $(vec[i])" for i in 1:I]
-    (N > 10 ? ["$(tab)⋮"] : [])
-    ["$(tab)├─ $(vec[i])" for i in J:(N - 1)]
-    "$(tab)└─ $(vec[N])"
-  ]
-  join(lines, "\n")
+  for i in 1:I
+    println(io, "$(tab)├─ $(elms[i])")
+  end
+  if N > 10
+    println(io, "$(tab)⋮")
+  end
+  for i in J:(N - 1)
+    println(io, "$(tab)├─ $(elms[i])")
+  end
+  print(io, "$(tab)└─ $(elms[N])")
 end
 
+# helper function to print a large iterable
+# calling the printelms function
+printitr(io::IO, itr, tab="") = printelms(io, collect(itr), tab)
+
+# helper function to print the polygons vertices
 function printverts(io::IO, verts)
   ioctx = IOContext(io, :compact => true)
   if length(verts) > 3
@@ -35,6 +42,7 @@ function printverts(io::IO, verts)
   end
 end
 
+# helper function to print the view indices
 function printinds(io::IO, inds)
   print(io, "[")
   if length(inds) > 8

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -131,9 +131,10 @@ function Base.show(io::IO, ::MIME"text/plain", m::Mesh{Dim,T}) where {Dim,T}
   summary(io, m)
   println(io)
   println(io, "  $nvert vertices")
-  println(io, io_lines(verts, "  "))
+  printelms(io, verts, "  ")
+  println(io)
   println(io, "  $nelms elements")
-  print(io, io_lines(elems, "  "))
+  printitr(io, elems, "  ")
 end
 
 """

--- a/src/multigeoms.jl
+++ b/src/multigeoms.jl
@@ -70,7 +70,7 @@ end
 function Base.show(io::IO, m::Multi)
   print(io, "Multi(")
   geoms = prettyname.(m.geoms)
-  counts = ["$(count(==(g), geoms))×$g" for g in unique(geoms)]
+  counts = ("$(count(==(g), geoms))×$g" for g in unique(geoms))
   join(io, counts, ", ")
   print(io, ")")
 end
@@ -78,5 +78,5 @@ end
 function Base.show(io::IO, ::MIME"text/plain", m::Multi)
   summary(io, m)
   println(io)
-  print(io, io_lines(m.geoms))
+  printelms(io, m.geoms)
 end

--- a/src/partitions.jl
+++ b/src/partitions.jl
@@ -53,18 +53,12 @@ end
 Base.show(io::IO, partition::Partition) = summary(io, partition)
 
 function Base.show(io::IO, ::MIME"text/plain", partition::Partition)
-  subs = partition.subsets
   meta = partition.metadata
   summary(io, partition)
   println(io)
-  N = length(subs)
-  I, J = N > 10 ? (5, N - 4) : (N - 1, N)
-  lines = [
-    ["├─$(partition[i])" for i in 1:I]
-    (N > 10 ? ["⋮"] : [])
-    ["├─$(partition[i])" for i in J:(N - 1)]
-    "└─$(partition[N])"
-  ]
-  print(io, join(lines, "\n"))
-  !isempty(meta) && print(io, "\nmetadata: ", join(keys(meta), ", "))
+  printelms(io, partition)
+  if !isempty(meta)
+    print(io, "\nmetadata: ")
+    join(io, keys(meta), ", ")
+  end
 end

--- a/src/polytopes.jl
+++ b/src/polytopes.jl
@@ -259,5 +259,5 @@ end
 function Base.show(io::IO, ::MIME"text/plain", p::Polytope)
   summary(io, p)
   println(io)
-  print(io, io_lines(vertices(p)))
+  printelms(io, vertices(p))
 end

--- a/src/polytopes/polyarea.jl
+++ b/src/polytopes/polyarea.jl
@@ -100,7 +100,7 @@ function Base.show(io::IO, p::PolyArea)
     printverts(io, vertices(r))
   else
     nverts = nvertices.(rings)
-    print(io, join(["$n-Ring" for n in nverts], ", "))
+    join(io, ("$n-Ring" for n in nverts), ", ")
   end
   print(io, ")")
 end
@@ -108,14 +108,12 @@ end
 function Base.show(io::IO, ::MIME"text/plain", p::PolyArea{Dim,T}) where {Dim,T}
   rings = p.rings
   println(io, "PolyArea{$Dim,$T}")
-  if length(rings) == 1
-    println(io, "  outer")
-    print(io, io_lines(rings[1:1], "  "))
-  else
-    println(io, "  outer")
-    println(io, io_lines(rings[1:1], "  "))
+  println(io, "  outer")
+  print(io, "  └─ $(rings[1])")
+  if length(rings) > 1
+    println(io)
     println(io, "  inner")
-    print(io, io_lines(rings[2:end], "  "))
+    printelms(io, @view(rings[2:end]), "  ")
   end
 end
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -13,16 +13,16 @@ See https://en.wikipedia.org/wiki/Geometric_primitive.
 abstract type Primitive{Dim,T} <: Geometry{Dim,T} end
 
 function Base.show(io::IO, geom::Primitive)
-  ioctx = IOContext(io, :compact => true)
   name = prettyname(geom)
-  print(ioctx, "$name(")
+  print(io, "$name(")
+  ioctx = IOContext(io, :compact => true)
   vals = map(fieldnames(typeof(geom))) do field
     val = getfield(geom, field)
     str = repr(val, context=ioctx)
     "$field: $str"
   end
-  join(ioctx, vals, ", ")
-  print(ioctx, ")")
+  join(io, vals, ", ")
+  print(io, ")")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", geom::Primitive)

--- a/test/partitioning.jl
+++ b/test/partitioning.jl
@@ -8,17 +8,17 @@
   @test sprint(show, p) == "100 Partition"
   @test sprint(show, MIME"text/plain"(), p) == """
   100 Partition
-  ├─1 view(::CartesianGrid{2,$T}, [32])
-  ├─1 view(::CartesianGrid{2,$T}, [97])
-  ├─1 view(::CartesianGrid{2,$T}, [3])
-  ├─1 view(::CartesianGrid{2,$T}, [20])
-  ├─1 view(::CartesianGrid{2,$T}, [73])
+  ├─ 1 view(::CartesianGrid{2,$T}, [32])
+  ├─ 1 view(::CartesianGrid{2,$T}, [97])
+  ├─ 1 view(::CartesianGrid{2,$T}, [3])
+  ├─ 1 view(::CartesianGrid{2,$T}, [20])
+  ├─ 1 view(::CartesianGrid{2,$T}, [73])
   ⋮
-  ├─1 view(::CartesianGrid{2,$T}, [89])
-  ├─1 view(::CartesianGrid{2,$T}, [14])
-  ├─1 view(::CartesianGrid{2,$T}, [82])
-  ├─1 view(::CartesianGrid{2,$T}, [78])
-  └─1 view(::CartesianGrid{2,$T}, [42])"""
+  ├─ 1 view(::CartesianGrid{2,$T}, [89])
+  ├─ 1 view(::CartesianGrid{2,$T}, [14])
+  ├─ 1 view(::CartesianGrid{2,$T}, [82])
+  ├─ 1 view(::CartesianGrid{2,$T}, [78])
+  └─ 1 view(::CartesianGrid{2,$T}, [42])"""
 
   @testset "UniformPartition" begin
     Random.seed!(123)


### PR DESCRIPTION
This PR refactors the `io_lines` function and replaces it with two other functions: `printelms` and `printitr`.
The `printelms` function will print the elements of an indexable collection with a known size. While the `printitr` function will collect the elements of the iterable and make a fallback to the `printelms` function.
This avoids code repetition that was happening in the Meshes.jl source code.
