### PR TITLE
Refactor `Vec` constructors

### DIFF
--- a/test/vectors.jl
+++ b/test/vectors.jl
@@ -38,7 +38,7 @@
   @test Vec{2,T}((-1.0, -2)) == Vec{2,T}((-1, -2.0))
   @test Vec{4,T}((0, -1.0, +2, -4.0)) == Vec{4,T}((0.0f0, -1.0f0, +2.0f0, -4.0f0))
 
-  # Integer coordinates converted to Float64
+  # integer coordinates are converted to float
   @test eltype(Vec(1)) == Float64
   @test eltype(Vec(1, 2)) == Float64
   @test eltype(Vec(1, 2, 3)) == Float64
@@ -60,7 +60,9 @@
   # throws
   @test_throws DimensionMismatch Vec{2,T}(1)
   @test_throws DimensionMismatch Vec{3,T}((2, 3))
+  @test_throws DimensionMismatch Vec{3,T}([2, 3])
   @test_throws DimensionMismatch Vec{-3,T}((4, 5, 6))
+  @test_throws DimensionMismatch Vec{-3,T}([4, 5, 6])
 
   # angles between 2D vectors
   @test ∠(V2(1, 0), V2(0, 1)) ≈ T(π / 2)


### PR DESCRIPTION
Now, parametric constructors only allow subtypes of `AbstractFloat` and `Quantity{<:AbstractFloat}`:
```
julia> Vec{3,Int}(1, 2, 3)
ERROR: TypeError: in Vec, in T, expected T<:Union{AbstractFloat, Quantity{<:AbstractFloat}}, got Type{Int64}
Stacktrace:
 [1] top-level scope
   @ REPL[12]:1
```
And now, only numbers are allowed in non-parametric constructors.