### PR TITLE
Fix `boundingbox` of `Grid` and `TransformedGrid`

### DIFF
--- a/src/boundingboxes.jl
+++ b/src/boundingboxes.jl
@@ -55,7 +55,15 @@ end
 
 boundingbox(t::Torus) = _pboxes(pointify(t))
 
-boundingbox(g::Grid) = Box(extrema(g)...)
+boundingbox(g::CartesianGrid) = Box(extrema(g)...)
+
+boundingbox(g::RectilinearGrid) = Box(extrema(g)...)
+
+boundingbox(g::TransformedGrid{Dim,T,<:CartesianGrid{Dim,T}}) where {Dim,T} =
+  boundingbox(parent(g)) |> transform(g) |> boundingbox
+
+boundingbox(g::TransformedGrid{Dim,T,<:RectilinearGrid{Dim,T}}) where {Dim,T} =
+  boundingbox(parent(g)) |> transform(g) |> boundingbox
 
 boundingbox(m::Mesh) = _pboxes(vertices(m))
 

--- a/src/mesh/transformedmesh.jl
+++ b/src/mesh/transformedmesh.jl
@@ -24,7 +24,7 @@ topology(m::TransformedMesh) = topology(m.mesh)
 vertex(m::TransformedMesh, ind::Int) = m.transform(vertex(m.mesh, ind))
 
 # alias to improve readability in IO methods
-const TransformedGrid{Dim,T} = TransformedMesh{Dim,T,GridTopology{Dim}}
+const TransformedGrid{Dim,T,G<:Grid{Dim,T},TR} = TransformedMesh{Dim,T,GridTopology{Dim},G,TR}
 
 TransformedGrid(g::Grid, t::Transform) = TransformedMesh(g, t)
 

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -80,6 +80,22 @@
   @test @allocated(boundingbox(v)) < 9000
 
   g = CartesianGrid{T}(10, 10)
+  d = convert(RectilinearGrid, g)
+  @test boundingbox(d) == Box(P2(0, 0), P2(10, 10))
+  @test @allocated(boundingbox(d)) < 50
+
+  g = CartesianGrid{T}(10, 10)
+  d = TransformedGrid(g, Rotate(T(π / 2)))
+  @test boundingbox(d) ≈ Box(P2(-10, 0), P2(0, 10))
+  @test @allocated(boundingbox(d)) < 660
+
+  g = CartesianGrid{T}(10, 10)
+  rg = convert(RectilinearGrid, g)
+  d = TransformedGrid(rg, Rotate(T(π / 2)))
+  @test boundingbox(d) ≈ Box(P2(-10, 0), P2(0, 10))
+  @test @allocated(boundingbox(d)) < 660
+
+  g = CartesianGrid{T}(10, 10)
   m = convert(SimpleMesh, g)
   @test boundingbox(m) == Box(P2(0, 0), P2(10, 10))
   @test @allocated(boundingbox(m)) < 50

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -87,13 +87,13 @@
   g = CartesianGrid{T}(10, 10)
   d = TransformedGrid(g, Rotate(T(π / 2)))
   @test boundingbox(d) ≈ Box(P2(-10, 0), P2(0, 10))
-  @test @allocated(boundingbox(d)) < 660
+  @test @allocated(boundingbox(d)) < 2300
 
   g = CartesianGrid{T}(10, 10)
   rg = convert(RectilinearGrid, g)
   d = TransformedGrid(rg, Rotate(T(π / 2)))
   @test boundingbox(d) ≈ Box(P2(-10, 0), P2(0, 10))
-  @test @allocated(boundingbox(d)) < 660
+  @test @allocated(boundingbox(d)) < 2300
 
   g = CartesianGrid{T}(10, 10)
   m = convert(SimpleMesh, g)


### PR DESCRIPTION
Visual test:
```
julia> using Meshes

julia> import GLMakie as Mke

julia> grid = CartesianGrid(10, 10);

julia> tgrid = TransformedGrid(grid, Rotate(π / 3));

julia> viz(tgrid, color=1:100, showfacets=true)

julia> viz!(boundingbox(tgrid) |> boundary, color=:red)
```
![Captura de tela de 2024-01-23 17-08-07](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/0d1436bb-1d10-4def-98d9-8cd38da0fa8c)
