### PR TITLE
generalize center(::Segment)

### DIFF
--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -21,7 +21,10 @@ Base.maximum(s::Segment) = s.vertices[2]
 
 Base.extrema(s::Segment) = s.vertices[1], s.vertices[2]
 
-center(s::Segment{Dim,T}) where {Dim,T} = s(T(0.5))
+function center(s::Segment)
+  a, b = coordinates.(extrema(s))
+  return Point((a + b) ./ 2)
+end
 
 Base.isapprox(s₁::Segment, s₂::Segment; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -54,6 +54,15 @@
     @test center(s) == P3(0.5, 0.5, 0.5)
     @test coordtype(center(s)) == T
 
+    x1 = T(0)u"m"
+    x2 = T(1)u"m"
+    s = Segment(Point(x1, x1, x1), Point(x2, x2, x2))
+    @test boundary(s) == Multi([Point(x1, x1, x1), Point(x2, x2, x2)])
+    @test perimeter(s) == 0u"m"
+    x_mid = T(0.5)u"m"
+    @test center(s) == Point(x_mid, x_mid, x_mid)
+    @test coordtype(center(s)) == typeof(x_mid)
+
     s = rand(Segment{2,T})
     @test s isa Segment
     @test embeddim(s) == 2


### PR DESCRIPTION
This PR is a follow-up of #706 which addresses #702 .

In the previous review, @juliohm commented on `@test coordtype(center(s))` stating

> The correct test here is one that checks the unit of the coordtype is u"m". We don't need to store TT to check the exact Unitful.jl type.

but I think it is important to test for the exact type, because I would expect that same type of `Point` as in the input `Segment` back when doing `center(::Segment)`.