### PR TITLE
Add recipe for `Vec`

### DIFF
--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -42,6 +42,7 @@ include("grid.jl")
 include("simplemesh.jl")
 include("subcartesiangrid.jl")
 include("geometryset.jl")
+include("vector.jl")
 include("fallbacks.jl")
 
 end

--- a/ext/fallbacks.jl
+++ b/ext/fallbacks.jl
@@ -4,16 +4,20 @@
 
 Makie.plottype(::Geometry) = Viz{<:Tuple{Geometry}}
 Makie.plottype(::Domain) = Viz{<:Tuple{Domain}}
+Makie.plottype(::Vec) = Viz{<:Tuple{Vec}}
+Makie.plottype(::AbstractVector{<:Vec}) = Viz{<:Tuple{AbstractVector{<:Vec}}}
 
 Makie.convert_arguments(::Type{<:Viz}, geom::Geometry) = (GeometrySet([geom]),)
 Makie.convert_arguments(::Type{<:Viz}, domain::Domain) = (GeometrySet(collect(domain)),)
 Makie.convert_arguments(::Type{<:Viz}, mesh::Mesh) = (convert(SimpleMesh, mesh),)
+Makie.convert_arguments(::Type{<:Viz}, vec::Vec) = ([vec],)
 
 # skip conversion for these types
 Makie.convert_arguments(::Type{<:Viz}, gset::GeometrySet) = (gset,)
 Makie.convert_arguments(::Type{<:Viz}, mesh::SimpleMesh) = (mesh,)
 Makie.convert_arguments(::Type{<:Viz}, grid::Grid) = (grid,)
 Makie.convert_arguments(::Type{<:Viz}, grid::SubCartesianGrid) = (grid,)
+Makie.convert_arguments(::Type{<:Viz}, vecs::AbstractVector{<:Vec}) = (vecs,)
 
 # vector of geometries for convenience
 Makie.plottype(::AbstractVector{<:Geometry}) = Viz{<:Tuple{AbstractVector{<:Geometry}}}

--- a/ext/vector.jl
+++ b/ext/vector.jl
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+function Makie.plot!(plot::Viz{<:Tuple{AbstractVector{Vec{Dim,T}}}}) where {Dim,T}
+  vecs = plot[:object]
+  color = plot[:color]
+  alpha = plot[:alpha]
+  colorscheme = plot[:colorscheme]
+
+  if Dim ∉ (2, 3)
+    error("not implemented")
+  end
+
+  # process color spec into colorant
+  colorant = Makie.@lift process($color, $colorscheme, $alpha)
+
+  # visualize as built-in arrows
+  origins = Makie.@lift fill(zero(Makie.Point{Dim,T}), length($vecs))
+  directions = Makie.@lift asmakie.($vecs)
+  Makie.arrows!(plot, origins, directions, color=colorant)
+end


### PR DESCRIPTION
Examples:
```julia
vs = [Vec(x, y) for x in 1:5 for y in 1:5]
viz(vs, color=1:25)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/a69ecc32-e31c-4280-b87f-585c4e402647)

```julia
vs = vs = [Vec(x, y, z) for x in 1:3 for y in 1:3 for z in 1:3]
viz(vs, color=1:27)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/3541d668-3873-41ab-8078-39818059c3a4)

closes https://github.com/JuliaEarth/GeoStats.jl/issues/381
