### PR TITLE
simplify `Vec` and `Point` constructors

### DIFF
--- a/src/primitives/point.jl
+++ b/src/primitives/point.jl
@@ -40,17 +40,15 @@ J = Point3f(1, 2, 3) # explicitly ask for single precision
 """
 struct Point{Dim,T} <: Primitive{Dim,T}
   coords::Vec{Dim,T}
-  Point{Dim,T}(coords::Vec{Dim,T}) where {Dim,T} = new{Dim,T}(coords)
+  Point(coords::Vec{Dim,T}) where {Dim,T} = new{Dim,T}(coords)
 end
 
 # convenience constructors
 Point{Dim,T}(coords...) where {Dim,T} = Point{Dim,T}(coords)
-Point{Dim,T}(coords) where {Dim,T} = Point{Dim,T}(Vec{Dim,T}(coords))
-Point{Dim,T}(coords) where {Dim,T<:Integer} = Point{Dim,Float64}(coords)
+Point{Dim,T}(coords) where {Dim,T} = Point(Vec{Dim,T}(coords))
 
 Point(coords...) = Point(coords)
 Point(coords) = Point(Vec(coords))
-Point(coords::Vec{Dim,T}) where {Dim,T} = Point{Dim,T}(coords)
 
 # coordinate type conversions
 Base.convert(::Type{Point{Dim,T}}, coords) where {Dim,T} = Point{Dim,T}(coords)

--- a/src/primitives/point.jl
+++ b/src/primitives/point.jl
@@ -44,11 +44,8 @@ struct Point{Dim,T} <: Primitive{Dim,T}
 end
 
 # convenience constructors
-Point{Dim,T}(coords...) where {Dim,T} = Point{Dim,T}(coords)
-Point{Dim,T}(coords) where {Dim,T} = Point(Vec{Dim,T}(coords))
-
-Point(coords...) = Point(coords)
-Point(coords) = Point(Vec(coords))
+Point{Dim,T}(coords...) where {Dim,T} = Point(Vec{Dim,T}(coords...))
+Point(coords...) = Point(Vec(coords...))
 
 # coordinate type conversions
 Base.convert(::Type{Point{Dim,T}}, coords) where {Dim,T} = Point{Dim,T}(coords)

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -79,13 +79,6 @@ function StaticArrays.similar_type(::Type{<:Vec}, ::Type{T}, ::Size{S}) where {T
   isone(N) && !(T <: Integer) ? Vec{L,T} : SArray{Tuple{S...},T,N,L}
 end
 
-# utils
-function checkdim(::Type{Vec{Dim,T}}, coords) where {Dim,T}
-  if Dim ≠ length(coords)
-    throw(DimensionMismatch("Invalid dimension."))
-  end
-end
-
 """
     ∠(u, v)
 

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -43,7 +43,7 @@ Vec3f(1, 2, 3) # explicitly ask for single precision
 """
 struct Vec{Dim,T} <: StaticVector{Dim,T}
   coords::NTuple{Dim,T}
-  Vec(coords::NTuple{Dim,T}) where {Dim,T} = new{Dim,float(T)}(NTuple{Dim,float(T)}(coords))
+  Vec(coords::NTuple{Dim,T}) where {Dim,T} = new{Dim,float(T)}(coords)
 end
 
 # convenience constructors

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -56,7 +56,7 @@ function Vec{Dim,T}(coords::Union{Tuple,AbstractVector}) where {Dim,T}
 end
 
 Vec(coords...) = Vec(coords)
-Vec(coords) = Vec(promote(coords...))
+Vec(coords::Tuple) = Vec(promote(coords...))
 
 # StaticVector constructors
 Vec(coords::StaticVector{Dim,T}) where {Dim,T} = Vec{Dim,T}(coords)

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -43,24 +43,18 @@ Vec3f(1, 2, 3) # explicitly ask for single precision
 """
 struct Vec{Dim,T} <: StaticVector{Dim,T}
   coords::NTuple{Dim,T}
-  Vec{Dim,T}(coords::NTuple{Dim,T}) where {Dim,T} = new{Dim,T}(coords)
-  Vec{Dim,T}(coords::NTuple{Dim,T}) where {Dim,T<:Integer} = new{Dim,Float64}(coords)
+  Vec(coords::NTuple{Dim,T}) where {Dim,T} = new{Dim,float(T)}(NTuple{Dim,float(T)}(coords))
 end
 
 # convenience constructors
 Vec{Dim,T}(coords...) where {Dim,T} = Vec{Dim,T}(coords)
