### PR TITLE
Simplify 3D `CartesianGrid` plot code

### DIFF
--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -97,13 +97,9 @@ function vizgrid3D!(::Type{<:CartesianGrid}, plot)
   nv = Makie.@lift nvertices($grid)
   nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
 
-  # origin, spacing and size of grid
-  or = Makie.@lift coordinates(minimum($grid))
+  # spacing and coordinates of grid
   sp = Makie.@lift spacing($grid)
-  sz = Makie.@lift size($grid)
-
-  # coordinates of centroids
-  xyz = [Makie.@lift(range($or[i] + $sp[i] / 2, step=$sp[i], length=$sz[i])) for i in 1:3]
+  xyz = Makie.@lift Meshes.xyz($grid)
 
   if nc[] == 1
     # visualize bounding box with a single
@@ -115,17 +111,17 @@ function vizgrid3D!(::Type{<:CartesianGrid}, plot)
       error("not implemented")
     else
       # visualize as built-in meshscatter
-      xs = Makie.@lift $(xyz[1]) .+ $sp[1] / 2
-      ys = Makie.@lift $(xyz[2]) .+ $sp[2] / 2
-      zs = Makie.@lift $(xyz[3]) .+ $sp[3] / 2
-      coords = Makie.@lift [(x, y, z) for z in $zs for y in $ys for x in $xs]
+      xs = Makie.@lift $xyz[1][(begin + 1):end]
+      ys = Makie.@lift $xyz[2][(begin + 1):end]
+      zs = Makie.@lift $xyz[3][(begin + 1):end]
       rect = Makie.@lift Makie.Rect3(-1 .* $sp, $sp)
+      coords = Makie.@lift [(x, y, z) for z in $zs for y in $ys for x in $xs]
       Makie.meshscatter!(plot, coords, marker=rect, markersize=1, color=colorant)
     end
   end
 
   if showfacets[]
-    tup = Makie.@lift xyzsegments(Meshes.xyz($grid)...)
+    tup = Makie.@lift xyzsegments($xyz...)
     x, y, z = Makie.@lift($tup[1]), Makie.@lift($tup[2]), Makie.@lift($tup[3])
     Makie.lines!(plot, x, y, z, color=facetcolor, linewidth=segmentsize)
   end


### PR DESCRIPTION
Benchmark code:
```julia
using Meshes
using BenchmarkTools
import GLMakie as Mke

grid = CartesianGrid(10, 10, 10)

@btime viz($grid, color=1:1000, showfacets=true)
```
## Results
master:
```
julia> @btime viz($grid, color=1:1000, showfacets=true);
  5.119 ms (34941 allocations: 1.99 MiB)
```
![Captura de tela de 2024-01-17 18-15-48](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/12207a75-8e67-4fc4-907f-db4b6a9ca48c)

PR:
```
julia> @btime viz($grid, color=1:1000, showfacets=true);
  5.124 ms (34882 allocations: 1.99 MiB)
```
![Captura de tela de 2024-01-17 18-13-47](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/8a98e861-c443-4c1d-aca0-8d97e7b8351d)



