### PR TITLE
type-paramterize Segment eval

### DIFF
--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -30,7 +30,7 @@ end
 Base.isapprox(s₁::Segment, s₂::Segment; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))
 
-function (s::Segment{Dim,T})(t) where {Dim,T}
+function (s::Segment)(t)
   if t < 0 || t > 1
     throw(DomainError(t, "s(t) is not defined for t outside [0, 1]."))
   end

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -26,8 +26,8 @@ center(s::Segment{Dim,T}) where {Dim,T} = s(T(0.5))
 Base.isapprox(s₁::Segment, s₂::Segment; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))
 
-function (s::Segment)(t)
-  if t < 0 || t > 1
+function (s::Segment{Dim,T})(t) where {Dim,T}
+  if t < zero(T) || t > one(T)
     throw(DomainError(t, "s(t) is not defined for t outside [0, 1]."))
   end
   a, b = s.vertices

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -21,15 +21,17 @@ Base.maximum(s::Segment) = s.vertices[2]
 
 Base.extrema(s::Segment) = s.vertices[1], s.vertices[2]
 
-center(s::Segment) = s(0.5)
+center(s::Segment{Dim,T}) where {Dim,T} = s(T(0.5))
+function center(s::Segment{Dim,T}) where {Dim,T<:Unitful.Quantity}
+  TT = get_precision(s)
+  s(TT(0.5))
+end
 
 Base.isapprox(s₁::Segment, s₂::Segment; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))
 
 function (s::Segment{Dim,T})(t) where {Dim,T}
-  TT = get_precision(s)
-  t = TT(t)
-  if t < zero(TT) || t > one(TT)
+  if t < 0 || t > 1
     throw(DomainError(t, "s(t) is not defined for t outside [0, 1]."))
   end
   a, b = s.vertices

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -21,13 +21,15 @@ Base.maximum(s::Segment) = s.vertices[2]
 
 Base.extrema(s::Segment) = s.vertices[1], s.vertices[2]
 
-center(s::Segment{Dim,T}) where {Dim,T} = s(T(0.5))
+center(s::Segment) = s(0.5)
 
 Base.isapprox(s₁::Segment, s₂::Segment; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))
 
 function (s::Segment{Dim,T})(t) where {Dim,T}
-  if t < zero(T) || t > one(T)
+  TT = get_precision(s)
+  t = TT(t)
+  if t < zero(TT) || t > one(TT)
     throw(DomainError(t, "s(t) is not defined for t outside [0, 1]."))
   end
   a, b = s.vertices

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -123,5 +123,5 @@ function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T}, c::Point{Dim,T}, 
 end
 
 get_precision(x) = typeof(ustrip(x))
-get_precision(p::Point) = get_precision(p.coords[1])
+get_precision(p::Point) = get_precision(first(coordinates.(p)))
 get_precision(s::Segment) = get_precision(first(s.vertices))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -77,7 +77,7 @@ end
 """
     intersectparameters(a, b, c, d)
 
-Compute the parameters `λ₁` and `λ₂` of the lines 
+Compute the parameters `λ₁` and `λ₂` of the lines
 `a + λ₁ ⋅ v⃗₁`, with `v⃗₁ = b - a` and
 `c + λ₂ ⋅ v⃗₂`, with `v⃗₂ = d - c` spanned by the input
 points `a`, `b` resp. `c`, `d` such that to yield line
@@ -103,7 +103,7 @@ function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T}, c::Point{Dim,T}, 
   # the zero entries of the diagonal of R
   _, R = qr([A y])
 
-  # for Dim == 2 one has to check the L1 norm of rows as 
+  # for Dim == 2 one has to check the L1 norm of rows as
   # there are more columns than rows
   τ = atol(T)
   rₐ = sum(>(τ), sum(abs, R, dims=2))
@@ -121,3 +121,7 @@ function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T}, c::Point{Dim,T}, 
 
   λ₁, λ₂, r, rₐ
 end
+
+get_precision(x) = typeof(ustrip(x))
+get_precision(p::Point) = get_precision(p.coords[1])
+get_precision(s::Segment) = get_precision(first(s.vertices))

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -54,6 +54,18 @@
     @test center(s) == P3(0.5, 0.5, 0.5)
     @test coordtype(center(s)) == T
 
+    # using Unitful.jl types
+    using Unitful: m
+    x1 = T(0)m
+    x2 = T(1)m
+    TT = typeof(x1)
+    s = Segment(Point{3,TT}(x1, x1, x1), Point{3,TT}(x2, x2, x2))
+    @test boundary(s) == Multi([Point{3,TT}(x1, x1, x1), Point{3,TT}(x2, x2, x2)])
+    @test perimeter(s) == 0m
+    x_mid = T(0.5)m
+    @test center(s) == Point{3,TT}(x_mid, x_mid, x_mid)
+    @test coordtype(center(s)) == typeof(T(0)m)
+
     s = rand(Segment{2,T})
     @test s isa Segment
     @test embeddim(s) == 2

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -64,7 +64,7 @@
     @test perimeter(s) == 0m
     x_mid = T(0.5)m
     @test center(s) == Point{3,TT}(x_mid, x_mid, x_mid)
-    @test coordtype(center(s)) == typeof(T(0)m)
+    @test coordtype(center(s)) == TT
 
     s = rand(Segment{2,T})
     @test s isa Segment


### PR DESCRIPTION
This breaks if you have the type of the Segment (points) be something that doesn't work with comparing to Int literals, such as Unitful.jl. By using `zero(T)` and `one(T)`, this is fixed.

I wasn't sure how to go about testing this, if you could provide advice here? Obvious way is to load Unitful, but I think you don't want to add that as a test dependency. I can't think of another type to use without adding a dependency. Maybe we can make some dummy type?