### PR TITLE
Add method for intersects(::Ray, ::Sphere)

### DIFF
--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -37,6 +37,16 @@ intersects(r::Ray, t::Triangle) = !isnothing(r ∩ t)
 
 intersects(t::Triangle, r::Ray) = intersects(r, t)
 
+function intersects(ray::Ray{Dim,T}, sphere::Sphere{Dim,T})::Bool where {Dim,T}
+    sphere_center = center(sphere) - ray(0)
+    r_over_d = radius(sphere) / hypot(sphere_center...)
+    r_over_d > one(T) && return true
+    centered_ray = ray(1) - ray(0)
+    return abs(∠(sphere_center, centered_ray)) < asin(r_over_d)
+end
+
+intersect(sphere::Sphere, ray::Ray) = intersects(ray, sphere)
+
 intersects(p::Point, g::Geometry) = p ∈ g
 
 intersects(g::Geometry, p::Point) = intersects(p, g)

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -37,7 +37,7 @@ intersects(r::Ray, t::Triangle) = !isnothing(r ∩ t)
 
 intersects(t::Triangle, r::Ray) = intersects(r, t)
 
-function intersects(ray::Ray{Dim,T}, sphere::Sphere{Dim,T})::Bool where {Dim,T}
+function intersects(ray::Ray{Dim,T}, sphere::Union{Ball{Dim,T},Sphere{Dim,T}})::Bool where {Dim,T}
     sphere_center = center(sphere) - ray(0)
     r_over_d = radius(sphere) / hypot(sphere_center...)
     r_over_d > one(T) && return true
@@ -45,7 +45,7 @@ function intersects(ray::Ray{Dim,T}, sphere::Sphere{Dim,T})::Bool where {Dim,T}
     return abs(∠(sphere_center, centered_ray)) < asin(r_over_d)
 end
 
-intersect(sphere::Sphere, ray::Ray) = intersects(ray, sphere)
+intersect(sphere::Union{Ball,Sphere}, ray::Ray) = intersects(ray, sphere)
 
 intersects(p::Point, g::Geometry) = p ∈ g
 

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -37,15 +37,19 @@ intersects(r::Ray, t::Triangle) = !isnothing(r ∩ t)
 
 intersects(t::Triangle, r::Ray) = intersects(r, t)
 
-function intersects(ray::Ray{Dim,T}, sphere::Union{Ball{Dim,T},Sphere{Dim,T}})::Bool where {Dim,T}
-    sphere_center = center(sphere) - ray(0)
-    r_over_d = radius(sphere) / hypot(sphere_center...)
-    r_over_d > one(T) && return true
-    centered_ray = ray(1) - ray(0)
-    return abs(∠(sphere_center, centered_ray)) < asin(r_over_d)
+function intersects(r::Ray, s::Sphere)
+    s_ = center(s) - r(0)
+    h = hypot(s_...)
+    radius(s) > h && return true
+    r_ = r(1) - r(0)
+    return abs(∠(s_, r_)) < asin(radius(s) / h)
 end
 
-intersect(sphere::Union{Ball,Sphere}, ray::Ray) = intersects(ray, sphere)
+intersects(s::Sphere, r::Ray) = intersects(r, s)
+
+intersects(r::Ray, b::Ball) = intersects(r, boundary(b))
+
+intersects(b::Ball, r::Ray) = intersects(r, b)
 
 intersects(p::Point, g::Geometry) = p ∈ g
 

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -38,11 +38,11 @@ intersects(r::Ray, t::Triangle) = !isnothing(r ∩ t)
 intersects(t::Triangle, r::Ray) = intersects(r, t)
 
 function intersects(r::Ray, s::Sphere)
-  s₀ = center(s) - r(0)
-  h = hypot(s₀...)
+  u = center(s) - r(0)
+  h = norm(u)
   radius(s) > h && return true
