### PR TITLE
`TransformedGrid` recipe: Add support for `Affine2D` transform

### DIFF
--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -6,6 +6,7 @@ module MeshesMakieExt
 
 using Meshes
 using Rotations
+using LinearAlgebra
 
 using Makie: cgrad
 using Makie: coloralpha


### PR DESCRIPTION
Examples:
```julia
grid = CartesianGrid(10, 10)
tgrid = TransformedGrid(grid, Affine(Angle2d(π / 3), [5, 5]))
viz(tgrid, color=1:100, showfacets=true)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/b02f7715-9dcd-4c9d-a974-cb95a1dc2b45)

```julia
θ = π / 3
A = [
  cos(θ) -sin(θ)
  sin(θ)  cos(θ)
]
b = [5, 5]

grid = CartesianGrid(10, 10)
tgrid = TransformedGrid(grid, Affine(A, b))
viz(tgrid, color=1:100, showfacets=true)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/231e4ccf-080c-40d8-aa78-fec6f0bc9961)

```julia
A = [2 0; 0 1.5]
b = [-5, -5]

grid = CartesianGrid(10, 10)
tgrid = TransformedGrid(grid, Affine(A, b))
viz(tgrid, color=1:100, showfacets=true)
```
![image](https://github.com/JuliaGeometry/Meshes.jl/assets/73039601/ec40c59a-760f-40ce-8e1a-38f0c891d57c)
