### PR TITLE
Change required methods to implement `Mesh` interface

### DIFF
--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -181,11 +181,6 @@ Base.minimum(g::Grid{Dim}) where {Dim} = vertex(g, ntuple(i -> 1, Dim))
 Base.maximum(g::Grid{Dim}) where {Dim} = vertex(g, size(g) .+ 1)
 Base.extrema(g::Grid{Dim}) where {Dim} = minimum(g), maximum(g)
 
-function vertices(g::Grid)
-  inds = CartesianIndices(size(g) .+ 1)
-  vec([vertex(g, ind) for ind in inds])
-end
-
 function element(g::Grid, ind::Int)
   elem = element(topology(g), ind)
   type = pltype(elem)

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -14,14 +14,14 @@ abstract type Mesh{Dim,T} <: Domain{Dim,T} end
 
 Return the vertex of a `mesh` at index `ind`.
 """
-vertex(m::Mesh, ind) = vertices(m)[ind]
+function vertex end
 
 """
     vertices(mesh)
 
 Return the vertices of the `mesh`.
 """
-function vertices end
+vertices(m::Mesh) = [vertex(m, ind) for ind in 1:nvertices(m)]
 
 """
     nvertices(mesh)
@@ -173,7 +173,9 @@ function XYZ end
 
 Base.size(g::Grid) = size(topology(g))
 
-vertex(grid::Grid{Dim}, ijk::Dims{Dim}) where {Dim} = vertex(grid, LinearIndices(size(grid) .+ 1)[ijk...])
+vertex(g::Grid, ind::Int) = vertex(g, CartesianIndices(size(g) .+ 1)[ind])
+
+vertex(g::Grid{Dim}, ijk::Dims{Dim}) where {Dim} = vertex(g, LinearIndices(size(g) .+ 1)[ijk...])
 
 Base.minimum(g::Grid{Dim}) where {Dim} = vertex(g, ntuple(i -> 1, Dim))
 Base.maximum(g::Grid{Dim}) where {Dim} = vertex(g, size(g) .+ 1)

--- a/src/mesh/simplemesh.jl
+++ b/src/mesh/simplemesh.jl
@@ -43,6 +43,8 @@ function SimpleMesh(vertices, connec::AbstractVector{<:Connectivity}; relations=
   SimpleMesh(vertices, topology)
 end
 
+vertex(m::SimpleMesh, ind::Int) = m.vertices[ind]
+
 vertices(m::SimpleMesh) = m.vertices
 
 nvertices(m::SimpleMesh) = length(m.vertices)


### PR DESCRIPTION
Now, the required method to implement `Mesh` interface is `vertex`, instead of `vertices`.