-  r₀ = r(1) - r(0)
-  abs(∠(s₀, r₀)) < asin(radius(s) / h)
+  v = r(1) - r(0)
+  abs(∠(u, v)) < asin(radius(s) / h)
 end
 
 intersects(s::Sphere, r::Ray) = intersects(r, s)

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -42,7 +42,7 @@ function intersects(r::Ray, s::Sphere)
   h = hypot(s₀...)
   radius(s) > h && return true
   r₀ = r(1) - r(0)
-  return abs(∠(s₀, r₀)) < asin(radius(s) / h)
+  abs(∠(s₀, r₀)) < asin(radius(s) / h)
 end
 
 intersects(s::Sphere, r::Ray) = intersects(r, s)

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -38,11 +38,11 @@ intersects(r::Ray, t::Triangle) = !isnothing(r ∩ t)
 intersects(t::Triangle, r::Ray) = intersects(r, t)
 
 function intersects(r::Ray, s::Sphere)
-    s_ = center(s) - r(0)
-    h = hypot(s_...)
-    radius(s) > h && return true
-    r_ = r(1) - r(0)
-    return abs(∠(s_, r_)) < asin(radius(s) / h)
+  s₀ = center(s) - r(0)
+  h = hypot(s₀...)
+  radius(s) > h && return true
+  r₀ = r(1) - r(0)
+  return abs(∠(s₀, r₀)) < asin(radius(s) / h)
 end
 
 intersects(s::Sphere, r::Ray) = intersects(r, s)

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -196,6 +196,21 @@
     @test intersects(r2, t) == false
     @test intersects(t, r2) == false
 
+    s = Sphere(P2(0,3),1)
+    r =  Ray((0,0),(1,0))
+    @test intersects(r,s) == false
+    @test intersects(s,r) == false
+    r =  Ray((0,0),(0,1))
+    @test intersects(r,s) == true
+    @test intersects(s,r) == true
+    s = Sphere(Point3(0,3,0),1)
+    r =  Ray((0,0,0),(1,0,0))
+    @test intersects(r,s) == false
+    @test intersects(s,r) == false
+    r =  Ray((0,0,0),(0,1,0))
+    @test intersects(r,s) == true
+    @test intersects(s,r) == true
+    
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]
     hole2 = P2[(0.6, 0.2), (0.8, 0.2), (0.8, 0.4), (0.6, 0.4)]

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -188,21 +188,23 @@
     @test intersects(r, b)
     @test intersects(b, r)
 
-    t = Triangle(P3(0, 0, 0), P3(2, 0, 0), P3(1, 2, 0))
-    r1 = Ray(P3(1, 1, 1), V3(0, 0, -1))
-    r2 = Ray(P3(1, 1, 1), V3(0, 0, 1))
+    t = Triangle(P3P3(0, 0, 0), P3P3(2, 0, 0), P3P3(1, 2, 0))
+    r1 = Ray(P3P3(1, 1, 1), V3V3(0, 0, -1))
+    r2 = Ray(P3P3(1, 1, 1), V3V3(0, 0, 1))
     @test intersects(r1, t) == true
     @test intersects(t, r1) == true
     @test intersects(r2, t) == false
     @test intersects(t, r2) == false
 
-    r = Ray((0, 0), (1, 0))
-    st = Sphere(P2(3, 0), 1)
-    sf = Sphere(P2(0, 3), 1)
-    for t in Translate.([(0, 0), (10, 0), (0, 10), (-10, 0), (0, -10)]), rot in Rotate.(Angle2d.(0:(π / 4):(7π / 4)))
-      f = t ∘ rot
-      @test intersects(f(r), f(st))
-      @test !intersects(f(r), f(sf))
+    r = Ray(P2(0, 0), V2(1, 0))
+    s1 = Sphere(P2(3, 0), T(1))
+    s2 = Sphere(P2(0, 3), T(1))
+    ts = Translate.([T.((0, 0)), T.((10, 0)), T.((0, 10)), T.((-10, 0)), T.((0, -10))])
+    rs = Rotate.(Angle2d.(T(0):T(π / 4):T(7π / 4)))
+    for t1 in ts, t2 in rs
+      t = t1 ∘ t2
+      @test intersects(t(r), t(s1))
+      @test !intersects(t(r), t(s2))
     end
 
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -130,14 +130,6 @@
   end
 
   @testset "intersects" begin
