### PR TITLE
Fix link in dehn's docs.

### DIFF
--- a/src/discretization/dehn.jl
+++ b/src/discretization/dehn.jl
@@ -9,7 +9,7 @@ Max Dehns' triangulation proved in 1899.
 
 The algorithm is described in the first chapter of Devadoss & Rourke 2011,
 and is based on a theorem derived in 1899 by the German mathematician Max Dehn.
-See https://en.wikipedia.org/wiki/Two_ears_theorem.
+See <https://en.wikipedia.org/wiki/Two_ears_theorem>.
 
 Because the algorithm relies on recursion, it is mostly appropriate for polygons
 with small number of vertices.


### PR DESCRIPTION
The link is not clickable on the docs site, because it is formatted as markdown. Now it should be fixed.
