### PR TITLE
Simplify convex hull from GrahamScan()

### DIFF
--- a/src/hulls/graham.jl
+++ b/src/hulls/graham.jl
@@ -50,9 +50,8 @@ function hull(points, ::GrahamScan)
   # all points are collinear, return segment
   isnothing(idx) && return Segment(O, q[end])
 
-  idx = max(idx, 2) # is this necessary?
-
   # rotational sweep
+  idx = max(idx, 2)
   r = [O, q[idx - 1], q[idx]]
   for B in q[(idx + 1):end]
     while ∠(r[end - 1], r[end], B) > atol(T) && length(r) ≥ 3

--- a/src/hulls/graham.jl
+++ b/src/hulls/graham.jl
@@ -43,13 +43,28 @@ function hull(points, ::GrahamScan)
   θ = [∠(A, O, B) for B in q]
   q = q[sortperm(θ)]
 
+  # initialise and skip collinear points at beginning 
+  r = [O]
+  idx = 1
+  while idx ≤ length(q) && coordinates(q[idx])[2] == coordinates(O)[2]
+    idx += 1
+  end
+  idx = max(idx, 2)
+  push!(r, q[idx - 1])
+  if idx > length(q)
+    return PolyArea(r)
+  else
+    push!(r, q[idx])
+  end
+
   # rotational sweep
-  r = [O, q[1], q[2]]
-  for B in q[3:end]
+  for B in q[(idx + 1):end]
     while ∠(r[end - 1], r[end], B) > atol(T) && length(r) ≥ 3
       pop!(r)
     end
-    push!(r, B)
+    if !iscollinear(r[end - 1], r[end], B)
+      push!(r, B)
+    end
   end
 
   PolyArea(r)

--- a/src/hulls/graham.jl
+++ b/src/hulls/graham.jl
@@ -45,15 +45,15 @@ function hull(points, ::GrahamScan)
 
   # skip collinear points at beginning 
   y(p) = coordinates(p)[2]
-  idx = findfirst(qᵢ -> y(qᵢ) ≠ y(O), q)
+  i = findfirst(qᵢ -> y(qᵢ) ≠ y(O), q)
   
   # all points are collinear, return segment
-  isnothing(idx) && return Segment(O, q[end])
+  isnothing(i) && return Segment(O, q[end])
 
   # rotational sweep
-  idx = max(idx, 2)
-  r = [O, q[idx - 1], q[idx]]
-  for B in q[(idx + 1):end]
+  i = max(i, 2)
+  r = [O, q[i - 1], q[i]]
+  for B in q[(i + 1):end]
     while ∠(r[end - 1], r[end], B) > atol(T) && length(r) ≥ 3
       pop!(r)
     end

--- a/src/hulls/graham.jl
+++ b/src/hulls/graham.jl
@@ -45,17 +45,14 @@ function hull(points, ::GrahamScan)
 
   # initialise and skip collinear points at beginning 
   r = [O]
-  idx = 1
-  while idx ≤ length(q) && coordinates(q[idx])[2] == coordinates(O)[2]
-    idx += 1
+  oy = coordinates(O)[2]
+  idx = findfirst(qq -> coordinates(qq)[2] ≠ oy, q)
+  if isnothing(idx)
+    push!(r, q[end]) # all points are collinear, so just add in the last point 
+    return PolyArea(r)
   end
   idx = max(idx, 2)
-  push!(r, q[idx - 1])
-  if idx > length(q)
-    return PolyArea(r)
-  else
-    push!(r, q[idx])
-  end
+  push!(r, q[idx - 1], q[idx])
 
   # rotational sweep
   for B in q[(idx + 1):end]

--- a/src/hulls/graham.jl
+++ b/src/hulls/graham.jl
@@ -43,18 +43,17 @@ function hull(points, ::GrahamScan)
   θ = [∠(A, O, B) for B in q]
   q = q[sortperm(θ)]
 
-  # initialise and skip collinear points at beginning 
-  r = [O]
-  oy = coordinates(O)[2]
-  idx = findfirst(qq -> coordinates(qq)[2] ≠ oy, q)
-  if isnothing(idx)
-    push!(r, q[end]) # all points are collinear, so just add in the last point 
-    return PolyArea(r)
-  end
-  idx = max(idx, 2)
-  push!(r, q[idx - 1], q[idx])
+  # skip collinear points at beginning 
+  y(p) = coordinates(p)[2]
+  idx = findfirst(qᵢ -> y(qᵢ) ≠ y(O), q)
+  
+  # all points are collinear, return segment
+  isnothing(idx) && return Segment(O, q[end])
+
+  idx = max(idx, 2) # is this necessary?
 
   # rotational sweep
+  r = [O, q[idx - 1], q[idx]]
   for B in q[(idx + 1):end]
     while ∠(r[end - 1], r[end], B) > atol(T) && length(r) ≥ 3
       pop!(r)

--- a/test/hulls.jl
+++ b/test/hulls.jl
@@ -74,7 +74,7 @@
 
       if method == GrahamScan()
         # simplifying rectangular hull / triangular
