### PR TITLE
update _winding for crs to reduce allocations

### DIFF
--- a/src/winding.jl
+++ b/src/winding.jl
@@ -42,9 +42,15 @@ end
 # flatten CRS to Cartesian in general case
 function _winding(::CRS, points, ring)
   flat = FlatCoords()
-  fpts = map(flat, points)
-  fring = ring |> flat
-  winding(fpts, fring)
+  v = vertices(ring)
+  n = nvertices(ring)
+
+  function w(p)
+    ∑ = sum(∠(flat(v[i]), flat(p), flat(v[i + 1])) for i in 1:n)
+    ∑ / oftype(∑, 2π)
+  end
+
+  tcollect(w(p) for p in points)
 end
 
 function _coords(points, ring)

--- a/test/winding.jl
+++ b/test/winding.jl
@@ -10,16 +10,19 @@
   @test winding(p, c) ≈ T(2)
   @test winding(p, reverse(c)) ≈ T(-2)
   @test winding([p, p], c) ≈ T[2, 2]
-  # We record the allocations for cartesian
-  allocated_cart = @allocated winding(p, c)
+  # record allocations for cartesian
+  alloccart = @allocated winding(p, c)
 
   p = latlon(0.5, 0.5)
   c = Ring([latlon(0, 0), latlon(1, 0), latlon(1, 1), latlon(0, 1)])
   @test winding(p, c) ≈ T(1)
   @test winding(p, reverse(c)) ≈ T(-1)
   @test winding([p, p], c) ≈ T[1, 1]
-  # We test that latlon does not incur in more allocations
-  @test allocated_cart == @allocated winding(p, c)
+  # record allocations for latlon
+  alloclatlon == @allocated winding(p, c)
+
+  # exact same memory allocations
+  @test alloccart == alloclatlon
 
   # error: both arguments must have the same CRS
   p = latlon(0.5, 0.5)

--- a/test/winding.jl
+++ b/test/winding.jl
@@ -19,7 +19,7 @@
   @test winding(p, reverse(c)) ≈ T(-1)
   @test winding([p, p], c) ≈ T[1, 1]
   # record allocations for latlon
-  alloclatlon == @allocated winding(p, c)
+  alloclatlon = @allocated winding(p, c)
 
   # exact same memory allocations
   @test alloccart == alloclatlon

--- a/test/winding.jl
+++ b/test/winding.jl
@@ -10,12 +10,16 @@
   @test winding(p, c) ≈ T(2)
   @test winding(p, reverse(c)) ≈ T(-2)
   @test winding([p, p], c) ≈ T[2, 2]
+  # We record the allocations for cartesian
+  allocated_cart = @allocated winding(p, c)
 
   p = latlon(0.5, 0.5)
   c = Ring([latlon(0, 0), latlon(1, 0), latlon(1, 1), latlon(0, 1)])
   @test winding(p, c) ≈ T(1)
   @test winding(p, reverse(c)) ≈ T(-1)
   @test winding([p, p], c) ≈ T[1, 1]
+  # We test that latlon does not incur in more allocations
+  @test allocated_cart == @allocated winding(p, c)
 
   # error: both arguments must have the same CRS
   p = latlon(0.5, 0.5)


### PR DESCRIPTION
This PR tries to cut down allocations for the new default `_winding` method for `CRS` points introduced in #909 

I have seen allocations were mostly coming from flattening the ring before calling the Cartesian winding.

This PR makes the method much more similar to the default one for Cartesian (it might be worth separating the common parts in a separate function maybe?)

I also added one test to ensure allocations do not increase compared to the `Cartesian` method.

With this PR, the benchmark of the following code (adapted from #900):
```julia
using Meshes
using CoordRefSystems
using BenchmarkTools
# Generate PolyArea from set of coords
function create_polyarea(f, raw_coords)
	pts = map(raw_coords) do (;x,y)
		f(x,y)
	end
	r = Ring(pts)
	PolyArea(r)
end

# Function to generate normal Point
f_point(x,y) = Point(x,y)
# Function to generate LatLon point
f_latlon(lon, lat) = LatLon(lat, lon) |> Point

# Simple square coordinates
square_coords = map(45:90:360) do φ
	y,x = sincosd(φ)
	(;x,y)
end

# Tests
p_cart = f_point(0,0)
poly_cart = create_polyarea(f_point, square_coords)
p_latlon = f_latlon(0,0)
poly_latlon = create_polyarea(f_latlon, square_coords)

@benchmark $p_cart in $poly_cart
@benchmark $p_latlon in $poly_latlon
```

goes from:
## master
```julia-repl
julia> @benchmark $p_cart in $poly_cart
BenchmarkTools.Trial: 10000 samples with 285 evaluations.
 Range (min … max):  280.351 ns … 338.460 μs  ┊ GC (min … max):  0.00% … 99.84%
 Time  (median):     428.070 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   448.538 ns ±   3.432 μs  ┊ GC (mean ± σ):  10.15% ±  2.21%

                         ▅█▁  
  ▅█▆▄▄▄▄▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▅███▇▅▄▄▃▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  280 ns           Histogram: frequency by time          655 ns <

 Memory estimate: 528 bytes, allocs estimate: 10.

julia> @benchmark $p_latlon in $poly_latlon
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   7.900 μs …  2.103 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     20.100 μs              ┊ GC (median):    0.00%        
 Time  (mean ± σ):   34.440 μs ± 52.187 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅██▇▆▅▄▃▂               ▁▁▁ ▁▁▁▁▁▁▁▁▁                       ▂
  ███████████▇▇▆▅▄▆▅▆▇▆▇▆████████████████▆▅▆▄▄▄▄▄▅▅▄▄▄▁▅▁▅▅▅▆ █
  7.9 μs       Histogram: log(frequency) by time       260 μs <

 Memory estimate: 4.14 KiB, allocs estimate: 50.
```
## this PR
```julia-repl
julia> @benchmark $p_cart in $poly_cart
BenchmarkTools.Trial: 10000 samples with 282 evaluations.
 Range (min … max):  280.851 ns … 338.752 μs  ┊ GC (min … max):  0.00% … 99.84%
 Time  (median):     425.532 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   448.062 ns ±   3.435 μs  ┊ GC (mean ± σ):  10.16% ±  2.21%

                        ▂█    
  ▃▇▅▄▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▂███▄▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  281 ns           Histogram: frequency by time          662 ns <

 Memory estimate: 528 bytes, allocs estimate: 10.

julia> @benchmark $p_latlon in $poly_latlon
BenchmarkTools.Trial: 10000 samples with 266 evaluations.
 Range (min … max):  291.729 ns … 369.256 μs  ┊ GC (min … max): 0.00% … 99.86%
 Time  (median):     430.827 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   463.845 ns ±   3.728 μs  ┊ GC (mean ± σ):  9.96% ±  1.98%

  ▃▆▅▅▄▃▂▁          ▂▇█▇▅▄▃▃▃▃▃▂▂▂▂▂▁▁                          ▂
  ███████████▇▇▇▆▆▅▅████████████████████▇▆▇▆▅▅▅▄▅▄▄▄▅▇▇▇▆▆▅▆▅▇▆ █
  292 ns        Histogram: log(frequency) by time        708 ns <

 Memory estimate: 528 bytes, allocs estimate: 10.
```