-    function assertintersecsundertransforms(g1, gt, gf)
-      translations = Iterators.map(Translate, [(0, 0), (10, 0), (0, 10), (-10, 0), (0, -10)])
-      rotations = Iterators.map(Rotate ∘ Rotations.Angle2d, 0:(π / 4):(7π / 4))
-      transforms = (t ∘ r for (t, r) in Iterators.product(translations, rotations))
-      @test all(intersects(t(g1), t(gt)) for t in transforms)
-      @test all(!intersects(t(g1), t(gf)) for t in transforms)
-    end
-
     t = Triangle(P2(0, 0), P2(1, 0), P2(0, 1))
     q = Quadrangle(P2(1, 1), P2(2, 1), P2(2, 2), P2(1, 2))
     @test intersects(t, t)
@@ -207,8 +199,12 @@
     r = Ray((0, 0), (1, 0))
     st = Sphere(P2(3, 0), 1)
     sf = Sphere(P2(0, 3), 1)
-    assertintersecsundertransforms(r, st, sf)
-    
+    for t in Translate.([(0, 0), (10, 0), (0, 10), (-10, 0), (0, -10)]), rot in Rotate.(Angle2d.(0:(π / 4):(7π / 4)))
+      f = t ∘ rot
+      @test intersects(f(r), f(st))
+      @test !intersects(f(r), f(sf))
+    end
+
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]
     hole2 = P2[(0.6, 0.2), (0.8, 0.2), (0.8, 0.4), (0.6, 0.4)]

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -199,13 +199,145 @@
     r = Ray(P2(0, 0), V2(1, 0))
     s1 = Sphere(P2(3, 0), T(1))
     s2 = Sphere(P2(0, 3), T(1))
-    ts = Translate.([T.((0, 0)), T.((10, 0)), T.((0, 10)), T.((-10, 0)), T.((0, -10))])
-    rs = Rotate.(Angle2d.(T(0):T(π / 4):T(7π / 4)))
-    for t1 in ts, t2 in rs
-      t = t1 ∘ t2
-      @test intersects(t(r), t(s1))
-      @test !intersects(t(r), t(s2))
-    end
+    t1 = Translate(T.(0, 0))
+    t2 = Translate(T.(10, 0))
+    t3 = Translate(T.(0, 10))
+    t4 = Translate(T.(-10, 0))
+    t5 = Translate(T.(0, -10))
+    r1 = Rotate(Angle2d(T(0)))
+    r2 = Rotate(Angle2d(T(π / 4)))
+    r3 = Rotate(Angle2d(T(2π / 4)))
+    r4 = Rotate(Angle2d(T(3π / 4)))
+    r5 = Rotate(Angle2d(T(π)))
+    r6 = Rotate(Angle2d(T(5π / 4)))
+    r7 = Rotate(Angle2d(T(6π / 4)))
+    r8 = Rotate(Angle2d(T(7π / 4)))
+
+    t0 = t1
+    t = t0 ∘ r1
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r2
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r3
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r4
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r5
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r6
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r7
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r8
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t0 = t2
+    t = t0 ∘ r1
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r2
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r3
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r4
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r5
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r6
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r7
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r8
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t0 = t3
+    t = t0 ∘ r1
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r2
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r3
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r4
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r5
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r6
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r7
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r8
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t0 = t4
+    t = t0 ∘ r1
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r2
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r3
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r4
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r5
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r6
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r7
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r8
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t0 = t5
+    t = t0 ∘ r1
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r2
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r3
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r4
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r5
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r6
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r7
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
+    t = t0 ∘ r8
+    @test intersects(t(r), t(s1))
+    @test !intersects(t(r), t(s2))
 
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -199,11 +199,11 @@
     r = Ray(P2(0, 0), V2(1, 0))
     s1 = Sphere(P2(3, 0), T(1))
     s2 = Sphere(P2(0, 3), T(1))
