### PR TITLE
Add recipe for `RotatedGrid`

### DIFF
--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -11,6 +11,8 @@ using Makie: cgrad
 using Makie: coloralpha
 using Makie.Colors: Colorant
 
+import TransformsBase as TB
+
 import Meshes: viz, viz!
 import Meshes: ascolors
 import Meshes: defaultscheme

--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -5,6 +5,7 @@
 module MeshesMakieExt
 
 using Meshes
+using Rotations
 
 using Makie: cgrad
 using Makie: coloralpha

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -18,118 +18,6 @@ vizgrid1D!(plot) = vizmesh1D!(plot)
 
 vizgrid2D!(plot) = vizmesh2D!(plot)
 
-function vizgrid2D!(plot::Viz{<:Tuple{CartesianGrid}})
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colorscheme = plot[:colorscheme]
-  segmentsize = plot[:segmentsize]
-  showfacets = plot[:showfacets]
-  facetcolor = plot[:facetcolor]
-
-  # process color spec into colorant
-  colorant = Makie.@lift process($color, $colorscheme, $alpha)
-
-  # number of vertices and colors
-  nv = Makie.@lift nvertices($grid)
-  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
-
-  # origin, spacing and size of grid
-  or = Makie.@lift coordinates(minimum($grid))
-  sp = Makie.@lift spacing($grid)
-  sz = Makie.@lift size($grid)
-
-  if nc[] == 1
-    # visualize bounding box with a single
-    # color for maximum performance
-    bbox = Makie.@lift boundingbox($grid)
-    viz!(plot, bbox, color=colorant)
-
-    if showfacets[]
-      tup = Makie.@lift xysegments(Meshes.xyz($grid)...)
-      x, y = Makie.@lift($tup[1]), Makie.@lift($tup[2])
-      Makie.lines!(plot, x, y, color=facetcolor, linewidth=segmentsize)
-    end
-  else
-    if nc[] == nv[]
-      # visualize as built-in image with interpolation
-      C = Makie.@lift reshape($colorant, $sz .+ 1)
-      Makie.image!(plot, C, interpolate=true)
-    else
-      # visualize as built-in image without interpolation
-      C = Makie.@lift reshape($colorant, $sz)
-      Makie.image!(plot, C, interpolate=false)
-    end
-
-    if showfacets[]
-      tup = Makie.@lift xysegments(0:$sz[1], 0:$sz[2])
-      x, y = Makie.@lift($tup[1]), Makie.@lift($tup[2])
-      Makie.lines!(plot, x, y, color=facetcolor, linewidth=segmentsize)
-    end
-
-    # adjust spacing and origin
-    spx, spy = sp[]
-    orx, ory = or[]
-    Makie.scale!(plot, spx, spy)
-    Makie.translate!(plot, orx, ory)
-  end
-end
-
-# defining a Makie.data_limits method is necessary because 
-# Makie.scale and Makie.translate don't adjust axis limits automatically
-function Makie.data_limits(plot::Viz{<:Tuple{CartesianGrid{2}}})
-  grid = plot[:object][]
-  pmin = Makie.Point3f(coordinates(minimum(grid))..., 0)
-  pmax = Makie.Point3f(coordinates(maximum(grid))..., 0)
-  Makie.limits_from_transformed_points([pmin, pmax])
-end
-
-function vizgrid2D!(plot::Viz{<:Tuple{RectilinearGrid}})
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colorscheme = plot[:colorscheme]
-  segmentsize = plot[:segmentsize]
-  showfacets = plot[:showfacets]
-  facetcolor = plot[:facetcolor]
-
-  # process color spec into colorant
-  colorant = Makie.@lift process($color, $colorscheme, $alpha)
-
-  # number of vertices and colors
-  nv = Makie.@lift nvertices($grid)
-  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
-
-  # grid coordinates
-  xyz = Makie.@lift Meshes.xyz($grid)
-  xs = Makie.@lift $xyz[1]
-  ys = Makie.@lift $xyz[2]
-
-  if nc[] == 1
-    # visualize bounding box with a single
-    # color for maximum performance
-    bbox = Makie.@lift boundingbox($grid)
-    viz!(plot, bbox, color=colorant)
-  else
-    if nc[] == nv[]
-      # visualize as a simple mesh so that
-      # colors can be specified at vertices
-      vizmesh2D!(plot)
-    else
-      # visualize as built-in heatmap
-      sz = Makie.@lift size($grid)
-      C = Makie.@lift reshape($colorant, $sz)
-      Makie.heatmap!(plot, xs, ys, C)
-    end
-  end
-
-  if showfacets[]
-    tup = Makie.@lift xysegments($xs, $ys)
-    x, y = Makie.@lift($tup[1]), Makie.@lift($tup[2])
-    Makie.lines!(plot, x, y, color=facetcolor, linewidth=segmentsize)
-  end
-end
-
 function vizgrid3D!(plot)
   grid = plot[:object]
   color = plot[:color]
