### PR TITLE
Fix constructor of `PointSet` taking `Vector{Vector}`

### DIFF
--- a/src/refinement/trisubdivision.jl
+++ b/src/refinement/trisubdivision.jl
@@ -3,15 +3,15 @@
 # ------------------------------------------------------------------
 
 """
-  TriSubdivision()
+    TriSubdivision()
 
 Refinement of a mesh by preliminarly triangulating it if needed and
 then subdividing each triangle into four triangles.
 
 ## References
 
-* Charles Loop. 1987. [Smooth subdivision surfaces based on 
-  triangles](https://charlesloop.com/thesis.pdf). 
+* Charles Loop. 1987. [Smooth subdivision surfaces based on
+  triangles](https://charlesloop.com/thesis.pdf).
   Master's thesis, University of Utah.
 """
 struct TriSubdivision <: RefinementMethod end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -62,7 +62,7 @@ PointSet(points::AbstractVector{Point{Dim,C}}) where {Dim,C<:CRS} = PointSet{Dim
 PointSet(points::Vararg{P}) where {P<:Point} = PointSet(collect(points))
 PointSet(coords::AbstractVector{TP}) where {TP<:Tuple} = PointSet(Point.(coords))
 PointSet(coords::Vararg{TP}) where {TP<:Tuple} = PointSet(collect(coords))
-PointSet(coords::AbstractVector{V}) where {V<:AbstractVector} = PointSet(Point.(coords))
+PointSet(coords::AbstractVector{V}) where {V<:AbstractVector} = PointSet(Tuple.(coords))
 PointSet(coords::Vararg{V}) where {V<:AbstractVector} = PointSet(collect(coords))
 PointSet(coords::AbstractMatrix) = PointSet(Tuple.(eachcol(coords)))
 

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -60,8 +60,10 @@
     pset3 = PointSet([T.((1, 2, 3)), T.((4, 5, 6))])
     pset4 = PointSet(T.((1, 2, 3)), T.((4, 5, 6)))
     pset5 = PointSet(T[1 4; 2 5; 3 6])
-    @test pset1 == pset2 == pset3 == pset4 == pset5
-    for pset in [pset1, pset2, pset3, pset4, pset5]
+    pset6 = PointSet(T[1, 2, 3], T[4, 5, 6])
+    pset7 = PointSet([T[1, 2, 3], T[4, 5, 6]])
+    @test pset1 == pset2 == pset3 == pset4 == pset5 == pset6 == pset7
+    for pset in [pset1, pset2, pset3, pset4, pset5, pset6, pset7]
       @test embeddim(pset) == 3
       @test Meshes.lentype(pset) === ℳ
       @test nelements(pset) == 2


### PR DESCRIPTION
Since `Point([1,2,3])` fails with 
```julia
julia> Point([1,2,3])
ERROR: MethodError: no method matching (CoordRefSystems.Cartesian{CoordRefSystems.NoDatum})(::Vector{Int64})
[...]
```
also the constructor calls `PointSet([[1,2,3], [4,5,6]])` and `PointSet([1,2,3], [4,5,6])`, which are suggested in the docs, fail. This PR fixes this issue and adds tests for this.
