### PR TITLE
`TransformedGrid` recipe: Add support for `Stretch` transform

### DIFF
--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -8,6 +8,7 @@ isoptimized(t::TB.SequentialTransform) = all(isoptimized, t)
 isoptimized(::GeometricTransform) = false
 isoptimized(::Rotate{<:Angle2d}) = true
 isoptimized(::Translate) = true
+isoptimized(::Stretch) = true
 
 vizgrid2D!(plot::Viz{<:Tuple{TransformedGrid}}) = transformedgrid!(plot, vizmesh2D!)
 
@@ -44,4 +45,9 @@ end
 function makietransform!(plot, trans::Translate)
   offsets = first(TB.parameters(trans))
   Makie.translate!(plot, offsets...)
+end
+
+function makietransform!(plot, trans::Stretch)
+  factors = first(TB.parameters(trans))
+  Makie.scale!(plot, factors...)
 end


### PR DESCRIPTION
Example:
```julia
grid = CartesianGrid(10, 10)
tgrid = TransformedGrid(grid, Stretch(1.5, 2.5))
viz(tgrid, color=1:100, showfacets=true)
```
![Captura de tela de 2024-01-24 17-17-42](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/c69d68e1-787d-476a-b3cb-ab6fb87f593a)
