### PR TITLE
Use the `sinc` function in `WinkelTripel` formula

### DIFF
--- a/src/crs/winkeltripel.jl
+++ b/src/crs/winkeltripel.jl
@@ -41,9 +41,12 @@ function Base.convert(::Type{Winkel{lat₁}}, coords::LatLon) where {lat₁}
   l = ustrip(λ)
   o = ustrip(ϕ)
   a = oftype(l, ustrip(majoraxis(🌎)))
+
   α = acos(cos(ϕ) * cos(λ / 2))
-  sincα = sin(α) / α # unnormalized sinc
+  sincα = sinc(α / π) # unnormalized sinc
+
   x = a / 2 * (l * cos(ϕ₁) + (2cos(ϕ) * sin(λ / 2)) / sincα)
   y = a / 2 * (o + sin(ϕ) / sincα)
+
   Winkel{lat₁}(x * u"m", y * u"m")
 end

--- a/test/crs.jl
+++ b/test/crs.jl
@@ -627,6 +627,10 @@
       c2 = convert(WinkelTripel, c1)
       @test c2 ≈ WinkelTripel(-T(7044801.6979576545), -T(5231448.051548355))
 
+      c1 = LatLon(T(0), T(0))
+      c2 = convert(WinkelTripel, c1)
+      @test c2 ≈ WinkelTripel(T(0), T(0))
+
       # EPSG/ESRI fallback
       c1 = LatLon(T(45), T(90))
       c2 = convert(ESRI{54042}, c1)


### PR DESCRIPTION
This change fixes the case where latitude and longitude are equal to zero.
master:
```
julia> c = LatLon(0, 0)
LatLon coordinates
├─ lat: 0.0°
└─ lon: 0.0°

julia> convert(WinkelTripel, c)
WinkelTripel coordinates
├─ x: NaN m
└─ y: NaN m
```
PR:
```
julia> c = LatLon(0, 0)
LatLon coordinates
├─ lat: 0.0°
└─ lon: 0.0°

julia> convert(WinkelTripel, c)
WinkelTripel coordinates
├─ x: 0.0 m
└─ y: 0.0 m
```