### PR TITLE
Specializing `boundingbox` for `Ray` primitives

### DIFF
--- a/src/boundingboxes.jl
+++ b/src/boundingboxes.jl
@@ -34,8 +34,8 @@ function boundingbox(r::Ray{Dim,T}) where {Dim,T}
   upper(p, v) = v > 0 ? typemax(T) : p
   p = r(0)
   v = r(1) - r(0)
-  l = lower.(coordinates(p), coordinates(v))
-  u = upper.(coordinates(p), coordinates(v))
+  l = lower.(coordinates(p), v)
+  u = upper.(coordinates(p), v)
   Box(Point(l), Point(u))
 end
 

--- a/src/boundingboxes.jl
+++ b/src/boundingboxes.jl
@@ -29,6 +29,12 @@ boundingbox(p::Point) = Box(p, p)
 
 boundingbox(b::Box) = b
 
+function boundingbox(r::Ray{Dim,T}) where {Dim,T}
+  lowerbound(x, direction) = direction < 0 ? typemin(T) : x
+  upperbound(x, direction) = direction > 0 ? typemax(T) : x
+  Box(Point(lowerbound.(r.p.coords, r.v)), Point(upperbound.(r.p.coords, r.v)))
+end
+
 function boundingbox(s::Sphere{Dim,T}) where {Dim,T}
   c = center(s)
   r = radius(s)

--- a/src/boundingboxes.jl
+++ b/src/boundingboxes.jl
@@ -30,9 +30,13 @@ boundingbox(p::Point) = Box(p, p)
 boundingbox(b::Box) = b
 
 function boundingbox(r::Ray{Dim,T}) where {Dim,T}
-  lowerbound(x, direction) = direction < 0 ? typemin(T) : x
-  upperbound(x, direction) = direction > 0 ? typemax(T) : x
-  Box(Point(lowerbound.(r.p.coords, r.v)), Point(upperbound.(r.p.coords, r.v)))
+  lower(p, v) = v < 0 ? typemin(T) : p
+  upper(p, v) = v > 0 ? typemax(T) : p
+  p = r(0)
+  v = r(1) - r(0)
+  l = lower.(coordinates(p), coordinates(v))
+  u = upper.(coordinates(p), coordinates(v))
+  Box(Point(l), Point(u))
 end
 
 function boundingbox(s::Sphere{Dim,T}) where {Dim,T}

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -7,6 +7,19 @@
   @test boundingbox(b) == b
   @test @allocated(boundingbox(b)) < 50
 
+  r = Ray(P2(0, 0), V2(1, 0))
+  @test boundingbox(r) == Box(P2(0, 0), P2(T(Inf), 0))
+  @test @allocated(boundingbox(r)) < 50
+  r = Ray(P2(1, 1), V2(0, 1))
+  @test boundingbox(r) == Box(P2(1, 1), P2(1, T(Inf)))
+  @test @allocated(boundingbox(r)) < 50
+  r = Ray(P2(1, 1), V2(-1, -1))
+  @test boundingbox(r) == Box(P2(T(-Inf), T(-Inf)), P2(1, 1))
+  @test @allocated(boundingbox(r)) < 50
+  r = Ray(P2(-1, 1), V2(1, -1))
+  @test boundingbox(r) == Box(P2(-1, T(-Inf)), P2(T(Inf), 1))
+  @test @allocated(boundingbox(r)) < 50
+
   s = Sphere(P2(0, 0), T(1))
   @test boundingbox(s) == Box(P2(-1, -1), P2(1, 1))
   @test @allocated(boundingbox(s)) < 50


### PR DESCRIPTION
Add method `boundingbox(::Ray)` that returns a box that contains the origin of the ray and is unbounded at the direction of the ray to contain all of its points. Since a ray could be seen as a primitive with an "infinite" size, its bounding box should be big enough to contains all of its points. Example:

```julia
julia> ray = Ray(Point(0.41169768366272996, 0.8990554132423699), Vec(0.47249211625247445, 0.2523149692768657))
Ray{2,Float64}
├─ p: Point(0.41169768366272996, 0.8990554132423699)
└─ v: Vec(0.47249211625247445, 0.2523149692768657)

julia> boundingbox(ray)
Box{2,Float64}
├─ min: Point(0.41169768366272996, 0.8990554132423699)
└─ max: Point(Inf, Inf)
```