### PR TITLE
Export and document inverse function for transforms

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -14,6 +14,13 @@ GeometricTransform
 CoordinateTransform
 ```
 
+Inverse transforms that are `isinvertible` can be computed with the `inverse` function
+(reexported by Meshes.jl).
+
+```@docs
+inverse
+```
+
 ## Rotate
 
 ```@docs

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -14,11 +14,12 @@ GeometricTransform
 CoordinateTransform
 ```
 
-Inverse transforms that are `isinvertible` can be computed with the `inverse` function
-(reexported by Meshes.jl).
+Some transforms have an inverse that can be created with the [`inverse`](@ref) function.
+The function [`isinvertible`](@ref) can be used to check if a transform is invertible.
 
 ```@docs
 inverse
+isinvertible
 ```
 
 ## Rotate

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -509,6 +509,7 @@ export
   LaplaceSmoothing,
   TaubinSmoothing,
   isaffine,
+  inverse,
 
   # miscellaneous
   signarea,

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -509,6 +509,7 @@ export
   LaplaceSmoothing,
   TaubinSmoothing,
   isaffine,
+  isinvertible,
   inverse,
 
   # miscellaneous


### PR DESCRIPTION
As discussed on zulip, this PR:
* exports `inverse`
* also mentions the function in the docs

I'm not sure about the docs, but giving that I was looking for it and couldn't figure out myself, I am strongly in favor of putting it somewhere somehow.