### PR TITLE
Add `EqualAreaCylindrical` projections

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -159,6 +159,8 @@ export
   Mercator,
   WebMercator,
   PlateCarree,
+  Lambert,
+  Behrmann,
   WinkelTripel,
   datum,
 

--- a/src/crs.jl
+++ b/src/crs.jl
@@ -143,6 +143,7 @@ include("crs/latlon.jl")
 include("crs/mercator.jl")
 include("crs/webmercator.jl")
 include("crs/eqdistcylindrical.jl")
+include("crs/eqareacylindrical.jl")
 include("crs/winkeltripel.jl")
 
 # ----------

--- a/src/crs/eqareacylindrical.jl
+++ b/src/crs/eqareacylindrical.jl
@@ -5,7 +5,7 @@
 """
     EqualAreaCylindrical{latₜₛ}
 
-Equal Area Cylindrical CRS with  latitude of true scale `latₜₛ` in degrees.
+Equal Area Cylindrical CRS with latitude of true scale `latₜₛ` in degrees.
 """
 const EqualAreaCylindrical{latₜₛ,M<:Met} = CRS{:EAC,@NamedTuple{x::M, y::M},WGS84,latₜₛ}
 

--- a/src/crs/eqareacylindrical.jl
+++ b/src/crs/eqareacylindrical.jl
@@ -1,0 +1,81 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    EqualAreaCylindrical{latₜₛ}
+
+Equal Area Cylindrical CRS with  latitude of true scale `latₜₛ` in degrees.
+"""
+const EqualAreaCylindrical{latₜₛ,M<:Met} = CRS{:EAC,@NamedTuple{x::M, y::M},WGS84,latₜₛ}
+
+EqualAreaCylindrical{latₜₛ}(x::M, y::M) where {latₜₛ,M<:Met} = EqualAreaCylindrical{latₜₛ,float(M)}(x, y)
+EqualAreaCylindrical{latₜₛ}(x::Met, y::Met) where {latₜₛ} = EqualAreaCylindrical{latₜₛ}(promote(x, y)...)
+EqualAreaCylindrical{latₜₛ}(x::Len, y::Len) where {latₜₛ} =
+  EqualAreaCylindrical{latₜₛ}(uconvert(u"m", x), uconvert(u"m", y))
+EqualAreaCylindrical{latₜₛ}(x::Number, y::Number) where {latₜₛ} =
+  EqualAreaCylindrical{latₜₛ}(addunit(x, u"m"), addunit(y, u"m"))
+
+"""
+    Lambert(x, y)
+
+Lambert cylindrical equal-area coordinates in length units (default to meter).
+
+## Examples
+
+```julia
+Lambert(1, 1) # add default units
+Lambert(1u"m", 1u"m") # integers are converted converted to floats
+Lambert(1.0u"km", 1.0u"km") # length quantities are converted to meters
+Lambert(1.0u"m", 1.0u"m")
+```
+
+See [ESRI:54034](https://epsg.io/54034).
+"""
+const Lambert = EqualAreaCylindrical{0.0u"°"}
+
+typealias(::Type{ESRI{54034}}) = Lambert
+
+"""
+    Behrmann(x, y)
+
+Behrmann coordinates in length units (default to meter).
+
+## Examples
+
+```julia
+Lambert(1, 1) # add default units
+Lambert(1u"m", 1u"m") # integers are converted converted to floats
+Lambert(1.0u"km", 1.0u"km") # length quantities are converted to meters
+Lambert(1.0u"m", 1.0u"m")
+```
+
+See [ESRI:54017](https://epsg.io/54017).
+"""
+const Behrmann = EqualAreaCylindrical{30.0u"°"}
+
+typealias(::Type{ESRI{54017}}) = Behrmann
+
+function Base.convert(::Type{EqualAreaCylindrical{latₜₛ}}, coords::LatLon) where {latₜₛ}
+  dat = datum(EqualAreaCylindrical{latₜₛ})
+  🌎 = ellipsoid(dat)
+  λ = deg2rad(coords.lon)
+  ϕ = deg2rad(coords.lat)
+  λ₀ = oftype(λ, deg2rad(longitudeₒ(dat)))
+  ϕₜₛ = oftype(ϕ, deg2rad(latₜₛ))
+  l = ustrip(λ)
+  l₀ = ustrip(λ₀)
+  a = oftype(l, ustrip(majoraxis(🌎)))
+  e = oftype(l, eccentricity(🌎))
+  e² = oftype(l, eccentricity²(🌎))
+
+  k₀ = cos(ϕₜₛ) / sqrt(1 - e² * sin(ϕₜₛ)^2)
+  sinϕ = sin(ϕ)
+  esinϕ = e * sinϕ
+  q = (1 - e²) * (sinϕ / (1 - esinϕ^2) - (1 / 2e) * log((1 - esinϕ) / (1 + esinϕ)))
+
+  x = a * k₀ * (l - l₀)
+  y = a * q / 2k₀
+
+  EqualAreaCylindrical{latₜₛ}(x * u"m", y * u"m")
+end

--- a/src/crs/eqdistcylindrical.jl
+++ b/src/crs/eqdistcylindrical.jl
@@ -3,18 +3,18 @@
 # ------------------------------------------------------------------
 
 """
-    EquidistantCylindrical{ID,latₜₛ}
+    EquidistantCylindrical{latₜₛ}
 
-Equidistant Cylindrical CRS with identifier `ID` and latitude of true scale `latₜₛ` in degrees.
+Equidistant Cylindrical CRS with latitude of true scale `latₜₛ` in degrees.
 """
-const EquidistantCylindrical{ID,latₜₛ,M<:Met} = CRS{ID,@NamedTuple{x::M, y::M},WGS84,latₜₛ}
+const EquidistantCylindrical{latₜₛ,M<:Met} = CRS{:EDC,@NamedTuple{x::M, y::M},WGS84,latₜₛ}
 
-EquidistantCylindrical{ID,latₜₛ}(x::M, y::M) where {ID,latₜₛ,M<:Met} = EquidistantCylindrical{ID,latₜₛ,float(M)}(x, y)
-EquidistantCylindrical{ID,latₜₛ}(x::Met, y::Met) where {ID,latₜₛ} = EquidistantCylindrical{ID,latₜₛ}(promote(x, y)...)
-EquidistantCylindrical{ID,latₜₛ}(x::Len, y::Len) where {ID,latₜₛ} =
-  EquidistantCylindrical{ID,latₜₛ}(uconvert(u"m", x), uconvert(u"m", y))
-EquidistantCylindrical{ID,latₜₛ}(x::Number, y::Number) where {ID,latₜₛ} =
-  EquidistantCylindrical{ID,latₜₛ}(addunit(x, u"m"), addunit(y, u"m"))
+EquidistantCylindrical{latₜₛ}(x::M, y::M) where {latₜₛ,M<:Met} = EquidistantCylindrical{latₜₛ,float(M)}(x, y)
+EquidistantCylindrical{latₜₛ}(x::Met, y::Met) where {latₜₛ} = EquidistantCylindrical{latₜₛ}(promote(x, y)...)
+EquidistantCylindrical{latₜₛ}(x::Len, y::Len) where {latₜₛ} =
+  EquidistantCylindrical{latₜₛ}(uconvert(u"m", x), uconvert(u"m", y))
+EquidistantCylindrical{latₜₛ}(x::Number, y::Number) where {latₜₛ} =
+  EquidistantCylindrical{latₜₛ}(addunit(x, u"m"), addunit(y, u"m"))
 
 """
     PlateCarree(x, y)
@@ -32,12 +32,12 @@ PlateCarree(1.0u"m", 1.0u"m")
 
 See [EPSG:32662](https://epsg.io/32662).
 """
-const PlateCarree = EquidistantCylindrical{EPSG{32662},0.0u"°"}
+const PlateCarree = EquidistantCylindrical{0.0u"°"}
 
 typealias(::Type{EPSG{32662}}) = PlateCarree
 
-function Base.convert(::Type{EquidistantCylindrical{ID,latₜₛ}}, coords::LatLon) where {ID,latₜₛ}
-  🌎 = ellipsoid(EquidistantCylindrical{ID,latₜₛ})
+function Base.convert(::Type{EquidistantCylindrical{latₜₛ}}, coords::LatLon) where {latₜₛ}
+  🌎 = ellipsoid(EquidistantCylindrical{latₜₛ})
   λ = deg2rad(coords.lon)
   ϕ = deg2rad(coords.lat)
   ϕₜₛ = oftype(ϕ, deg2rad(latₜₛ))
@@ -48,10 +48,10 @@ function Base.convert(::Type{EquidistantCylindrical{ID,latₜₛ}}, coords::LatL
   x = a * l * cos(ϕₜₛ)
   y = a * o
 
-  EquidistantCylindrical{ID,latₜₛ}(x * u"m", y * u"m")
+  EquidistantCylindrical{latₜₛ}(x * u"m", y * u"m")
 end
 
-function Base.convert(::Type{LatLon}, coords::EquidistantCylindrical{ID,latₜₛ}) where {ID,latₜₛ}
+function Base.convert(::Type{LatLon}, coords::EquidistantCylindrical{latₜₛ}) where {latₜₛ}
   🌎 = ellipsoid(coords)
   x = coords.x
   y = coords.y

--- a/src/crs/latlon.jl
+++ b/src/crs/latlon.jl
@@ -18,7 +18,7 @@ LatLon(45.0u"°", 45.0u"°")
 
 See [EPSG:4326](https://epsg.io/4326).
 """
-const LatLon{D<:Deg} = CRS{EPSG{4326},@NamedTuple{lat::D, lon::D},WGS84,NoParams}
+const LatLon{D<:Deg} = CRS{:LatLon,@NamedTuple{lat::D, lon::D},WGS84,NoParams}
 
 typealias(::Type{EPSG{4326}}) = LatLon
 

--- a/src/crs/mercator.jl
+++ b/src/crs/mercator.jl
@@ -18,7 +18,7 @@ Mercator(1.0u"m", 1.0u"m")
 
 See [EPSG:3395](https://epsg.io/3395).
 """
-const Mercator{M<:Met} = CRS{EPSG{3395},@NamedTuple{x::M, y::M},WGS84,NoParams}
+const Mercator{M<:Met} = CRS{:Mercator,@NamedTuple{x::M, y::M},WGS84,NoParams}
 
 typealias(::Type{EPSG{3395}}) = Mercator
 

--- a/src/crs/webmercator.jl
+++ b/src/crs/webmercator.jl
@@ -18,7 +18,7 @@ WebMercator(1.0u"m", 1.0u"m")
 
 See [EPSG:3857](https://epsg.io/3857).
 """
-const WebMercator{M<:Met} = CRS{EPSG{3857},@NamedTuple{x::M, y::M},WGS84,NoParams}
+const WebMercator{M<:Met} = CRS{:WebMercator,@NamedTuple{x::M, y::M},WGS84,NoParams}
 
 typealias(::Type{EPSG{3857}}) = WebMercator
 

--- a/src/crs/winkeltripel.jl
+++ b/src/crs/winkeltripel.jl
@@ -2,12 +2,12 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-const Winkel{ID,lat₁,M<:Met} = CRS{ID,@NamedTuple{x::M, y::M},WIII,lat₁}
+const Winkel{lat₁,M<:Met} = CRS{:Winkel,@NamedTuple{x::M, y::M},WIII,lat₁}
 
-Winkel{ID,lat₁}(x::M, y::M) where {ID,lat₁,M<:Met} = Winkel{ID,lat₁,float(M)}(x, y)
-Winkel{ID,lat₁}(x::Met, y::Met) where {ID,lat₁} = Winkel{ID,lat₁}(promote(x, y)...)
-Winkel{ID,lat₁}(x::Len, y::Len) where {ID,lat₁} = Winkel{ID,lat₁}(uconvert(u"m", x), uconvert(u"m", y))
-Winkel{ID,lat₁}(x::Number, y::Number) where {ID,lat₁} = Winkel{ID,lat₁}(addunit(x, u"m"), addunit(y, u"m"))
+Winkel{lat₁}(x::M, y::M) where {lat₁,M<:Met} = Winkel{lat₁,float(M)}(x, y)
+Winkel{lat₁}(x::Met, y::Met) where {lat₁} = Winkel{lat₁}(promote(x, y)...)
+Winkel{lat₁}(x::Len, y::Len) where {lat₁} = Winkel{lat₁}(uconvert(u"m", x), uconvert(u"m", y))
+Winkel{lat₁}(x::Number, y::Number) where {lat₁} = Winkel{lat₁}(addunit(x, u"m"), addunit(y, u"m"))
 
 """
     WinkelTripel(x, y)
@@ -23,9 +23,9 @@ WinkelTripel(1.0u"km", 1.0u"km") # length quantities are converted to meters
 WinkelTripel(1.0u"m", 1.0u"m")
 ```
 
-See [ESRI:3395](https://epsg.io/53042).
+See [ESRI:53042](https://epsg.io/53042).
 """
-const WinkelTripel = Winkel{ESRI{53042},50.467u"°"}
+const WinkelTripel = Winkel{50.467u"°"}
 
 typealias(::Type{ESRI{53042}}) = WinkelTripel
 
@@ -33,8 +33,8 @@ typealias(::Type{ESRI{53042}}) = WinkelTripel
 # CONVERSIONS
 # ------------
 
-function Base.convert(::Type{Winkel{ID,lat₁}}, coords::LatLon) where {ID,lat₁}
-  🌎 = ellipsoid(Winkel{ID,lat₁})
+function Base.convert(::Type{Winkel{lat₁}}, coords::LatLon) where {lat₁}
+  🌎 = ellipsoid(Winkel{lat₁})
   λ = deg2rad(coords.lon)
   ϕ = deg2rad(coords.lat)
   ϕ₁ = oftype(ϕ, deg2rad(lat₁))
@@ -45,5 +45,5 @@ function Base.convert(::Type{Winkel{ID,lat₁}}, coords::LatLon) where {ID,lat�
   sincα = sin(α) / α # unnormalized sinc
   x = a / 2 * (l * cos(ϕ₁) + (2cos(ϕ) * sin(λ / 2)) / sincα)
   y = a / 2 * (o + sin(ϕ) / sincα)
-  Winkel{ID,lat₁}(x * u"m", y * u"m")
+  Winkel{lat₁}(x * u"m", y * u"m")
 end

--- a/test/crs.jl
+++ b/test/crs.jl
@@ -461,7 +461,7 @@
       c2 = convert(Mercator, c1)
       @test c2 ≈ Mercator(-T(10018754.171394622), -T(5591295.9185533915))
 
-      # EPSG fallback
+      # EPSG/ESRI fallback
       c1 = LatLon(T(45), T(90))
       c2 = convert(EPSG{3395}, c1)
       @test c2 ≈ Mercator(T(10018754.171394622), T(5591295.9185533915))
@@ -497,7 +497,7 @@
       c3 = convert(LatLon, c2)
       @test c3 ≈ c1
 
-      # EPSG fallback
+      # EPSG/ESRI fallback
       c1 = LatLon(T(45), T(90))
       c2 = convert(EPSG{3857}, c1)
       @test c2 ≈ WebMercator(T(10018754.171394622), T(5621521.486192066))
@@ -538,7 +538,7 @@
       c3 = convert(LatLon, c2)
       @test c3 ≈ c1
 
-      # EPSG fallback
+      # EPSG/ESRI fallback
       c1 = LatLon(T(45), T(90))
       c2 = convert(EPSG{32662}, c1)
       @test c2 ≈ PlateCarree(T(10018754.171394622), T(5009377.085697311))
@@ -552,6 +552,62 @@
       @inferred convert(LatLon, c2)
       @inferred convert(EPSG{32662}, c1)
       @inferred convert(EPSG{4326}, c2)
+    end
+
+    @testset "LatLon <> Lambert" begin
+      c1 = LatLon(T(45), T(90))
+      c2 = convert(Lambert, c1)
+      @test c2 ≈ Lambert(T(10018754.171394622), T(4489858.8869480025))
+
+      c1 = LatLon(-T(45), T(90))
+      c2 = convert(Lambert, c1)
+      @test c2 ≈ Lambert(T(10018754.171394622), -T(4489858.8869480025))
+
+      c1 = LatLon(T(45), -T(90))
+      c2 = convert(Lambert, c1)
+      @test c2 ≈ Lambert(-T(10018754.171394622), T(4489858.8869480025))
+
+      c1 = LatLon(-T(45), -T(90))
+      c2 = convert(Lambert, c1)
+      @test c2 ≈ Lambert(-T(10018754.171394622), -T(4489858.8869480025))
+
+      # EPSG/ESRI fallback
+      c1 = LatLon(T(45), T(90))
+      c2 = convert(ESRI{54034}, c1)
+      @test c2 ≈ Lambert(T(10018754.171394622), T(4489858.8869480025))
+
+      # type stability
+      c1 = LatLon(T(45), T(90))
+      @inferred convert(Lambert, c1)
+      @inferred convert(ESRI{54034}, c1)
+    end
+
+    @testset "LatLon <> Behrmann" begin
+      c1 = LatLon(T(45), T(90))
+      c2 = convert(Behrmann, c1)
+      @test c2 ≈ Behrmann(T(8683765.222580686), T(5180102.328839251))
+
+      c1 = LatLon(-T(45), T(90))
+      c2 = convert(Behrmann, c1)
+      @test c2 ≈ Behrmann(T(8683765.222580686), -T(5180102.328839251))
+
+      c1 = LatLon(T(45), -T(90))
+      c2 = convert(Behrmann, c1)
+      @test c2 ≈ Behrmann(-T(8683765.222580686), T(5180102.328839251))
+
+      c1 = LatLon(-T(45), -T(90))
+      c2 = convert(Behrmann, c1)
+      @test c2 ≈ Behrmann(-T(8683765.222580686), -T(5180102.328839251))
+
+      # EPSG/ESRI fallback
+      c1 = LatLon(T(45), T(90))
+      c2 = convert(ESRI{54017}, c1)
+      @test c2 ≈ Behrmann(T(8683765.222580686), T(5180102.328839251))
+
+      # type stability
+      c1 = LatLon(T(45), T(90))
+      @inferred convert(Behrmann, c1)
+      @inferred convert(ESRI{54017}, c1)
     end
 
     @testset "LatLon <> WinkelTripel" begin
@@ -571,7 +627,7 @@
       c2 = convert(WinkelTripel, c1)
       @test c2 ≈ WinkelTripel(-T(7036918.714302972), -T(5225594.172156317))
 
-      # EPSG fallback
+      # EPSG/ESRI fallback
       c1 = LatLon(T(45), T(90))
       c2 = convert(ESRI{53042}, c1)
       @test c2 ≈ WinkelTripel(T(7036918.714302972), T(5225594.172156317))


### PR DESCRIPTION
This PR adds two projections derived from Equal Area Cylindrical:
* Lambert cylindrical equal-area (`lat_ts = 0°`)
* Behrmann (`lat_ts = 30°`)