-function Vec{Dim,T}(coords::Tuple) where {Dim,T}
-  checkdim(Vec{Dim,T}, coords)
-  Vec{Dim,T}(NTuple{Dim,T}(coords))
-end
-function Vec{Dim,T}(coords::AbstractVector) where {Dim,T}
-  checkdim(Vec{Dim,T}, coords)
-  Vec{Dim,T}(NTuple{Dim,T}(coords))
+function Vec{Dim,T}(coords::Union{Tuple, AbstractVector}) where {Dim,T}
+  checkdim(Vec{Dim,float(T)}, coords)
+  Vec(NTuple{Dim,float(T)}(coords))
 end
 
 Vec(coords...) = Vec(coords)
-Vec(coords::Tuple) = Vec(promote(coords...))
-Vec(coords::NTuple{Dim,T}) where {Dim,T} = Vec{Dim,T}(coords)
+Vec(coords) = Vec(promote(coords...))
 
 # StaticVector constructors
 Vec(coords::StaticVector{Dim,T}) where {Dim,T} = Vec{Dim,T}(coords)

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -48,8 +48,10 @@ end
 
 # convenience constructors
 Vec{Dim,T}(coords...) where {Dim,T} = Vec{Dim,T}(coords)
-function Vec{Dim,T}(coords::Union{Tuple, AbstractVector}) where {Dim,T}
-  checkdim(Vec{Dim,float(T)}, coords)
+function Vec{Dim,T}(coords::Union{Tuple,AbstractVector}) where {Dim,T}
+  if Dim ≠ length(coords)
+    throw(DimensionMismatch("invalid dimension"))
+  end
   Vec(NTuple{Dim,float(T)}(coords))
 end
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -6,6 +6,15 @@
     @test coordtype(Point(1, 1)) == Float64
     @test coordtype(Point(1.0, 1.0)) == Float64
     @test coordtype(Point(1.0f0, 1.0f0)) == Float32
+    point = Point(1u"m",1u"m")
+    @test unit(coordtype(point)) == u"m"
+    @test Unitful.numtype(coordtype(point)) === Float64
+    point = Point(1.0u"m",1.0u"m")
+    @test unit(coordtype(point)) == u"m"
+    @test Unitful.numtype(coordtype(point)) === Float64
+    point = Point(1.0f0u"m",1.0f0u"m")
+    @test unit(coordtype(point)) == u"m"
+    @test Unitful.numtype(coordtype(point)) === Float32
     @test coordtype(Point1(1)) == Float64
     @test coordtype(Point2(1, 1)) == Float64
     @test coordtype(Point3(1, 1, 1)) == Float64

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -6,15 +6,6 @@
     @test coordtype(Point(1, 1)) == Float64
     @test coordtype(Point(1.0, 1.0)) == Float64
     @test coordtype(Point(1.0f0, 1.0f0)) == Float32
-    point = Point(1u"m",1u"m")
-    @test unit(coordtype(point)) == u"m"
-    @test Unitful.numtype(coordtype(point)) === Float64
-    point = Point(1.0u"m",1.0u"m")
-    @test unit(coordtype(point)) == u"m"
-    @test Unitful.numtype(coordtype(point)) === Float64
-    point = Point(1.0f0u"m",1.0f0u"m")
-    @test unit(coordtype(point)) == u"m"
-    @test Unitful.numtype(coordtype(point)) === Float32
     @test coordtype(Point1(1)) == Float64
     @test coordtype(Point2(1, 1)) == Float64
     @test coordtype(Point3(1, 1, 1)) == Float64
@@ -102,6 +93,17 @@
     @test coordtype(Point(1)) == Float64
     @test coordtype(Point(1, 2)) == Float64
     @test coordtype(Point(1, 2, 3)) == Float64
