### PR TITLE
Refactor sideof surface mesh

### DIFF
--- a/src/projecting.jl
+++ b/src/projecting.jl
@@ -22,16 +22,16 @@ proj2D(p::PolyArea) = PolyArea(proj2D.(rings(p)))
 # IMPLEMENTATION
 # ---------------
 
-function proj2D(points::AbstractVector{<:Point{3}})
-  # retrieve coordinates
-  X = reduce(hcat, coordinates.(points))
-  μ = colmean(X)
+proj2D(points::AbstractVector{<:Point{3}}) = proj(points, svdbasis(points))
 
-  # compute SVD basis
-  u, v = svdbasis(X, μ)
+function proj(points, basis)
+  # retrieve basis
+  u, v = basis
+
+  # centroid of projection
+  c = centroid(PointSet(points))
 
   # project points
-  c = Point(μ...)
   map(points) do p
     d = p - c
     Point(d ⋅ u, d ⋅ v)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -47,16 +47,16 @@ function householderbasis(n::Vec{3,T}) where {T}
 end
 
 """
-    svdbasis(X, [μ])
+    svdbasis(points)
 
-Returns the 2D basis that retains most of the variance in the columns of `X`
-with predefined mean `μ`. The matrix `X` is assumed to be 3 by n, i.e. it
-holds 3D coordinates of a list of points.
+Returns the 2D basis that retains most of the variance in the list of 3D `points`
+using the singular value decomposition (SVD).
 
 See https://math.stackexchange.com/a/99317.
 """
-function svdbasis(X::AbstractMatrix{T}, μ=colmean(X)) where {T}
-  @assert size(X, 1) == 3 "svdbasis only defined for 3 by n matrices"
+function svdbasis(p::AbstractVector{Point{3,T}}) where {T}
+  X = reduce(hcat, coordinates.(p))
+  μ = sum(X, dims=2) / size(X, 2)
   Z = X .- μ
   U = svd(Z).U
   u = Vec(U[:, 1]...)
@@ -64,8 +64,6 @@ function svdbasis(X::AbstractMatrix{T}, μ=colmean(X)) where {T}
   n = Vec{3,T}(0, 0, 1)
   (u × v) ⋅ n < 0 ? (v, u) : (u, v)
 end
-
-colmean(X) = sum(X, dims=2) / size(X, 2)
 
 """
     mayberound(λ, x, tol)

--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -1,15 +1,27 @@
 @testset "sideof" begin
+  # -----
+  # LINE
+  # -----
+
   p1, p2, p3 = P2(0, 0), P2(1, 1), P2(0.25, 0.5)
   l = Line(P2(0.5, 0.0), P2(0.0, 1.0))
   @test sideof(p1, l) == LEFT
   @test sideof(p2, l) == RIGHT
   @test sideof(p3, l) == ON
 
+  # -----
+  # RING
+  # -----
+
   p1, p2, p3 = P2(0.5, 0.5), P2(1.5, 0.5), P2(1, 1)
   c = Ring(P2[(0, 0), (1, 0), (1, 1), (0, 1)])
   @test sideof(p1, c) == IN
   @test sideof(p2, c) == OUT
   @test sideof(p3, c) == IN
+
+  # -----
+  # MESH
+  # -----
 
   points = P3[(0, 0, 0), (1, 0, 0), (0, 1, 0), (0.25, 0.25, 1)]
   connec = connect.([(1, 3, 2), (1, 2, 4), (1, 4, 3), (2, 3, 4)], Triangle)
@@ -48,7 +60,7 @@
 
   # sideof only defined for surface meshes
   points = P3[(0, 0, 0), (1, 0, 0), (1, 1, 1), (0, 1, 0)]
-  connec = connect.([(1, 2, 3, 4)], [Tetrahedron])
+  connec = connect.([(1, 2, 3, 4)], Tetrahedron)
   mesh = SimpleMesh(points, connec)
   @test_throws AssertionError("sideof only defined for surface meshes") sideof(P3(0, 0, 0), mesh)
 end


### PR DESCRIPTION
@kylebeggs some of the tests are failing and I would like to simplify the original code that you submitted some time ago for improved performance. Can you please comment on the different branches of the code? Isn't the ray casting algorithm only concerned with how many times we intersect with triangles, no matter the type of intersection?

Can we simplify these branches only account for the cases IN (including the case ON the surface) and OUT?