### PR TITLE
Fixes #635: search using 3D simplex

### DIFF
--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -155,7 +155,7 @@ function gjk!(O::Point{3,T}, points) where T
     B, A = points
     AB = B - A
     AO = O - A
-    d = AB × AO × AB
+    d = perpendicular(AB, AO)
   elseif length(points) == 3
     # triangle case
     C, B, A = points
@@ -258,4 +258,4 @@ function perpendicular(v::Vec{2,T}, d::Vec{2,T}) where T
   Vec(r[1], r[2])
 end
 
-perpendicular(v::Vec{3}, d::Vec{3}) = a × b × a
+perpendicular(v::Vec{3}, d::Vec{3}) = v × d × v

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -164,7 +164,7 @@ function gjk!(O::Point{3,T}, points) where T
     AC = C - A
     AO = O - A
     ABCᵀ = AB × AC
-    if ABCᵀ ⋅ AO > 0
+    if ABCᵀ ⋅ AO < 0
       points[1], points[2] = points[2], points[1]
       ABCᵀ = -ABCᵀ
     end

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -107,12 +107,12 @@ function intersects(g₁::Geometry{Dim,T}, g₂::Geometry{Dim,T}) where {Dim,T}
 end
 
 """
-    gjk!(origin::Point{Dim,T}, points) where {Dim,T}
+    gjk!(O::Point{Dim,T}, points) where {Dim,T}
 
 Perform one iteration of the GJK algorithm.
 
 It returns `nothing` if the `Dim`-simplex represented by `points`
-contains the origin point. Otherwise, it returns a vector with
+contains the origin point `O`. Otherwise, it returns a vector with
 the direction for searching the next point.
 
 If the simplex is complete, it removes one point from the set to
@@ -122,19 +122,19 @@ See also [`intersects`](@ref).
 """
 function gjk! end
 
-function gjk!(origin::Point{2,T}, points) where T
+function gjk!(O::Point{2,T}, points) where T
   # line segment case
   if length(points) == 2
     B, A = points
     AB = B - A
-    AO = origin - A
+    AO = O - A
     d = perpendicular(AB, AO)
   else
     # triangle simplex case
     C, B, A = points
     AB = B - A
     AC = C - A
-    AO = origin - A
+    AO = O - A
     ABᵀ = -perpendicular(AB, AC)
     ACᵀ = -perpendicular(AC, AB)
     if ABᵀ ⋅ AO > zero(T)
@@ -150,19 +150,19 @@ function gjk!(origin::Point{2,T}, points) where T
   d
 end
 
-function gjk!(origin::Point{3,T}, points) where T
+function gjk!(O::Point{3,T}, points) where T
   # line segment case
   if length(points) == 2
     B, A = points
     AB = B - A
-    AO = origin - A
+    AO = O - A
     d = AB × AO × AB
   elseif length(points) == 3
     # triangle case
     C, B, A = points
     AB = B - A
     AC = C - A
-    AO = origin - A
+    AO = O - A
     ABCᵀ = AB × AC
     if ABCᵀ ⋅ AO > 0
       points[1], points[2] = points[2], points[1]
@@ -185,7 +185,7 @@ function gjk!(origin::Point{3,T}, points) where T
     AB = B - A
     AC = C - A
     AD = D - A
-    AO = origin - A
+    AO = O - A
     ABCᵀ = AB × AC
     ADBᵀ = AD × AB
     ACDᵀ = AC × AD
@@ -245,9 +245,9 @@ intersects(m::Multi, c::Chain) = intersects(c, m)
 
 # support point in Minkowski difference
 function minkowskipoint(g₁::Geometry{Dim,T}, g₂::Geometry{Dim,T}, d) where {Dim,T}
-  n = Vec{Dim,T}(d[1:Dim])
+  n = Vec{Dim,T}(d)
   v = supportfun(g₁, n) - supportfun(g₂, -n)
-  Point(ntuple(i -> i ≤ Dim ? v[i] : zero(T), Dim))
+  Point(v)
 end
 
 # origin of coordinate system
@@ -262,3 +262,5 @@ function perpendicular(v::Vec{2,T}, d::Vec{2,T}) where T
   r = a × b × a
   Vec(r[1], r[2])
 end
+
+perpendicular(v::Vec{3,T}, d::Vec{3,T}) where T = a × b × a

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -258,4 +258,4 @@ function perpendicular(v::Vec{2,T}, d::Vec{2,T}) where T
   Vec(r[1], r[2])
 end
 
-perpendicular(v::Vec{3,T}, d::Vec{3,T}) where T = a × b × a
+perpendicular(v::Vec{3}, d::Vec{3}) = a × b × a

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -93,7 +93,6 @@ function intersects(g₁::Geometry{Dim,T}, g₂::Geometry{Dim,T}) where {Dim,T}
 
   # move towards the origin
   d = O - P
