### PR TITLE
Small optimization in `isapprox(coords1, coords2)`

### DIFF
--- a/src/coordinates.jl
+++ b/src/coordinates.jl
@@ -52,7 +52,7 @@ _fnames(coords::Coordinates) = fieldnames(typeof(coords))
 function Base.isapprox(coords₁::C, coords₂::C; kwargs...) where {N,C<:Coordinates{N}}
   f₁ = _fields(coords₁)
   f₂ = _fields(coords₂)
-  all(isapprox(getfield(f₁, i), getfield(f₂, i); kwargs...) for i in 1:N)
+  all(ntuple(i -> isapprox(getfield(f₁, i), getfield(f₂, i); kwargs...), N))
 end
 
 # -----------


### PR DESCRIPTION
## Benchmark
Code:
```julia
using Meshes
using BenchmarkTools

c = Polar(1, 1)
@btime c ≈ c
```
master:
```
julia> @btime c ≈ c
  93.678 ns (8 allocations: 192 bytes)
true
```
PR:
```
julia> @btime c ≈ c
  12.727 ns (0 allocations: 0 bytes)
true
```