-    t1 = Translate(T.(0, 0))
-    t2 = Translate(T.(10, 0))
-    t3 = Translate(T.(0, 10))
-    t4 = Translate(T.(-10, 0))
-    t5 = Translate(T.(0, -10))
+    t1 = Translate(T(0), T(0))
+    t2 = Translate(T(10), T(0))
+    t3 = Translate(T(0), T(10))
+    t4 = Translate(T(-10), T(0))
+    t5 = Translate(T(0), T(-10))
     r1 = Rotate(Angle2d(T(0)))
     r2 = Rotate(Angle2d(T(π / 4)))
     r3 = Rotate(Angle2d(T(2π / 4)))
@@ -338,6 +338,16 @@
     t = t0 ∘ r8
     @test intersects(t(r), t(s1))
     @test !intersects(t(r), t(s2))
+
+    r = Ray(P2(0, 0), V2(1, 0))
+    s = Sphere(P2(floatmax(Float32) / 2, 0), 1)
+    @test intersects(r, s)
+
+    r = Ray(P3(0, 0, 0), V3(1, 0, 0))
+    s1 = Sphere(P3(5, 0, 1 - eps(T(1))), T(1))
+    s2 = Sphere(P3(5, 0, 1 + eps(T(1))), T(1))
+    @test intersects(r, s1)
+    @test !intersects(r, s2)
 
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -130,6 +130,14 @@
   end
 
   @testset "intersects" begin
+    function assertintersecsundertransforms(g1, gt, gf)
+      translations = Iterators.map(Translate, [(0, 0), (10, 0), (0, 10), (-10, 0), (0, -10)])
+      rotations = Iterators.map(Rotate ∘ Rotations.Angle2d, 0:(π / 4):(7π / 4))
+      transforms = (t ∘ r for (t, r) in Iterators.product(translations, rotations))
+      @test all(intersects(t(g1), t(gt)) for t in transforms)
+      @test all(!intersects(t(g1), t(gf)) for t in transforms)
+    end
+
     t = Triangle(P2(0, 0), P2(1, 0), P2(0, 1))
     q = Quadrangle(P2(1, 1), P2(2, 1), P2(2, 2), P2(1, 2))
     @test intersects(t, t)
@@ -196,20 +204,10 @@
     @test intersects(r2, t) == false
     @test intersects(t, r2) == false
 
-    s = Sphere(P2(0,3),1)
-    r =  Ray((0,0),(1,0))
-    @test intersects(r,s) == false
-    @test intersects(s,r) == false
-    r =  Ray((0,0),(0,1))
-    @test intersects(r,s) == true
-    @test intersects(s,r) == true
-    s = Sphere(Point3(0,3,0),1)
-    r =  Ray((0,0,0),(1,0,0))
-    @test intersects(r,s) == false
-    @test intersects(s,r) == false
-    r =  Ray((0,0,0),(0,1,0))
-    @test intersects(r,s) == true
-    @test intersects(s,r) == true
+    r = Ray((0, 0), (1, 0))
+    st = Sphere(P2(3, 0), 1)
+    sf = Sphere(P2(0, 3), 1)
+    assertintersecsundertransforms(r, st, sf)
     
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]


### PR DESCRIPTION
Add a method for `intersects(::Ray, ::Sphere)`
Implemented via checking if the angle from sphere center, to ray base, to the ray tip is less than the angle from the sphere center, to ray base, to a point tangent to the sphere. If the former is less than the later, they intersect. 

![image](https://github.com/JuliaGeometry/Meshes.jl/assets/9949357/b384b190-a3d3-4cf5-aacf-bddfb5076102)