@@ -145,52 +33,13 @@ function vizgrid3D!(plot)
   end
 end
 
-function vizgrid3D!(plot::Viz{<:Tuple{CartesianGrid}})
-  # retrieve parameters
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colorscheme = plot[:colorscheme]
-  segmentsize = plot[:segmentsize]
-  showfacets = plot[:showfacets]
-  facetcolor = plot[:facetcolor]
+# ----------------
+# SPECIALIZATIONS
+# ----------------
 
-  # process color spec into colorant
-  colorant = Makie.@lift process($color, $colorscheme, $alpha)
-
-  # number of vertices and colors
-  nv = Makie.@lift nvertices($grid)
-  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
-
-  # spacing and coordinates
-  sp = Makie.@lift spacing($grid)
-  xyz = Makie.@lift Meshes.xyz($grid)
-
-  if nc[] == 1
-    # visualize bounding box with a single
-    # color for maximum performance
-    bbox = Makie.@lift boundingbox($grid)
-    viz!(plot, bbox, color=colorant)
-  else
-    if nc[] == nv[]
-      error("not implemented")
-    else
-      # visualize as built-in meshscatter
-      xs = Makie.@lift $xyz[1][(begin + 1):end]
-      ys = Makie.@lift $xyz[2][(begin + 1):end]
-      zs = Makie.@lift $xyz[3][(begin + 1):end]
-      rect = Makie.@lift Makie.Rect3(-1 .* $sp, $sp)
-      coords = Makie.@lift [(x, y, z) for z in $zs for y in $ys for x in $xs]
-      Makie.meshscatter!(plot, coords, marker=rect, markersize=1, color=colorant)
-    end
-  end
-
-  if showfacets[]
-    tup = Makie.@lift xyzsegments($xyz...)
-    x, y, z = Makie.@lift($tup[1]), Makie.@lift($tup[2]), Makie.@lift($tup[3])
-    Makie.lines!(plot, x, y, z, color=facetcolor, linewidth=segmentsize)
-  end
-end
+include("grid/cartesian.jl")
+include("grid/rectilinear.jl")
+include("grid/transformed.jl")
 
 # helper functions to create a minimum number
 # of line segments within Cartesian/Rectilinear grid

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -1,0 +1,116 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+function vizgrid2D!(plot::Viz{<:Tuple{CartesianGrid}})
+  grid = plot[:object]
+  color = plot[:color]
+  alpha = plot[:alpha]
+  colorscheme = plot[:colorscheme]
+  segmentsize = plot[:segmentsize]
+  showfacets = plot[:showfacets]
+  facetcolor = plot[:facetcolor]
+
+  # process color spec into colorant
+  colorant = Makie.@lift process($color, $colorscheme, $alpha)
+
+  # number of vertices and colors
+  nv = Makie.@lift nvertices($grid)
+  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+
+  # origin, spacing and size of grid
+  or = Makie.@lift coordinates(minimum($grid))
+  sp = Makie.@lift spacing($grid)
+  sz = Makie.@lift size($grid)
+
+  if nc[] == 1
+    # visualize bounding box with a single
+    # color for maximum performance
+    bbox = Makie.@lift boundingbox($grid)
+    viz!(plot, bbox, color=colorant)
+
+    if showfacets[]
+      tup = Makie.@lift xysegments(Meshes.xyz($grid)...)
+      x, y = Makie.@lift($tup[1]), Makie.@lift($tup[2])
+      Makie.lines!(plot, x, y, color=facetcolor, linewidth=segmentsize)
+    end
+  else
+    if nc[] == nv[]
+      # visualize as built-in image with interpolation
+      C = Makie.@lift reshape($colorant, $sz .+ 1)
+      Makie.image!(plot, C, interpolate=true)
+    else
+      # visualize as built-in image without interpolation
+      C = Makie.@lift reshape($colorant, $sz)
+      Makie.image!(plot, C, interpolate=false)
+    end
+
+    if showfacets[]
+      tup = Makie.@lift xysegments(0:$sz[1], 0:$sz[2])
+      x, y = Makie.@lift($tup[1]), Makie.@lift($tup[2])
+      Makie.lines!(plot, x, y, color=facetcolor, linewidth=segmentsize)
+    end
+
+    # adjust spacing and origin
+    spx, spy = sp[]
+    orx, ory = or[]
+    Makie.scale!(plot, spx, spy)
+    Makie.translate!(plot, orx, ory)
+  end
+end
+
+# defining a Makie.data_limits method is necessary because 
+# Makie.scale and Makie.translate don't adjust axis limits automatically
+function Makie.data_limits(plot::Viz{<:Tuple{CartesianGrid{2}}})
+  grid = plot[:object][]
+  pmin = Makie.Point3f(coordinates(minimum(grid))..., 0)
+  pmax = Makie.Point3f(coordinates(maximum(grid))..., 0)
+  Makie.limits_from_transformed_points([pmin, pmax])
+end
+
+function vizgrid3D!(plot::Viz{<:Tuple{CartesianGrid}})
+  # retrieve parameters
+  grid = plot[:object]
+  color = plot[:color]
+  alpha = plot[:alpha]
+  colorscheme = plot[:colorscheme]
+  segmentsize = plot[:segmentsize]
+  showfacets = plot[:showfacets]
+  facetcolor = plot[:facetcolor]
+
+  # process color spec into colorant
+  colorant = Makie.@lift process($color, $colorscheme, $alpha)
+
+  # number of vertices and colors
+  nv = Makie.@lift nvertices($grid)
+  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+
+  # spacing and coordinates
+  sp = Makie.@lift spacing($grid)
+  xyz = Makie.@lift Meshes.xyz($grid)
+
+  if nc[] == 1
+    # visualize bounding box with a single
+    # color for maximum performance
+    bbox = Makie.@lift boundingbox($grid)
+    viz!(plot, bbox, color=colorant)
+  else
+    if nc[] == nv[]
+      error("not implemented")
+    else
+      # visualize as built-in meshscatter
+      xs = Makie.@lift $xyz[1][(begin + 1):end]
+      ys = Makie.@lift $xyz[2][(begin + 1):end]
+      zs = Makie.@lift $xyz[3][(begin + 1):end]
+      rect = Makie.@lift Makie.Rect3(-1 .* $sp, $sp)
+      coords = Makie.@lift [(x, y, z) for z in $zs for y in $ys for x in $xs]
+      Makie.meshscatter!(plot, coords, marker=rect, markersize=1, color=colorant)
+    end
+  end
+
+  if showfacets[]
+    tup = Makie.@lift xyzsegments($xyz...)
+    x, y, z = Makie.@lift($tup[1]), Makie.@lift($tup[2]), Makie.@lift($tup[3])
+    Makie.lines!(plot, x, y, z, color=facetcolor, linewidth=segmentsize)
+  end
+end

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -1,0 +1,49 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+function vizgrid2D!(plot::Viz{<:Tuple{RectilinearGrid}})
+  grid = plot[:object]
+  color = plot[:color]
+  alpha = plot[:alpha]
+  colorscheme = plot[:colorscheme]
+  segmentsize = plot[:segmentsize]
+  showfacets = plot[:showfacets]
+  facetcolor = plot[:facetcolor]
+
+  # process color spec into colorant
+  colorant = Makie.@lift process($color, $colorscheme, $alpha)
+
+  # number of vertices and colors
+  nv = Makie.@lift nvertices($grid)
+  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+
+  # grid coordinates
+  xyz = Makie.@lift Meshes.xyz($grid)
+  xs = Makie.@lift $xyz[1]
+  ys = Makie.@lift $xyz[2]
+
+  if nc[] == 1
+    # visualize bounding box with a single
+    # color for maximum performance
+    bbox = Makie.@lift boundingbox($grid)
+    viz!(plot, bbox, color=colorant)
+  else
+    if nc[] == nv[]
+      # visualize as a simple mesh so that
+      # colors can be specified at vertices
+      vizmesh2D!(plot)
+    else
+      # visualize as built-in heatmap
+      sz = Makie.@lift size($grid)
+      C = Makie.@lift reshape($colorant, $sz)
+      Makie.heatmap!(plot, xs, ys, C)
+    end
+  end
+
+  if showfacets[]
+    tup = Makie.@lift xysegments($xs, $ys)
+    x, y = Makie.@lift($tup[1]), Makie.@lift($tup[2])
+    Makie.lines!(plot, x, y, color=facetcolor, linewidth=segmentsize)
+  end
+end

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+const RotatedGrid{Dim,T} = TransformedGrid{Dim,T,G,TR} where {G,TR<:Rotate{<:Angle2d}}
+
+function vizgrid2D!(plot::Viz{<:Tuple{RotatedGrid}})
+  tgrid = plot[:object]
+  grid = Makie.@lift parent(tgrid)
+  trans = Makie.@lift Meshes.transform(tgrid)
+  # TODO
+end

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -25,15 +25,8 @@ end
 
 function Makie.data_limits(plot::Viz{<:Tuple{RotatedGrid{2}}})
   tgrid = plot[:object][]
