### PR TITLE
Refactor sideof surface mesh

### DIFF
--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -1,15 +1,27 @@
 @testset "sideof" begin
+  # -----
+  # LINE
+  # -----
+
   p1, p2, p3 = P2(0, 0), P2(1, 1), P2(0.25, 0.5)
   l = Line(P2(0.5, 0.0), P2(0.0, 1.0))
   @test sideof(p1, l) == LEFT
   @test sideof(p2, l) == RIGHT
   @test sideof(p3, l) == ON
 
+  # -----
+  # RING
+  # -----
+
   p1, p2, p3 = P2(0.5, 0.5), P2(1.5, 0.5), P2(1, 1)
   c = Ring(P2[(0, 0), (1, 0), (1, 1), (0, 1)])
   @test sideof(p1, c) == IN
   @test sideof(p2, c) == OUT
   @test sideof(p3, c) == IN
+
+  # -----
+  # MESH
+  # -----
 
   points = P3[(0, 0, 0), (1, 0, 0), (0, 1, 0), (0.25, 0.25, 1)]
   connec = connect.([(1, 3, 2), (1, 2, 4), (1, 4, 3), (2, 3, 4)], Triangle)
@@ -48,7 +60,7 @@
 
   # sideof only defined for surface meshes
   points = P3[(0, 0, 0), (1, 0, 0), (1, 1, 1), (0, 1, 0)]
-  connec = connect.([(1, 2, 3, 4)], [Tetrahedron])
+  connec = connect.([(1, 2, 3, 4)], Tetrahedron)
   mesh = SimpleMesh(points, connec)
   @test_throws AssertionError("sideof only defined for surface meshes") sideof(P3(0, 0, 0), mesh)
 end


### PR DESCRIPTION
@kylebeggs some of the tests are failing and I would like to simplify the original code that you submitted some time ago for improved performance. Can you please comment on the different branches of the code? Isn't the ray casting algorithm only concerned with how many times we intersect with triangles, no matter the type of intersection?

Can we simplify these branches only account for the cases IN (including the case ON the surface) and OUT?