+
+    # Unitful coordinates
+    point = Point(1u"m",1u"m")
+    @test unit(coordtype(point)) == u"m"
+    @test Unitful.numtype(coordtype(point)) === Float64
+    point = Point(1.0u"m",1.0u"m")
+    @test unit(coordtype(point)) == u"m"
+    @test Unitful.numtype(coordtype(point)) === Float64
+    point = Point(1.0f0u"m",1.0f0u"m")
+    @test unit(coordtype(point)) == u"m"
+    @test Unitful.numtype(coordtype(point)) === Float32
 
     # generalized inequality
     @test P2(1, 1) ⪯ P2(1, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using Unitful
 using Rotations
 using Test, Random
 using ReferenceTests, ImageIO
+using Unitful
 
 import TransformsBase as TB
 import CairoMakie as Mke

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,6 @@ using Unitful
 using Rotations
 using Test, Random
 using ReferenceTests, ImageIO
-using Unitful
 
 import TransformsBase as TB
 import CairoMakie as Mke

--- a/test/vectors.jl
+++ b/test/vectors.jl
@@ -3,6 +3,15 @@
   @test eltype(Vec(1, 1)) == Float64
   @test eltype(Vec(1.0, 1.0)) == Float64
   @test eltype(Vec(1.0f0, 1.0f0)) == Float32
+  vector = Vec(1u"m",1u"m")
+  @test unit(eltype(vector)) == u"m"
+  @test Unitful.numtype(eltype(vector)) === Float64
+  vector = Vec(1.0u"m",1.0u"m")
+  @test unit(eltype(vector)) == u"m"
+  @test Unitful.numtype(eltype(vector)) === Float64
+  vector = Vec(1.0f0u"m",1.0f0u"m")
+  @test unit(eltype(vector)) == u"m"
+  @test Unitful.numtype(eltype(vector)) === Float32
   @test eltype(Vec1(1)) == Float64
   @test eltype(Vec2(1, 1)) == Float64
   @test eltype(Vec3(1, 1, 1)) == Float64

--- a/test/vectors.jl
+++ b/test/vectors.jl
@@ -2,16 +2,7 @@
   # vararg constructors
   @test eltype(Vec(1, 1)) == Float64
   @test eltype(Vec(1.0, 1.0)) == Float64
-  @test eltype(Vec(1.0f0, 1.0f0)) == Float32
-  vector = Vec(1u"m",1u"m")
-  @test unit(eltype(vector)) == u"m"
-  @test Unitful.numtype(eltype(vector)) === Float64
-  vector = Vec(1.0u"m",1.0u"m")
-  @test unit(eltype(vector)) == u"m"
-  @test Unitful.numtype(eltype(vector)) === Float64
-  vector = Vec(1.0f0u"m",1.0f0u"m")
-  @test unit(eltype(vector)) == u"m"
-  @test Unitful.numtype(eltype(vector)) === Float32
+  @test eltype(Vec(1.0f0, 1.0f0)) == Float32 
   @test eltype(Vec1(1)) == Float64
   @test eltype(Vec2(1, 1)) == Float64
   @test eltype(Vec3(1, 1, 1)) == Float64
@@ -54,6 +45,17 @@
   @test Tuple(Vec(1)) == (1.0,)
   @test Tuple(Vec(1, 2)) == (1.0, 2.0)
   @test Tuple(Vec(1, 2, 3)) == (1.0, 2.0, 3.0)
+
+  # Unitful coordinates
+  vector = Vec(1u"m",1u"m")
+  @test unit(eltype(vector)) == u"m"
+  @test Unitful.numtype(eltype(vector)) === Float64
+  vector = Vec(1.0u"m",1.0u"m")
+  @test unit(eltype(vector)) == u"m"
+  @test Unitful.numtype(eltype(vector)) === Float64
+  vector = Vec(1.0f0u"m",1.0f0u"m")
+  @test unit(eltype(vector)) == u"m"
+  @test Unitful.numtype(eltype(vector)) === Float32
 
   # throws
   @test_throws DimensionMismatch Vec{2,T}(1)


### PR DESCRIPTION
follow-up of #601 

Type promotion of `Point` is rely on `Vec`, so I remove the floating-point promotion at a `Point` constructor. `Vec` promotes type `T` into `float(T)`. I listed possible scenarios how the promotion will work:

|T| float(T) |
|---|---|
|Integer|Float64|
|Float64|Float64|
|Float32|Float32|
|Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}|Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}|
|Quantity{Float32, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}|Quantity{Float32, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}|
|Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}|Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}|

The table proves that the `Unitful` quantities will be promoted as expected. I have checked with my test code:
```Julia repl
julia> using Meshes

julia> x= 1u"m"
1 m

julia> Point(x,x,x)
Point(1.0 m, 1.0 m, 1.0 m)

julia> y=1f0u"m"
1.0f0 m

julia> Point(x,y,x)
Point(1.0f0 m, 1.0f0 m, 1.0f0 m)
```