### PR TITLE
don't apply translation to Vec, only to Point; fix #622

### DIFF
--- a/src/primitives/frustum.jl
+++ b/src/primitives/frustum.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 """
-  Frustum(bot, top)
+    Frustum(bot, top)
 
 A frustum (truncated cone) with `bot` and `top` disks.
 See https://en.wikipedia.org/wiki/Frustum.

--- a/src/primitives/frustumsurface.jl
+++ b/src/primitives/frustumsurface.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 """
-  FrustumSurface(bot, top)
+    FrustumSurface(bot, top)
 
 A frustum (truncated cone) surface with `bot` and `top` disks.
 See https://en.wikipedia.org/wiki/Frustum.

--- a/src/primitives/plane.jl
+++ b/src/primitives/plane.jl
@@ -47,7 +47,8 @@ normal(p::Plane) = normalize(p.u × p.v)
 
 Base.isapprox(p₁::Plane{T}, p₂::Plane{T}) where {T} =
   isapprox((p₁.v - p₁.u) ⋅ normal(p₂), zero(T), atol=atol(T)) &&
-  isapprox((p₂.v - p₂.u) ⋅ normal(p₁), zero(T), atol=atol(T))
+  isapprox((p₂.v - p₂.u) ⋅ normal(p₁), zero(T), atol=atol(T)) &&
+  isapprox((p₂(0,0) - p₁(0,0)) ⋅ normal(p₁), zero(T), atol=atol(T))
 
 (p::Plane)(u, v) = p.p + u * p.u + v * p.v
 

--- a/src/primitives/plane.jl
+++ b/src/primitives/plane.jl
@@ -47,8 +47,7 @@ normal(p::Plane) = normalize(p.u × p.v)
 
 Base.isapprox(p₁::Plane{T}, p₂::Plane{T}) where {T} =
   isapprox((p₁.v - p₁.u) ⋅ normal(p₂), zero(T), atol=atol(T)) &&
-  isapprox((p₂.v - p₂.u) ⋅ normal(p₁), zero(T), atol=atol(T)) &&
-  isapprox((p₂(0,0) - p₁(0,0)) ⋅ normal(p₁), zero(T), atol=atol(T))
+  isapprox((p₂.v - p₂.u) ⋅ normal(p₁), zero(T), atol=atol(T))
 
 (p::Plane)(u, v) = p.p + u * p.u + v * p.v
 

--- a/src/transforms/translate.jl
+++ b/src/transforms/translate.jl
@@ -20,4 +20,5 @@ isinvertible(::Type{<:Translate}) = true
 
 Base.inv(t::Translate) = Translate(-1 .* t.offsets)
 
-applycoord(t::Translate, v::Vec) = v + Vec(t.offsets)
+applycoord(t::Translate, v::Vec) = v
+applycoord(t::Translate, p::Point) = p + Vec(t.offsets)

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -240,7 +240,7 @@
     f = Translate(T(0), T(0), T(1))
     g = Plane(P3(0, 0, 0), V3(0, 0, 1))
     r, c = TB.apply(f, g)
-    @test r ≈ Plane(P3(0, 0, 0), V3(0, 0, 1))
+    @test r ≈ Plane(P3(0, 0, 1), V3(0, 0, 1))
     @test TB.revert(f, r, c) ≈ g
 
     # ---------
@@ -388,7 +388,7 @@
     f = Stretch(T(1), T(1), T(2))
     g = Cylinder(T(1))
     r, c = TB.apply(f, g)
-    @test r ≈ Cylinder(P3(0, 0, 1), P3(0, 0, 2))
+    @test r ≈ Cylinder(P3(0, 0, 0), P3(0, 0, 2))
     @test TB.revert(f, r, c) ≈ g
 
     # ---------


### PR DESCRIPTION
I'm not sure that this is the right solution for #622, but this is my take on it.
It's based on juliohm's comment:
>Perhaps we should skip the Vec field always, except in a few cases? Our current Point struct holds a Vec but that will change soon. It is the only case where we want to apply the transform to the Vec.

What dou you think?

I'll extend the tests if you agree with this solution.

Edit: the example from the issue looks like this with this PR:

```julia
julia> p1 = Plane((10, 0, 10), (0, 0, 1))
Plane{3,Float64}
├─ p: Point(10.0, 0.0, 10.0)
├─ u: Vec(1.0, -0.0, -0.0)
└─ v: Vec(-0.0, 1.0, -0.0)

julia> ft = Translate(100, 35, 70)
Translate transform
└─ offsets = (100, 35, 70)

julia> ft(p1)
Plane{3,Float64}
├─ p: Point(110.0, 35.0, 80.0)
├─ u: Vec(1.0, -0.0, -0.0)
└─ v: Vec(-0.0, 1.0, -0.0)

julia> d1 = Disk(p1, 15.0)
Disk{3,Float64}
├─ plane: Plane(p: (10.0, 0.0, 10.0), u: (1.0, -0.0, -0.0), v: (-0.0, 1.0, -0.0))
└─ radius: 15.0

julia> ft(d1)
Disk{3,Float64}
├─ plane: Plane(p: (110.0, 35.0, 80.0), u: (1.0, -0.0, -0.0), v: (-0.0, 1.0, -0.0))
└─ radius: 15.0

julia> r1 = Ray((0,0,0), (1,0,0))
Ray{3,Float64}
├─ p: Point(0.0, 0.0, 0.0)
└─ v: Vec(1.0, 0.0, 0.0)

julia> ft(r1)
Ray{3,Float64}
├─ p: Point(100.0, 35.0, 70.0)
└─ v: Vec(1.0, 0.0, 0.0)

julia> t1 = Torus((0.,0.,0.), (1.,0.,0.), (0.,1.,0.), 0.2)
Torus{3,Float64}
├─ center: Point(0.5, 0.5, 0.0)
├─ normal: Vec(0.0, 0.0, 1.0)
├─ major: 0.7071067811865476
└─ minor: 0.2

julia> ft(t1)
Torus{3,Float64}
├─ center: Point(100.5, 35.5, 70.0)
├─ normal: Vec(0.0, 0.0, 1.0)
├─ major: 0.7071067811865476
└─ minor: 0.2
```

Fix #622