### PR TITLE
Utilities for Simplex type.

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -14,7 +14,7 @@ using Random
 using Bessels: gamma
 using Unitful: AbstractQuantity, numtype
 using StatsBase: AbstractWeights, Weights, quantile
-using Distances: PreMetric, Euclidean, Mahalanobis, evaluate
+using Distances: PreMetric, SqEuclidean, Euclidean, Mahalanobis, evaluate, pairwise
 using Rotations: Rotation, QuatRotation, Angle2d, rotation_between
 using NearestNeighbors: KDTree, BallTree, knn, inrange
 using Transducers: Filter, Map, TakeWhile, tcollect, ⨟

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -83,8 +83,14 @@ function measure(t::Tetrahedron)
   abs((A - D) ⋅ ((B - D) × (C - D))) / 6
 end
 
-"Compute the measure (i.e. hyper-volume) for a simplex in any dimension using the Cayley-Menger Determinant."
+"""
+    measure(splx::Simplex)
+
+Compute the measure (i.e. hyper-volume) for a simplex in any dimension using the Cayley-Menger Determinant.
+"""
 function measure(splx::Simplex{K,Dim,T,N}) where {K,Dim,T<:Real,N}
+  # Find the equation e.g. at
+  # https://en.wikipedia.org/wiki/Cayley%E2%80%93Menger_determinant#Definition.
   Ds_ = pairwise(SqEuclidean(), coordinates.(vertices(splx)))
   Ds = [
     Ds_ ones(size(Ds_, 1))

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -89,15 +89,14 @@ end
 Compute the measure (i.e. hyper-volume) for a simplex in any dimension using the Cayley-Menger Determinant.
 """
 function measure(splx::Simplex{K,Dim,T,N}) where {K,Dim,T<:Real,N}
-  # Find the equation e.g. at
   # https://en.wikipedia.org/wiki/Cayley%E2%80%93Menger_determinant#Definition.
-  Ds_ = pairwise(SqEuclidean(), coordinates.(vertices(splx)))
-  Ds = [
-    Ds_ ones(size(Ds_, 1))
-    ones(size(Ds_, 2))' 0
+  dists = pairwise(SqEuclidean(), coordinates.(vertices(splx)))
+  mat = [
+    dists ones(size(dists, 1))
+    ones(size(dists, 2))' 0
   ]
   factor = (-1)^(K + 1) / (factorial(K)^2 * 2^K)
-  return sqrt(factor * det(Ds))
+  sqrt(factor * det(mat))
 end
 
 measure(c::Chain) = sum(measure, segments(c))

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -83,11 +83,6 @@ function measure(t::Tetrahedron)
   abs((A - D) ⋅ ((B - D) × (C - D))) / 6
 end
 
-"""
-    measure(splx::Simplex)
-
-Compute the measure (i.e. hyper-volume) for a simplex in any dimension using the Cayley-Menger Determinant.
-"""
 function measure(splx::Simplex{K,Dim,T,N}) where {K,Dim,T<:Real,N}
   # https://en.wikipedia.org/wiki/Cayley%E2%80%93Menger_determinant#Definition.
   dists = pairwise(SqEuclidean(), coordinates.(vertices(splx)))

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -83,6 +83,17 @@ function measure(t::Tetrahedron)
   abs((A - D) ⋅ ((B - D) × (C - D))) / 6
 end
 
+"Compute the measure (i.e. hyper-volume) for a simplex in any dimension using the Cayley-Menger Determinant."
+function measure(splx::Simplex{K,Dim,T,N}) where {K,Dim,T<:Real,N}
+  Ds_ = pairwise(SqEuclidean(), coordinates.(vertices(splx)))
+  Ds = [
+    Ds_ ones(size(Ds_, 1))
+    ones(size(Ds_, 2))' 0
+  ]
+  factor = (-1)^(K + 1) / (factorial(K)^2 * 2^K)
+  return sqrt(factor * det(Ds))
+end
+
 measure(c::Chain) = sum(measure, segments(c))
 
 measure(g::Geometry) = sum(measure, simplexify(g))

--- a/src/polytopes/simplex.jl
+++ b/src/polytopes/simplex.jl
@@ -37,3 +37,17 @@ nvertices(::Type{<:Simplex{K}}) where {K} = K + 1
 
 Base.isapprox(s₁::Simplex, s₂::Simplex; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(vertices(s₁), vertices(s₂)))
+
+"Compute normal vector to simplex with euclidean norm of 1."
+function normal(splx::Simplex{K,Dim,T}) where {K,Dim,T<:Real}
+  Dim > K || throw(
+    ArgumentError("simplex embedding dimension must be larger than parametric dimension for a normal vector to exist")
+  )
+  # It turns out the QR decomposition can be used to find an orthogonal basis,
+  # where by construction the nth column of `Q` is orthogonal to columns 1:(n-1).
+  # Further, `qr` guarantees `Q` to be unitary, therefore `norm(Q[:, i]) ≈ 1` for all columns.
+  p0, pothers... = vertices(splx)
+  extendedbasis = [(p - p0 for p in pothers)... rand!(similar(coordinates(p0)))]
+  normal = qr(extendedbasis).Q[:, end]
+  return normal
+end

--- a/src/polytopes/simplex.jl
+++ b/src/polytopes/simplex.jl
@@ -50,8 +50,8 @@ function normal(splx::Simplex{K,Dim,T}) where {K,Dim,T<:Real}
   # It turns out the QR decomposition can be used to find an orthogonal basis,
   # where by construction the nth column of `Q` is orthogonal to columns 1:(n-1).
   # Further, `qr` guarantees `Q` to be unitary, therefore `norm(Q[:, i]) ≈ 1` for all columns.
-  p0, pothers... = vertices(splx)
-  extendedbasis = [(p - p0 for p in pothers)... rand!(similar(coordinates(p0)))]
-  normal = qr(extendedbasis).Q[:, end]
-  return normal
+  p1, pothers... = vertices(splx)
+  basis = [(p - p1 for p in pothers)... rand!(similar(coordinates(p1)))]
+  normal = qr(basis).Q[:, end]
+  normal
 end

--- a/src/polytopes/simplex.jl
+++ b/src/polytopes/simplex.jl
@@ -46,7 +46,7 @@ function normal(splx::Simplex{K,Dim,T}) where {K,Dim,T<:Real}
   # where by construction the nth column of `Q` is orthogonal to columns 1:(n-1).
   # Further, `qr` guarantees `Q` to be unitary, therefore `norm(Q[:, i]) ≈ 1` for all columns.
   p1, pothers... = vertices(splx)
-  basis = [(p - p1 for p in pothers)... rand!(similar(coordinates(p1)))]
+  basis = [stack(pothers .- [p1]; dims=2) rand!(similar(coordinates(p1)))]
   normal = qr(basis).Q[:, end]
   normal
 end

--- a/src/polytopes/simplex.jl
+++ b/src/polytopes/simplex.jl
@@ -38,7 +38,11 @@ nvertices(::Type{<:Simplex{K}}) where {K} = K + 1
 Base.isapprox(s₁::Simplex, s₂::Simplex; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(vertices(s₁), vertices(s₂)))
 
-"Compute normal vector to simplex with euclidean norm of 1."
+"""
+    normal(splx::Simplex)
+
+Compute normal vector to simplex with euclidean norm of 1.
+"""
 function normal(splx::Simplex{K,Dim,T}) where {K,Dim,T<:Real}
   Dim > K || throw(
     ArgumentError("simplex embedding dimension must be larger than parametric dimension for a normal vector to exist")

--- a/src/polytopes/simplex.jl
+++ b/src/polytopes/simplex.jl
@@ -38,11 +38,6 @@ nvertices(::Type{<:Simplex{K}}) where {K} = K + 1
 Base.isapprox(s₁::Simplex, s₂::Simplex; kwargs...) =
   all(isapprox(v₁, v₂; kwargs...) for (v₁, v₂) in zip(vertices(s₁), vertices(s₂)))
 
-"""
-    normal(splx::Simplex)
-
-Compute normal vector to simplex with euclidean norm of 1.
-"""
 function normal(splx::Simplex{K,Dim,T}) where {K,Dim,T<:Real}
   Dim > K || throw(
     ArgumentError("simplex embedding dimension must be larger than parametric dimension for a normal vector to exist")

--- a/src/predicates/in.jl
+++ b/src/predicates/in.jl
@@ -173,3 +173,25 @@ Base.in(p::Point, m::Multi) = any(g -> p ∈ g, parent(m))
 Tells whether or not the `point` is in the `domain`.
 """
 Base.in(p::Point, d::Domain) = any(e -> p ∈ e, d)
+
+
+"""
+    point ∈ simplex
+
+Tells whether or not the `point` is in the `simplex`.
+Both must be embedded in the same dimension.
+Currently requires the simplex to have "full" parametric dimension, e.g. a triangle embedded in a plane.
+"""
+function Base.in(p::Point{Dim}, splx::Simplex{K,Dim}) where {K,Dim}
+  paramdim(splx) == Dim || throw(ArgumentError("simplex containment is only defined when the parametric dimension and the embedding dimension are the same"))
+  verts = vertices(splx)
+  ax = eachindex(verts)
+  faces = map(ax) do i
+    Simplex{K-1}(verts[ax .!= i]...)
+  end
+
+  p0 = centroid(splx)
+  all(faces) do face
+    sideof(p0, face) == sideof(p, face)
+  end
+end

--- a/src/predicates/in.jl
+++ b/src/predicates/in.jl
@@ -176,11 +176,11 @@ Base.in(p::Point, d::Domain) = any(e -> p ∈ e, d)
 
 
 """
-    point ∈ simplex
+    Base.in(p::Point{Dim}, splx::Simplex{K,Dim})
 
-Tells whether or not the `point` is in the `simplex`.
-Both must be embedded in the same dimension.
-Currently requires the simplex to have "full" parametric dimension, e.g. a triangle embedded in a plane.
+Tells whether or not the point `p` is contained in the Simplex `splx`.
+Both must be embedded in the same dimension. Currently requires the simplex to have "full"
+parametric dimension, e.g. a triangle embedded in a plane.
 """
 function Base.in(p::Point{Dim}, splx::Simplex{K,Dim}) where {K,Dim}
   paramdim(splx) == Dim || throw(ArgumentError("simplex containment is only defined when the parametric dimension and the embedding dimension are the same"))

--- a/src/predicates/in.jl
+++ b/src/predicates/in.jl
@@ -175,13 +175,6 @@ Tells whether or not the `point` is in the `domain`.
 Base.in(p::Point, d::Domain) = any(e -> p ∈ e, d)
 
 
-"""
-    Base.in(p::Point{Dim}, splx::Simplex{K,Dim})
-
-Tells whether or not the point `p` is contained in the Simplex `splx`.
-Both must be embedded in the same dimension. Currently requires the simplex to have "full"
-parametric dimension, e.g. a triangle embedded in a plane.
-"""
 function Base.in(p::Point{Dim}, splx::Simplex{K,Dim}) where {K,Dim}
   paramdim(splx) == Dim || throw(ArgumentError("simplex containment is only defined when the parametric dimension and the embedding dimension are the same"))
   verts = vertices(splx)

--- a/src/sideof.jl
+++ b/src/sideof.jl
@@ -55,22 +55,6 @@ function sideof(point::Point{2,T}, ring::Ring{2,T}) where {T}
   ifelse(isapprox(w, zero(T), atol=atol(T)), OUT, IN)
 end
 
-# -----
-# MESH
-# -----
-
-"""
-    sideof(point, mesh)
-
-Determines on which side the `point` is in relation to the surface `mesh`.
-Possible results are `IN` or `OUT` the `mesh`.
-"""
-sideof(point::Point{3}, mesh::Mesh{3}) = sideof((point,), mesh) |> first
-
-# -----
-# K-SIMPLEX
-# -----
-
 """
     sideof(point, simplex)
 
@@ -82,6 +66,18 @@ function sideof(point::Point{Dim}, splx::Simplex{K,Dim}) where {K,Dim}
   Dim == (K + 1) || throw(ArgumentError("`sideof` is only defined for `paramdim(splx)+1==Dim`"))
   ifelse(signbit(normal(splx)' * (centroid(splx) - point)), LEFT, RIGHT)
 end
+
+# -----
+# MESH
+# -----
+
+"""
+    sideof(point, mesh)
+
+Determines on which side the `point` is in relation to the surface `mesh`.
+Possible results are `IN` or `OUT` the `mesh`.
+"""
+sideof(point::Point{3}, mesh::Mesh{3}) = sideof((point,), mesh) |> first
 
 # ----------
 # FALLBACKS

--- a/src/sideof.jl
+++ b/src/sideof.jl
@@ -67,6 +67,22 @@ Possible results are `IN` or `OUT` the `mesh`.
 """
 sideof(point::Point{3}, mesh::Mesh{3}) = sideof((point,), mesh) |> first
 
+# -----
+# K-SIMPLEX
+# -----
+
+"""
+    sideof(point, simplex)
+
+Determines on which side the `point` is in relation to a k-simplex.
+Possible results are `LEFT` or `RIGHT`, although they are only useful for
+comparison, not for geometrical interpretation.
+"""
+function sideof(point::Point{Dim}, splx::Simplex{K,Dim}) where {K,Dim}
+  Dim == (K + 1) || throw(ArgumentError("`sideof` is only defined for `paramdim(splx)+1==Dim`"))
+  ifelse(signbit(normal(splx)' * (centroid(splx) - point)), LEFT, RIGHT)
+end
+
 # ----------
 # FALLBACKS
 # ----------

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -947,5 +947,21 @@
     # compare against Tetrahedon
     pts = [P3(rand(3)) for _ in 1:4]
     @test measure(Simplex(pts...)) ≈ measure(Tetrahedron(pts...))
+
+    # normal
+    let Dim = 4, N = 4
+      splx = Simplex(ntuple(i -> Point{Dim,T}(rand(T, Dim)), N))
+      n = normal(splx)
+      v0, vothers... = vertices(splx)
+      for v in vothers
+        @test (n' * (v - v0)) ≈ 0.0 atol = eps(T)
+      end
+    end
+
+    # Embedding dimension too low to construct normal vector.
+    let Dim = 3, N = 4
+      splx = Simplex(ntuple(i -> Point{Dim,T}(rand(T, Dim)), N))
+      @test_throws ArgumentError normal(splx)
+    end
   end
 end

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -963,5 +963,18 @@
       splx = Simplex(ntuple(i -> Point{Dim,T}(rand(T, Dim)), N))
       @test_throws ArgumentError normal(splx)
     end
+
+    # containment
+    let Dim = 3, N = 4
+      splx = Simplex(ntuple(i -> Point{Dim,T}(rand(T, Dim)), N))
+      @test centroid(splx) ∈ splx
+      @test all((v + sqrt(eps(T)) * (centroid(splx) - v)) ∈ splx for v in vertices(splx))
+      @test .!any((v + sqrt(eps(T)) * (v - centroid(splx))) ∈ splx for v in vertices(splx))
+    end
+    # Simplex containment is not defined for these dimensions.
+    let Dim = 4, N = 4
+      splx = Simplex(ntuple(i -> Point{Dim,T}(rand(T, Dim)), N))
+      @test_throws ArgumentError centroid(splx) ∈ splx
+    end
   end
 end

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -934,5 +934,18 @@
       ├─ Point(0.0, 1.0, 0.0)
       └─ Point(0.0, 0.0, 1.0)"""
     end
+
+    # measure
+    # Points forming a square with the first point in the center.
+    pts = [P3(0, 0, 0), P3(-1, -1, 0), P3(-1, 1, 0), P3(1, 1, 0), P3(1, -1, 0)]
+    simplicies = connect.([(1, 2, 3), (1, 3, 4), (1, 4, 5), (1, 5, 2)], Simplex)
+    splx1 = materialize(simplicies[1], pts)
+    @test measure(splx1) ≈ 1.0
+    splx2 = materialize(connect((2, 3, 5), Simplex), pts)
+    @test measure(splx2) ≈ 2.0
+
+    # compare against Tetrahedon
+    pts = [P3(rand(3)) for _ in 1:4]
+    @test measure(Simplex(pts...)) ≈ measure(Tetrahedron(pts...))
   end
 end

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -938,10 +938,9 @@
     # measure
     # Points forming a square with the first point in the center.
     pts = [P3(0, 0, 0), P3(-1, -1, 0), P3(-1, 1, 0), P3(1, 1, 0), P3(1, -1, 0)]
-    simplicies = connect.([(1, 2, 3), (1, 3, 4), (1, 4, 5), (1, 5, 2)], Simplex)
-    splx1 = materialize(simplicies[1], pts)
+    splx1 = Simplex(pts[1], pts[2], pts[3])
     @test measure(splx1) ≈ 1.0
-    splx2 = materialize(connect((2, 3, 5), Simplex), pts)
+    splx2 = Simplex(pts[2], pts[3], pts[5])
     @test measure(splx2) ≈ 2.0
 
     # compare against Tetrahedon

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -954,7 +954,7 @@
       n = normal(splx)
       v0, vothers... = vertices(splx)
       for v in vothers
-        @test (n' * (v - v0)) ≈ 0.0 atol = eps(T)
+        @test (n' * (v - v0)) ≈ 0.0 atol = sqrt(eps(T))
       end
     end
 

--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -60,4 +60,5 @@
   points = P3[(0, 0, 0), (1, 0, 0), (0, 1, 0)]
   splx = Simplex(points...)
   @test sideof(P3(0, 0, 1), splx) != sideof(P3(0, 0, -1), splx)
+  @test sideof(P3(0, 0, 1), splx) == sideof(P3(rand(3)...), splx)
 end

--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -54,4 +54,10 @@
   connec = connect.([(1, 2, 3, 4)], [Tetrahedron])
   mesh = SimpleMesh(points, connec)
   @test_throws AssertionError("winding number only defined for surface meshes") sideof(P3(0, 0, 0), mesh)
+
+  # sideof for simplex
+  # we embed a triangle in 3d space and check whether points on either side have different "sideof" value
+  points = P3[(0, 0, 0), (1, 0, 0), (0, 1, 0)]
+  splx = Simplex(points...)
+  @test sideof(P3(0, 0, 1), splx) != sideof(P3(0, 0, -1), splx)
 end


### PR DESCRIPTION
This PR should be processed after #744 and before #746.

We introduce additional functionality for the new `Simplex` data type.

In particular, we introduce
- `measure`, i.e. the hyper-volume, efficiently computed in any dimension;
- `normal`, yielding a normal vector for a simplex;
- `Base.in` allowing to check whether a point is contained in a simplex or not; and
- `sideof`, which allows us to compare whether two points are on the same side of a simplex.

Notice that `Base.in` and `sideof` are not applicable for arbitrary combinations or parametric and embedding dimension. To illustrate, consider a triangle embedded in 3d space.
It is sensible to ask whether a Point3 is on one side of the (infinitely extended) triangle, or on the other. Similarly, we can define a normal vector that is unique up to the sign.
However, it is difficult to ask whether a Point3 is contained by this triangle.

Conversely, consider now a triangle embedded in 2D space.
We can now easily define whether a Point2 is in the triangle or not; however it is not possible to find a normal vector without expanding the dimension.

More generally, `normal` is only defined if `Dim > paramdim` and is unique (up to a sign) if `Dim == paramdim+1`.
`sideof` is only defined for the latter case (due to the requirement of a unique normal vector). Finally, `Base.in` is only defined if `Dim == paramdim`

Notice that we can define `Base.in` simply by checking `sideof` for each facet (which has paramdim reduced by 1) compared to the centroid.