### PR TITLE
Treat `NaN` as `missing` in the `viz` function

### DIFF
--- a/ext/colors.jl
+++ b/ext/colors.jl
@@ -30,7 +30,7 @@ setalpha(colors, ::Nothing) = colors
 # convert user input to colors
 function process(values::V, scheme, alphas)
   # find invalid and valid indices
-  iinds = findall(ismissing, values)
+  iinds = findall(v -> ismissing(v) || (v isa Number && isnan(v)), values)
   vinds = setdiff(1:length(values), iinds)
 
   # invalid values are assigned full transparency

--- a/ext/colors.jl
+++ b/ext/colors.jl
@@ -30,7 +30,8 @@ setalpha(colors, ::Nothing) = colors
 # convert user input to colors
 function process(values::V, scheme, alphas)
   # find invalid and valid indices
-  iinds = findall(v -> ismissing(v) || (v isa Number && isnan(v)), values)
+  isinvalid(v) = ismissing(v) || (v isa Number && isnan(v))
+  iinds = findall(isinvalid, values)
   vinds = setdiff(1:length(values), iinds)
 
   # invalid values are assigned full transparency


### PR DESCRIPTION
Example:
```julia-repl
julia> using Meshes

julia> using Random

julia> import GLMakie as Mke

julia> x = shuffle([fill(NaN, 10); rand(90)]);

julia> grid = CartesianGrid(10, 10)
10×10 CartesianGrid{2,Float64}
  minimum: Point(0.0, 0.0)
  maximum: Point(10.0, 10.0)
  spacing: (1.0, 1.0)

julia> viz(grid, color=x)
```

![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/aba63512-d490-4a8f-a5be-c2fc721c7de6)
