### PR TITLE
Fix edge case for bridge

### DIFF
--- a/src/transforms/bridge.jl
+++ b/src/transforms/bridge.jl
@@ -68,33 +68,50 @@ function bridge(rings, rinds, δ)
     A = outer[omax]
     B = inner[imax]
 
-    # direction and normal to segment A--B
-    v = B - A
-    u = Vec(-v[2], v[1])
-    n = u / norm(u)
+    # Check for edge case where A and B are equivalent
+    if A == B
+      outer = [
+        outer[begin:(omax - 1)]
+        [A]
+        circshift(inner, -imax + 1)[2:end]
+        [A]
+        outer[(omax + 1):end]
+      ]
+      oinds = [
+        oinds[begin:omax-1]
+        circshift(iinds, -imax + 1)
+        oinds[omax:end]
+      ]
+    else
 
-    # the point A is split into A′ and A′′ and
-    # the point B is split into B′ and B′′ based
-    # on a given bridge width δ
-    A′ = A + (δ / 2) * n
-    A′′ = A - (δ / 2) * n
-    B′ = B + (δ / 2) * n
-    B′′ = B - (δ / 2) * n
+      # direction and normal to segment A--B
+      v = B - A
+      u = Vec(-v[2], v[1])
+      n = u / norm(u)
 
-    # insert hole at closest vertex
-    outer = [
-      outer[begin:(omax - 1)]
-      [A′, B′]
-      circshift(inner, -imax + 1)[2:end]
-      [B′′, A′′]
-      outer[(omax + 1):end]
-    ]
-    oinds = [
-      oinds[begin:omax]
-      circshift(iinds, -imax + 1)
-      [iinds[imax]]
-      oinds[omax:end]
-    ]
+      # the point A is split into A′ and A′′ and
+      # the point B is split into B′ and B′′ based
+      # on a given bridge width δ
+      A′ = A + (δ / 2) * n
+      A′′ = A - (δ / 2) * n
+      B′ = B + (δ / 2) * n
+      B′′ = B - (δ / 2) * n
+
+      # insert hole at closest vertex
+      outer = [
+        outer[begin:(omax - 1)]
+        [A′, B′]
+        circshift(inner, -imax + 1)[2:end]
+        [B′′, A′′]
+        outer[(omax + 1):end]
+      ]
+      oinds = [
+        oinds[begin:omax]
+        circshift(iinds, -imax + 1)
+        [iinds[imax]]
+        oinds[omax:end]
+      ]
+    end
   end
 
   # find duplicate vertices

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -596,6 +596,26 @@
       (0.0, 1.0)
     ]
     @test all(vertices(bpoly) .≈ target)
+
+    # https://github.com/JuliaGeometry/Meshes.jl/issues/629
+    outer = Ring(P2(0., 0.), P2(0., 3.), P2(2., 3.), P2(2., 2.), P2(3., 2.), P2(3., 0.))
+    hole = Ring(Point(1., 1.), Point(1., 2.), Point(2., 2.), Point(2., 1.))
+    poly = PolyArea(outer, hole)
+    bpoly = poly |> Bridge(T(0.01))
+
+    target = P2[
+      (0.,0.),
+      (3.,0.),
+      (3.,2.),
+      (2.,2.),
+      (2.,1.),
+      (1.,1.),
+      (1.,2.),
+      (2.,2.),
+      (2.,3.),
+      (0.,3.),
+    ]
+    @test all(vertices(bpoly) .≈ target)
   end
 
   @testset "Smoothing" begin


### PR DESCRIPTION
Fixes #629

If the nearest points to be bridged are identical, I made the outer ring continue by simply using the point rather than creating two shifted versions.  Technically, it makes the resulting polygon intersect itself at that point.  If we require polygons to not intersect themselves, I can amend it so that one of the vertices is shifted, then it continues with the algorithm offsetting the vertices to make a non-intersecting polygon.