### PR TITLE
Add `TranslatedGrid` recipe

### DIFF
--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -33,6 +33,20 @@ function vizgrid3D!(plot)
   end
 end
 
+# defining a Makie.data_limits method is necessary because
+# Makie.scale!, Makie.translate! and Makie.rotate!
+# don't adjust axis limits automatically
+function Makie.data_limits(plot::Viz{<:Tuple{Grid}})
+  grid = plot[:object][]
+  bbox = boundingbox(grid)
+  pmin = aspoint3f(minimum(bbox))
+  pmax = aspoint3f(maximum(bbox))
+  Makie.limits_from_transformed_points([pmin, pmax])
+end
+
+aspoint3f(p::Point{2}) = Makie.Point3f(coordinates(p)..., 0)
+aspoint3f(p::Point{3}) = Makie.Point3f(coordinates(p)...)
+
 # ----------------
 # SPECIALIZATIONS
 # ----------------

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -59,15 +59,6 @@ function vizgrid2D!(plot::Viz{<:Tuple{CartesianGrid}})
   end
 end
 
-# defining a Makie.data_limits method is necessary because 
-# Makie.scale and Makie.translate don't adjust axis limits automatically
-function Makie.data_limits(plot::Viz{<:Tuple{CartesianGrid{2}}})
-  grid = plot[:object][]
-  pmin = Makie.Point3f(coordinates(minimum(grid))..., 0)
-  pmax = Makie.Point3f(coordinates(maximum(grid))..., 0)
-  Makie.limits_from_transformed_points([pmin, pmax])
-end
-
 function vizgrid3D!(plot::Viz{<:Tuple{CartesianGrid}})
   # retrieve parameters
   grid = plot[:object]

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -15,7 +15,7 @@ function vizgrid2D!(plot::Viz{<:Tuple{RotatedGrid}})
 
   grid = Makie.@lift parent($tgrid)
   trans = Makie.@lift Meshes.transform($tgrid)
-  rot = Makie.@lift TB.parameters($trans).rot
+  rot = Makie.@lift first(TB.parameters($trans))
   θ = Makie.@lift first(Rotations.params($rot))
 
   # plot and rotate the grid
@@ -23,10 +23,42 @@ function vizgrid2D!(plot::Viz{<:Tuple{RotatedGrid}})
   Makie.rotate!(plot, θ[])
 end
 
-function Makie.data_limits(plot::Viz{<:Tuple{RotatedGrid{2}}})
-  tgrid = plot[:object][]
-  bbox = boundingbox(tgrid)
-  pmin = Makie.Point3f(coordinates(minimum(bbox))..., 0)
-  pmax = Makie.Point3f(coordinates(maximum(bbox))..., 0)
-  Makie.limits_from_transformed_points([pmin, pmax])
+const TranslatedGrid{Dim,T} = TransformedGrid{Dim,T,G,TR} where {G,TR<:Translate{Dim}}
+
+function vizgrid2D!(plot::Viz{<:Tuple{TranslatedGrid}})
+  tgrid = plot[:object]
+  color = plot[:color]
+  alpha = plot[:alpha]
+  colorscheme = plot[:colorscheme]
+  segmentsize = plot[:segmentsize]
+  showfacets = plot[:showfacets]
+  facetcolor = plot[:facetcolor]
+
+  grid = Makie.@lift parent($tgrid)
+  trans = Makie.@lift Meshes.transform($tgrid)
+  offsets = Makie.@lift first(TB.parameters($trans))
+
+  # plot and translate the grid
+  viz!(plot, grid; color, alpha, colorscheme, segmentsize, showfacets, facetcolor)
+  o₁, o₂ = offsets[]
+  Makie.translate!(plot, o₁, o₂)
+end
+
+function vizgrid3D!(plot::Viz{<:Tuple{TranslatedGrid}})
+  tgrid = plot[:object]
+  color = plot[:color]
+  alpha = plot[:alpha]
+  colorscheme = plot[:colorscheme]
+  segmentsize = plot[:segmentsize]
+  showfacets = plot[:showfacets]
+  facetcolor = plot[:facetcolor]
+
+  grid = Makie.@lift parent($tgrid)
+  trans = Makie.@lift Meshes.transform($tgrid)
+  offsets = Makie.@lift first(TB.parameters($trans))
+
+  # plot and translate the grid
+  viz!(plot, grid; color, alpha, colorscheme, segmentsize, showfacets, facetcolor)
+  o₁, o₂, o₃ = offsets[]
+  Makie.translate!(plot, o₁, o₂, o₃)
 end

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -25,7 +25,11 @@ end
 
 const TranslatedGrid{Dim,T} = TransformedGrid{Dim,T,G,TR} where {G,TR<:Translate{Dim}}
 
-function vizgrid2D!(plot::Viz{<:Tuple{TranslatedGrid}})
+vizgrid2D!(plot::Viz{<:Tuple{TranslatedGrid}}) = translatedgrid!(plot)
+
+vizgrid3D!(plot::Viz{<:Tuple{TranslatedGrid}}) = translatedgrid!(plot)
+
+function translatedgrid!(plot)
   tgrid = plot[:object]
   color = plot[:color]
   alpha = plot[:alpha]
@@ -40,25 +44,5 @@ function vizgrid2D!(plot::Viz{<:Tuple{TranslatedGrid}})
 
   # plot and translate the grid
   viz!(plot, grid; color, alpha, colorscheme, segmentsize, showfacets, facetcolor)
-  o₁, o₂ = offsets[]
-  Makie.translate!(plot, o₁, o₂)
-end
-
-function vizgrid3D!(plot::Viz{<:Tuple{TranslatedGrid}})
-  tgrid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colorscheme = plot[:colorscheme]
-  segmentsize = plot[:segmentsize]
-  showfacets = plot[:showfacets]
-  facetcolor = plot[:facetcolor]
-
-  grid = Makie.@lift parent($tgrid)
-  trans = Makie.@lift Meshes.transform($tgrid)
-  offsets = Makie.@lift first(TB.parameters($trans))
-
-  # plot and translate the grid
-  viz!(plot, grid; color, alpha, colorscheme, segmentsize, showfacets, facetcolor)
-  o₁, o₂, o₃ = offsets[]
-  Makie.translate!(plot, o₁, o₂, o₃)
+  Makie.translate!(plot, offsets[]...)
 end


### PR DESCRIPTION
Examples:
```
julia> grid = CartesianGrid(10, 10);

julia> tgrid = TransformedGrid(grid, Translate(2, 2));

julia> viz(tgrid, color=1:100, showfacets=true)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/3c60f49a-82c5-4e56-8f70-0dc3d4254643)

```
julia> grid = CartesianGrid(5, 5, 5);

julia> tgrid = TransformedGrid(grid, Translate(2, 2, 2));

julia> viz(tgrid, color=1:125, showfacets=true)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/f66b10a8-ea4e-41c3-b60e-74572f2f71eb)