-  grid = parent(tgrid)
-  trans = Meshes.transform(tgrid)
-  bbox = _bbox(grid, trans)
+  bbox = boundingbox(tgrid)
   pmin = Makie.Point3f(coordinates(minimum(bbox))..., 0)
   pmax = Makie.Point3f(coordinates(maximum(bbox))..., 0)
   Makie.limits_from_transformed_points([pmin, pmax])
-end
-
-function _bbox(grid, trans)
-  q = convert(Quadrangle, boundingbox(grid))
-  boundingbox(trans(q))
 end

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -6,7 +6,34 @@ const RotatedGrid{Dim,T} = TransformedGrid{Dim,T,G,TR} where {G,TR<:Rotate{<:Ang
 
 function vizgrid2D!(plot::Viz{<:Tuple{RotatedGrid}})
   tgrid = plot[:object]
-  grid = Makie.@lift parent(tgrid)
-  trans = Makie.@lift Meshes.transform(tgrid)
-  # TODO
+  color = plot[:color]
+  alpha = plot[:alpha]
+  colorscheme = plot[:colorscheme]
+  segmentsize = plot[:segmentsize]
+  showfacets = plot[:showfacets]
+  facetcolor = plot[:facetcolor]
+
+  grid = Makie.@lift parent($tgrid)
+  trans = Makie.@lift Meshes.transform($tgrid)
+  rot = Makie.@lift TB.parameters($trans).rot
+  θ = Makie.@lift first(Rotations.params($rot))
+
+  # plot and rotate the grid
+  viz!(plot, grid; color, alpha, colorscheme, segmentsize, showfacets, facetcolor)
+  Makie.rotate!(plot, θ[])
+end
+
+function Makie.data_limits(plot::Viz{<:Tuple{RotatedGrid{2}}})
+  tgrid = plot[:object][]
+  grid = parent(tgrid)
+  trans = Meshes.transform(tgrid)
+  bbox = _bbox(grid, trans)
+  pmin = Makie.Point3f(coordinates(minimum(bbox))..., 0)
+  pmax = Makie.Point3f(coordinates(maximum(bbox))..., 0)
+  Makie.limits_from_transformed_points([pmin, pmax])
+end
+
+function _bbox(grid, trans)
+  q = convert(Quadrangle, boundingbox(grid))
+  boundingbox(trans(q))
 end

--- a/src/mesh/transformedmesh.jl
+++ b/src/mesh/transformedmesh.jl
@@ -24,7 +24,7 @@ topology(m::TransformedMesh) = topology(m.mesh)
 vertex(m::TransformedMesh, ind::Int) = m.transform(vertex(m.mesh, ind))
 
 # alias to improve readability in IO methods
-const TransformedGrid{Dim,T} = TransformedMesh{Dim,T,GridTopology{Dim}}
+const TransformedGrid{Dim,T,G<:Grid{Dim,T},TR} = TransformedMesh{Dim,T,GridTopology{Dim},G,TR}
 
 TransformedGrid(g::Grid, t::Transform) = TransformedMesh(g, t)
 


### PR DESCRIPTION
Example:
```julia
grid = CartesianGrid(10, 10)
rot = Rotate(π/3)
tgrid = TransformedGrid(grid, rot)
viz(tgrid, color=1:100, showfacets=true)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/6245f713-2680-4e80-8773-1e1bd106ee90)
