### PR TITLE
WIP: Implement macro for automatically defining commutative methods

### DIFF
--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -97,7 +97,6 @@ return types, Julia is able to optimize the branches of the code
 and generate specialized code. This is not the case when
 `f === identity`.
 """
-intersection(f, g₁, g₂) = intersection(f, g₂, g₁)
 intersection(g₁, g₂) = intersection(identity, g₁, g₂)
 
 # ----------------

--- a/src/intersections/domains.jl
+++ b/src/intersections/domains.jl
@@ -11,7 +11,7 @@
   end
 end
 
-@commutativef intersection(f, dom::Domain, pset::PointSet) = intersection(f, Multi(collect(dom)), pset)
+intersection(f, dom::Domain, pset::PointSet) = intersection(f, Multi(collect(dom)), pset)
 
 function intersection(f, dom₁::Domain{Dim,T}, dom₂::Domain{Dim,T}) where {Dim,T}
   # loop over all geometries

--- a/src/intersections/domains.jl
+++ b/src/intersections/domains.jl
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-function intersection(f, geom::Geometry, pset::PointSet)
+@commutativef function intersection(f, geom::Geometry, pset::PointSet)
   ps = filter(∈(geom), collect(pset))
   if isempty(ps)
     return @IT NotIntersecting nothing f
@@ -11,7 +11,7 @@ function intersection(f, geom::Geometry, pset::PointSet)
   end
 end
 
-intersection(f, dom::Domain, pset::PointSet) = intersection(f, Multi(collect(dom)), pset)
+@commutativef intersection(f, dom::Domain, pset::PointSet) = intersection(f, Multi(collect(dom)), pset)
 
 function intersection(f, dom₁::Domain{Dim,T}, dom₂::Domain{Dim,T}) where {Dim,T}
   # loop over all geometries

--- a/src/intersections/planes.jl
+++ b/src/intersections/planes.jl
@@ -26,7 +26,7 @@ end
 const LineLike{T} = Union{Line{3,T},Ray{3,T},Segment{3,T}}
 
 # (https://en.wikipedia.org/wiki/Line-plane_intersection)
-function intersection(f, line::LineLike{T}, plane::Plane{T}) where {T}
+@commutativef function intersection(f, line::LineLike{T}, plane::Plane{T}) where {T}
   # auxiliary parameters
   d = line(1) - line(0)
   n = normal(plane)

--- a/src/intersections/points.jl
+++ b/src/intersections/points.jl
@@ -5,5 +5,5 @@
 intersection(f, point₁::Point, point₂::Point) =
   point₁ == point₂ ? (@IT Intersecting point₁ f) : (@IT NotIntersecting nothing f)
 
-intersection(f, point::Point, geom::Geometry) =
+@commutativef intersection(f, point::Point, geom::Geometry) =
   point ∈ geom ? (@IT Intersecting point f) : (@IT NotIntersecting nothing f)

--- a/src/intersections/polygons.jl
+++ b/src/intersections/polygons.jl
@@ -19,4 +19,4 @@ function intersection(f, poly₁::Polygon, poly₂::Polygon)
   end
 end
 
-intersection(f, poly::Polygon{2}, box::Box{2}) = intersection(f, poly, convert(Quadrangle, box))
+@commutativef intersection(f, poly::Polygon{2}, box::Box{2}) = intersection(f, poly, convert(Quadrangle, box))

--- a/src/intersections/rays.jl
+++ b/src/intersections/rays.jl
@@ -69,7 +69,7 @@ end
 # 2. intersect at origin of ray (Touching -> Point)
 # 3. overlap of line and ray (Overlapping -> Ray)
 # 4. do not overlap nor intersect (NotIntersecting -> Nothing)
-function intersection(f, ray::Ray{N,T}, line::Line{N,T}) where {N,T}
+@commutativef function intersection(f, ray::Ray{N,T}, line::Line{N,T}) where {N,T}
   a, b = ray(0), ray(1)
   c, d = line(0), line(1)
 
@@ -97,7 +97,7 @@ end
 
 # Williams A, Barrus S, Morley R K, et al., 2005.
 # (https://dl.acm.org/doi/abs/10.1145/1198555.1198748)
-function intersection(f, ray::Ray{Dim,T}, box::Box{Dim,T}) where {Dim,T}
+@commutativef function intersection(f, ray::Ray{Dim,T}, box::Box{Dim,T}) where {Dim,T}
   invdir = one(T) ./ (ray(1) - ray(0))
   lo, up = coordinates.(extrema(box))
   orig = coordinates(ray(0))
@@ -138,7 +138,7 @@ end
 #
 # Möller, T. & Trumbore, B., 1997.
 # (https://www.tandfonline.com/doi/abs/10.1080/10867651.1997.10487468)
-function intersection(f, ray::Ray{3,T}, tri::Triangle{3,T}) where {T}
+@commutativef function intersection(f, ray::Ray{3,T}, tri::Triangle{3,T}) where {T}
   vs = vertices(tri)
   o = ray(0)
   d = ray(1) - ray(0)
@@ -205,4 +205,4 @@ function intersection(f, ray::Ray{3,T}, tri::Triangle{3,T}) where {T}
   return @IT Crossing ray(λ) f
 end
 
-intersection(f, ray::Ray, p::Polygon) = intersection(f, GeometrySet([ray]), simplexify(p))
+@commutativef intersection(f, ray::Ray, p::Polygon) = intersection(f, GeometrySet([ray]), simplexify(p))

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -104,7 +104,7 @@ end
 # 3. intersects at one end point of segment and origin of ray (CornerTouching -> Point)
 # 4. overlap at more than one point (Overlapping -> Segment)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
-function intersection(f, seg::Segment{N,T}, ray::Ray{N,T}) where {N,T}
+@commutativef function intersection(f, seg::Segment{N,T}, ray::Ray{N,T}) where {N,T}
   a, b = ray(0), ray(1)
   c, d = seg(0), seg(1)
 
@@ -172,7 +172,7 @@ end
 # 2. intersect at an end point of segment (Touching -> Point)
 # 3. overlap of line and segment (Overlapping -> Segment)
 # 4. do not overlap nor intersect (NotIntersecting -> Nothing)
-function intersection(f, seg::Segment{N,T}, line::Line{N,T}) where {N,T}
+@commutativef function intersection(f, seg::Segment{N,T}, line::Line{N,T}) where {N,T}
   a, b = line(0), line(1)
   c, d = seg(0), seg(1)
 
@@ -203,7 +203,7 @@ end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.
 # (https://www.sciencedirect.com/science/article/pii/S0925772109001448?via%3Dihub)
-function intersection(f, seg::Segment{3,T}, tri::Triangle{3,T}) where {T}
+@commutativef function intersection(f, seg::Segment{3,T}, tri::Triangle{3,T}) where {T}
   Q1, Q2 = vertices(seg)
   V1, V2, V3 = vertices(tri)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -143,26 +143,34 @@ For an `expression` that defines a function or method with arguments (a::A, b::B
 automatically generate an additional method definition with arguments (b::B, a::A).
 """
 macro commutative(expr)
