### PR TITLE
Fix `showfacets` of geometries with rank 1

### DIFF
--- a/ext/geometryset.jl
+++ b/ext/geometryset.jl
@@ -54,8 +54,8 @@ function Makie.plot!(plot::Viz{<:Tuple{GeometrySet}})
     if isempty(bounds[])
       # nothing to be done
     elseif all(ranks[] .== 1)
-      # all boundaries are point sets
-      points = Makie.@lift mapreduce(collect, vcat, $bounds)
+      # all boundaries are multipoints
+      points = Makie.@lift mapreduce(parent, vcat, $bounds)
       viz!(plot, (Makie.@lift GeometrySet($points)), color=facetcolor, pointsize=pointsize)
     elseif all(ranks[] .== 2)
       # all boundaries are geometries


### PR DESCRIPTION
MWE:
```
julia> using Meshes

julia> import GLMakie as Mke

julia> c = Rope((1.0, 0.5), (1.0, 1.0), (2.0, 0.0), (0.0, 0.0))
Rope{2,Float64}
├─ Point(1.0, 0.5)
├─ Point(1.0, 1.0)
├─ Point(2.0, 0.0)
└─ Point(0.0, 0.0)

julia> viz(c, showfacets=true)
ERROR: TypeError: in typeassert, expected Integer, got a value of type Float64
Stacktrace:
  [1] _similar_shape(itr::MultiPoint{2, Float64, Point2}, ::Base.HasLength)
    @ Base ./array.jl:710
  [2] _collect(cont::UnitRange{Int64}, itr::MultiPoint{2, Float64, Point2}, ::Base.HasEltype, isz::Base.HasLength)
    @ Base ./array.jl:765
  [3] collect(itr::MultiPoint{2, Float64, Point2})
  ...
```