-        points = [P2(i - 1, j - 1) for i in 1:11, j in 1:11] |> vec
+        points = [P2(i - 1, j - 1) for i in 1:11 for j in 1:11] 
         chull = hull(points, method)
         @test vertices(chull) == [P2(0, 0), P2(10, 0), P2(10, 10), P2(0, 10)]
         for _ in 1:100 # test presence of interior points doesn't affect the result 
@@ -90,11 +90,11 @@
         # degenerate cases
         points = [P2(0, 0), P2(1, 0), P2(2, 0)]
         chull = hull(points, method)
-        @test vertices(chull) == [P2(0, 0), P2(1, 0), P2(2, 0)] # the degeneracy fix of PolyArea inserts P2(1,0)
+        @test vertices(chull) == (P2(0, 0), P2(2, 0))
 
         points = [P2(0, 0), P2(1, 0), P2(2, 0), P2(10, 0), P2(100, 0)]
         chull = hull(points, method)
-        @test vertices(chull) == [P2(0, 0), P2(50, 0), P2(100, 0)] # the degeneracy fix of PolyArea inserts P2(50,0)
+        @test vertices(chull) == (P2(0, 0), P2(100, 0))
 
         # partially collinear 
         points = [

--- a/test/hulls.jl
+++ b/test/hulls.jl
@@ -72,7 +72,7 @@
       chul = hull(pts, method)
       @test nvertices(chul) < length(pts)
 
-      if method == GrahamScan() # simplification not yet implemented for JarvisMarch()
+      if method == GrahamScan()
         # simplifying rectangular hull / triangular
         points = [P2(i - 1, j - 1) for i in 1:11, j in 1:11] |> vec
         chull = hull(points, method)

--- a/test/hulls.jl
+++ b/test/hulls.jl
@@ -71,6 +71,73 @@
       pts = vertices(poly)
       chul = hull(pts, method)
       @test nvertices(chul) < length(pts)
+
+      if method == GrahamScan() # simplification not yet implemented for JarvisMarch()
+        # simplifying rectangular hull / triangular
+        points = [P2(i - 1, j - 1) for i in 1:11, j in 1:11] |> vec
+        chull = hull(points, method)
+        @test vertices(chull) == [P2(0, 0), P2(10, 0), P2(10, 10), P2(0, 10)]
+        for _ in 1:100 # test presence of interior points doesn't affect the result 
+          push!(points, P2(10 * rand(), 10 * rand()))
+        end
+        chull = hull(points, method)
+        @test vertices(chull) == [P2(0, 0), P2(10, 0), P2(10, 10), P2(0, 10)]
+
+        points = [P2(-1, 0), P2(0, 0), P2(1, 0), P2(0, 2)]
+        chull = hull(points, method)
+        @test vertices(chull) == [P2(-1, 0), P2(1, 0), P2(0, 2)]
+
+        # degenerate cases
+        points = [P2(0, 0), P2(1, 0), P2(2, 0)]
+        chull = hull(points, method)
+        @test vertices(chull) == [P2(0, 0), P2(1, 0), P2(2, 0)] # the degeneracy fix of PolyArea inserts P2(1,0)
+
+        points = [P2(0, 0), P2(1, 0), P2(2, 0), P2(10, 0), P2(100, 0)]
+        chull = hull(points, method)
+        @test vertices(chull) == [P2(0, 0), P2(50, 0), P2(100, 0)] # the degeneracy fix of PolyArea inserts P2(50,0)
+
+        # partially collinear 
+        points = [
+          P2(2, 0),
+          P2(4, 0),
+          P2(6, 0),
+          P2(10, 0),
+          P2(12, 1),
+          P2(14, 3),
+          P2(14, 6),
+          P2(14, 9),
+          P2(13, 10),
+          P2(11, 11),
+          P2(8, 12),
+          P2(3, 11),
+          P2(0, 8),
+          P2(0, 7),
+          P2(0, 6),
+          P2(0, 5),
+          P2(0, 4),
+          P2(0, 3),
+          P2(0, 2),
+          P2(1, 0)
+        ]
+        chull = hull(points, method)
+        truth = [
+          P2(0, 2),
+          P2(1, 0),
+          P2(10, 0),
+          P2(12, 1),
+          P2(14, 3),
+          P2(14, 9),
+          P2(13, 10),
+          P2(11, 11),
+          P2(8, 12),
+          P2(3, 11),
+          P2(0, 8)
+        ]
+        @test vertices(chull) == truth
+        push!(points, P2(4, 8), P2(2, 6), P2(6, 2), P2(10, 8), P2(8, 8), P2(10, 6))
+        chull = hull(points, method)
+        @test vertices(chull) == truth
+      end
     end
   end
 


### PR DESCRIPTION
Here is one way that the convex hull can be simplified in the presence of collinear points, at least for `GrahamScan()`. This is to address https://github.com/JuliaGeometry/Meshes.jl/issues/549#issuecomment-1773743092. The basic idea is to keep popping while making a left turn, but only actually push if the turn is a strictly right turn (not a straight jump). It does require some extra handling for the initialisation, though.

I tried doing the same idea for `JarvisMarch()`, but I am not familiar enough with it to do that. (The algorithm I was using in the linked issue was the monotone chain algorithm.)