-  # TODO update to reflect changes in @commutativef for where keyword
-  # If expr is a regular or generic function definition
-  if (expr.head == :function) || (expr.head == :(=))
+  # expr must be a regular or generic function/method definition
+  if (expr.head != :function) && (expr.head != :(=))
+    error("@commutative only applies to function and method definitions.")
+  end
+
+  # Create a new function definition whose arguments are swapped
+  if expr.args[1].head == :where
+    # Usage of the parametric `where` introduces an extra layer of expression nesting
+    if (expr.args[1].args[1].head != :call) || (length(expr.args[1].args[1].args) != 3)
+      error("@commutative operates on a function with exactly two arguments")
+    end
+    expr_commuted = deepcopy(expr)
+    expr_commuted.args[1].args[1].args[2] = expr.args[1].args[1].args[3]
+    expr_commuted.args[1].args[1].args[3] = expr.args[1].args[1].args[2]
+  else
     if (expr.args[1].head != :call) || (length(expr.args[1].args) != 3)
       error("@commutative operates on a function with exactly two arguments")
     end
-
-    # Create a new function definition whose arguments are swapped
     expr_commuted = deepcopy(expr)
     expr_commuted.args[1].args[2] = expr.args[1].args[3]
     expr_commuted.args[1].args[3] = expr.args[1].args[2]
-
-    # Define regular and commuted methods
-    return :(begin
-              $(esc(expr))
-              $(esc(expr_commuted))
-            end)
-  else
-    error("@commutative only applies to function and method definitions.")
   end
+
+  # Define the regular and commuted methods
+  return :(begin
+            $(esc(expr))
+            $(esc(expr_commuted))
+          end)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -137,6 +137,25 @@ function intersectparameters(a::Point{Dim,T}, b::Point{Dim,T}, c::Point{Dim,T}, 
 end
 
 """
+    XYZ(xyz)
+
+Generate the coordinate arrays `XYZ` from the coordinate vectors `xyz`.
+"""
+@generated function XYZ(xyz::NTuple{Dim,<:AbstractVector{T}}) where {Dim,T}
+  exprs = ntuple(Dim) do d
+    quote
+      a = xyz[$d]
+      A = Array{T,Dim}(undef, length.(xyz))
+      @nloops $Dim i A begin
+        @nref($Dim, A, i) = a[$(Symbol(:i_, d))]
+      end
+      A
+    end
+  end
+  Expr(:tuple, exprs...)
+end
+
+"""
   @commutative(expr)
 
 For an `expression` that defines a function or method with arguments (a::A, b::B),


### PR DESCRIPTION
This change would eliminate the generic argument-switching method that causes `StackOverflow`s to occur for non-implemented methods.