-
   while true
     P = minkowskipoint(g₁, g₂, d)
     if (P - O) ⋅ d < zero(T)

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -243,9 +243,8 @@ intersects(m::Multi, c::Chain) = intersects(c, m)
 # ------------------
 
 # support point in Minkowski difference
-function minkowskipoint(g₁::Geometry{Dim,T}, g₂::Geometry{Dim,T}, d) where {Dim,T}
-  n = Vec{Dim,T}(d)
-  v = supportfun(g₁, n) - supportfun(g₂, -n)
+function minkowskipoint(g₁::Geometry, g₂::Geometry, d)
+  v = supportfun(g₁, d) - supportfun(g₂, -d)
   Point(v)
 end
 

--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -243,10 +243,7 @@ intersects(m::Multi, c::Chain) = intersects(c, m)
 # ------------------
 
 # support point in Minkowski difference
-function minkowskipoint(g₁::Geometry, g₂::Geometry, d)
-  v = supportfun(g₁, d) - supportfun(g₂, -d)
-  Point(v)
-end
+minkowskipoint(g₁::Geometry, g₂::Geometry, d) = Point(supportfun(g₁, d) - supportfun(g₂, -d))
 
 # origin of coordinate system
 minkowskiorigin(Dim, T) = Point(ntuple(i -> zero(T), Dim))

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -235,8 +235,12 @@
     # https://github.com/JuliaGeometry/Meshes.jl/issues/635
     q1 = Quadrangle(P3(4.0, 4.0, 0.0), P3(3.0, 3.0, 2.0), P3(3.0, 1.0, 2.0), P3(4.0, 0.0, 0.0))
     q2 = Quadrangle(P3(3.6, 3.0, 1.0), P3(5.6, 3.0, 1.0), P3(5.6, 1.0, 1.0), P3(3.6, 1.0, 1.0))
-    @test intersects(q1, q2) == false
-    @test intersects(q1, q1) == true
+    q3 = Quadrangle(P3(3.6, 1.0, 1.0), P3(5.6, 1.0, 1.0), P3(5.6, -1.0, 1.0), P3(3.6, -1.0, 1.0))
+    q4 = Quadrangle(P3(2.1, 1.0, 1.0), P3(4.1, 1.0, 1.0), P3(4.1, -1.0, 1.0), P3(2.1, -1.0, 1.0))
+    @test !intersects(q1, q2)
+    @test !intersects(q1, q3)
+    @test intersects(q1, q1)
+    @test intersects(q1, q4)
 
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -241,6 +241,12 @@
     @test !intersects(q1, q3)
     @test intersects(q1, q1)
     @test intersects(q1, q4)
+  
+    h1 = Tetrahedron(P3(1, 1, 0), P3(4, 4, 0), P3(2.5, 2.5, 1.5), P3(1, 3, 2))
+    h2 = Tetrahedron(P3(-1.0, 2.0, 1.0), P3(2.0, 1.0, 1.0), P3(-1.0, 4.0, 0.0), P3(0.5, 2.5, 1.5))
+    h3 = Tetrahedron(P3(-1.3, 2.0, 1.0), P3(1.7, 1.0, 1.0), P3(-1.3, 4.0, 0.0), P3(0.2, 2.5, 1.5))
+    @test intersects(h1,h2)
+    @test !intersects(h1,h3)
 
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -232,6 +232,12 @@
     @test intersects(r, s1)
     @test !intersects(r, s2)
 
+    # https://github.com/JuliaGeometry/Meshes.jl/issues/635
+    q1 = Quadrangle(P3(4.0, 4.0, 0.0), P3(3.0, 3.0, 2.0), P3(3.0, 1.0, 2.0), P3(4.0, 0.0, 0.0))
+    q2 = Quadrangle(P3(3.6, 3.0, 1.0), P3(5.6, 3.0, 1.0), P3(5.6, 1.0, 1.0), P3(3.6, 1.0, 1.0))
+    @test intersects(q1, q2) == false
+    @test intersects(q1, q1) == true
+
     outer = P2[(0, 0), (1, 0), (1, 1), (0, 1)]
     hole1 = P2[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]
     hole2 = P2[(0.6, 0.2), (0.8, 0.2), (0.8, 0.4), (0.6, 0.4)]


### PR DESCRIPTION
Make `intersects` function to search the intersection with a tetrahedron (3D simplex) instead of a triangle (2D simplex)
when the points are in a 3D euclidean space.

If you can, feel free to add more tests to check if the algorithm is correct.

(Sorry for the misspellings in the commit message)

Fix #635 