### PR TITLE
Return a `MultiPoint` instead of a `PointSet` in `boundary` function

### DIFF
--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -18,12 +18,12 @@ boundary(::Line) = nothing
 function boundary(b::BezierCurve)
   p = controls(b)
   p₁, p₂ = first(p), last(p)
-  p₁ ≈ p₂ ? nothing : PointSet([p₁, p₂])
+  p₁ ≈ p₂ ? nothing : Multi([p₁, p₂])
 end
 
 boundary(::Plane) = nothing
 
-boundary(b::Box{1}) = PointSet([minimum(b), maximum(b)])
+boundary(b::Box{1}) = Multi([minimum(b), maximum(b)])
 
 function boundary(b::Box{2})
   A = coordinates(minimum(b))
@@ -79,11 +79,11 @@ boundary(::FrustumSurface) = nothing
 
 boundary(::Torus) = nothing
 
-boundary(s::Segment) = PointSet(pointify(s))
+boundary(s::Segment) = Multi(pointify(s))
 
 function boundary(r::Rope)
   v = vertices(r)
-  PointSet([first(v), last(v)])
+  Multi([first(v), last(v)])
 end
 
 boundary(::Ring) = nothing

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -49,7 +49,7 @@
     @test !(s ≈ Segment(Point(1, 1, 2, 1), Point(0, 0, 0, 0)))
 
     s = Segment(P3(0, 0, 0), P3(1, 1, 1))
-    @test boundary(s) == PointSet([P3(0, 0, 0), P3(1, 1, 1)])
+    @test boundary(s) == Multi([P3(0, 0, 0), P3(1, 1, 1)])
     @test perimeter(s) == zero(T)
     @test center(s) == P3(0.5, 0.5, 0.5)
     @test coordtype(center(s)) == T
@@ -137,7 +137,7 @@
     @test centroid(c) == P2(0.5, 0.5)
 
     c = Rope(P2[(0, 0), (1, 0), (1, 1), (0, 1)])
-    @test boundary(c) == PointSet(P2[(0, 0), (0, 1)])
+    @test boundary(c) == Multi(P2[(0, 0), (0, 1)])
     c = Ring(P2[(0, 0), (1, 0), (1, 1), (0, 1)])
     @test isnothing(boundary(c))
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -363,9 +363,9 @@
       @test_throws DomainError(T(1.2), "b(t) is not defined for t outside [0, 1].") b(T(1.2), method)
     end
 
-    @test boundary(b) == PointSet(P2(0, 0), P2(1, 0))
+    @test boundary(b) == Multi([P2(0, 0), P2(1, 0)])
     b = BezierCurve(P2(0, 0), P2(1, 1))
-    @test boundary(b) == PointSet([P2(0, 0), P2(1, 1)])
+    @test boundary(b) == Multi([P2(0, 0), P2(1, 1)])
     @test perimeter(b) == zero(T)
 
     b = BezierCurve(P2.(randn(100), randn(100)))
@@ -435,7 +435,7 @@
     @test extrema(b) == (P3(0, 0, 0), P3(1, 1, 1))
 
     b = Box(P1(0), P1(1))
-    @test boundary(b) == PointSet([P1(0), P1(1)])
+    @test boundary(b) == Multi([P1(0), P1(1)])
     @test measure(b) == T(1)
     @test P1(0) ∈ b
     @test P1(1) ∈ b


### PR DESCRIPTION
closes #679 