### PR TITLE
Remove obsolete PointSet constructors

### DIFF
--- a/docs/src/algorithms/clamping.md
+++ b/docs/src/algorithms/clamping.md
@@ -12,7 +12,7 @@ using Meshes # hide
 import CairoMakie as Mke # hide
 
 # set of 2D points to clamp
-points = PointSet(rand(2, 100))
+points = PointSet(rand(Point{2}, 100))
 
 # 2D box defining the clamping boundaries
 box = Box((0.25, 0.25), (0.75, 0.75))

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -53,18 +53,12 @@ julia> PointSet([Point(1,2,3), Point(4,5,6)])
 julia> PointSet(Point(1,2,3), Point(4,5,6))
 julia> PointSet([(1,2,3), (4,5,6)])
 julia> PointSet((1,2,3), (4,5,6))
-julia> PointSet([[1,2,3], [4,5,6]])
-julia> PointSet([1,2,3], [4,5,6])
-julia> PointSet([1 4; 2 5; 3 6])
 ```
 """
 PointSet(points::AbstractVector{Point{Dim,C}}) where {Dim,C<:CRS} = PointSet{Dim,C}(points)
 PointSet(points::Vararg{P}) where {P<:Point} = PointSet(collect(points))
 PointSet(coords::AbstractVector{TP}) where {TP<:Tuple} = PointSet(Point.(coords))
 PointSet(coords::Vararg{TP}) where {TP<:Tuple} = PointSet(collect(coords))
-PointSet(coords::AbstractVector{V}) where {V<:AbstractVector} = PointSet(Tuple.(coords))
-PointSet(coords::Vararg{V}) where {V<:AbstractVector} = PointSet(collect(coords))
-PointSet(coords::AbstractMatrix) = PointSet(Tuple.(eachcol(coords)))
 
 # constructor with iterator of points
 PointSet(points) = PointSet(map(identity, points))

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -68,10 +68,10 @@
   @test @allocated(boundingbox(m)) < 50
   @test @allocated(boundingbox(d)) < 50
 
-  d = PointSet(T[0 1 2; 0 2 1])
+  d = PointSet(cart(0, 0), cart(1, 2), cart(2, 1))
   @test boundingbox(d) == Box(cart(0, 0), cart(2, 2))
   @test @allocated(boundingbox(d)) < 50
-  d = PointSet(T[1 2; 2 1])
+  d = PointSet(cart(1, 2), cart(2, 1))
   @test boundingbox(d) == Box(cart(1, 1), cart(2, 2))
   @test @allocated(boundingbox(d)) < 50
 
@@ -85,7 +85,7 @@
   @test boundingbox(d) == Box(cart(1, 1), cart(11, 11))
   @test @allocated(boundingbox(d)) < 50
 
-  d = PointSet(T[0 1 2; 0 2 1])
+  d = PointSet(cart(0, 0), cart(1, 2), cart(2, 1))
   v = view(d, 1:2)
   @test boundingbox(v) == Box(cart(0, 0), cart(1, 2))
   @test @allocated(boundingbox(v)) < 50

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1142,7 +1142,7 @@
 
     r = Ray(cart(-1.0, -1.0, -1.0), vector(1.0, 1.0, 1.0))
     @test intersection(r, o) |> type == Intersecting
-    @test r ∩ o == PointSet([cart(0.0, 0.0, 0.0)])
+    @test r ∩ o == PointSet(cart(0.0, 0.0, 0.0))
 
     r = Ray(cart(-1.0, -1.0, -1.0), vector(-1.0, -1.0, -1.0))
     @test intersection(r, o) |> type == NotIntersecting

--- a/test/partitioning.jl
+++ b/test/partitioning.jl
@@ -216,10 +216,7 @@
   end
 
   @testset "BallPartition" begin
-    pset = PointSet(T[
-      0 1 1 0 0.2
-      0 0 1 1 0.2
-    ])
+    pset = PointSet(cart(0, 0), cart(1, 0), cart(1, 1), cart(0, 1), cart(0.2, 0.2))
 
     # 3 balls with 1 point, and 1 ball with 2 points
     p = partition(pset, BallPartition(T(0.5)))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -59,11 +59,8 @@
     pset2 = PointSet(cart(1, 2, 3), cart(4, 5, 6))
     pset3 = PointSet([T.((1, 2, 3)), T.((4, 5, 6))])
     pset4 = PointSet(T.((1, 2, 3)), T.((4, 5, 6)))
-    pset5 = PointSet(T[1 4; 2 5; 3 6])
-    pset6 = PointSet(T[1, 2, 3], T[4, 5, 6])
-    pset7 = PointSet([T[1, 2, 3], T[4, 5, 6]])
-    @test pset1 == pset2 == pset3 == pset4 == pset5 == pset6 == pset7
-    for pset in [pset1, pset2, pset3, pset4, pset5, pset6, pset7]
+    @test pset1 == pset2 == pset3 == pset4
+    for pset in [pset1, pset2, pset3, pset4]
       @test embeddim(pset) == 3
       @test Meshes.lentype(pset) === ℳ
       @test nelements(pset) == 2


### PR DESCRIPTION
These are left-overs from our major refactor in the last months.

cc: @JoshuaLampert 