### PR TITLE
Add support for using `rand` without `Dim` for all geometries

### DIFF
--- a/src/polytopes/hexahedron.jl
+++ b/src/polytopes/hexahedron.jl
@@ -36,3 +36,5 @@ end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Hexahedron{Dim}}) where {Dim} =
   Hexahedron(ntuple(i -> rand(rng, Point{Dim}), 8))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Hexahedron}) = rand(rng, Hexahedron{3})

--- a/src/polytopes/ngon.jl
+++ b/src/polytopes/ngon.jl
@@ -67,6 +67,8 @@ signarea(ngon::Ngon) = sum(signarea, simplexify(ngon))
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Ngon{N,Dim}}) where {N,Dim} = Ngon{N}(ntuple(i -> rand(rng, Point{Dim}), N))
 
+Random.rand(rng::Random.AbstractRNG, ::Type{Ngon{N}}) where {N} = rand(rng, Ngon{N,3})
+
 # ----------
 # TRIANGLES
 # ----------

--- a/src/polytopes/polyarea.jl
+++ b/src/polytopes/polyarea.jl
@@ -115,3 +115,5 @@ function Base.show(io::IO, ::MIME"text/plain", p::PolyArea)
 end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{PolyArea{Dim}}) where {Dim} = PolyArea(rand(rng, Ring{Dim}))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{PolyArea}) = rand(rng, PolyArea{3})

--- a/src/polytopes/pyramid.jl
+++ b/src/polytopes/pyramid.jl
@@ -17,3 +17,5 @@ Base.isapprox(p₁::Pyramid, p₂::Pyramid; atol=atol(lentype(p₁)), kwargs...)
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(p₁.vertices, p₂.vertices))
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Pyramid{Dim}}) where {Dim} = Pyramid(ntuple(i -> rand(rng, Point{Dim}), 5))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Pyramid}) = rand(rng, Pyramid{3})

--- a/src/polytopes/ring.jl
+++ b/src/polytopes/ring.jl
@@ -66,6 +66,8 @@ function Random.rand(rng::Random.AbstractRNG, ::Type{Ring{Dim}}) where {Dim}
   Ring(v)
 end
 
+Random.rand(rng::Random.AbstractRNG, ::Type{Ring}) = rand(rng, Ring{3})
+
 """
     innerangles(ring)
 

--- a/src/polytopes/rope.jl
+++ b/src/polytopes/rope.jl
@@ -31,3 +31,5 @@ Base.open(r::Rope) = r
 Base.reverse!(r::Rope) = (reverse!(r.vertices); r)
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Rope{Dim}}) where {Dim} = Rope(rand(rng, Point{Dim}, rand(rng, 2:50)))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Rope}) = rand(rng, Rope{3})

--- a/src/polytopes/segment.jl
+++ b/src/polytopes/segment.jl
@@ -40,3 +40,5 @@ function (s::Segment)(t)
 end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Segment{Dim}}) where {Dim} = Segment(ntuple(i -> rand(rng, Point{Dim}), 2))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Segment}) = rand(rng, Segment{3})

--- a/src/polytopes/tetrahedron.jl
+++ b/src/polytopes/tetrahedron.jl
@@ -27,3 +27,5 @@ end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Tetrahedron{Dim}}) where {Dim} =
   Tetrahedron(ntuple(i -> rand(rng, Point{Dim}), 4))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Tetrahedron}) = rand(rng, Tetrahedron{3})

--- a/src/polytopes/wedge.jl
+++ b/src/polytopes/wedge.jl
@@ -17,3 +17,5 @@ Base.isapprox(t₁::Wedge, t₂::Wedge; atol=atol(lentype(t₁)), kwargs...) =
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(t₁.vertices, t₂.vertices))
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Wedge{Dim}}) where {Dim} = Wedge(ntuple(i -> rand(rng, Point{Dim}), 6))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Wedge}) = rand(rng, Wedge{3})

--- a/src/primitives/ball.jl
+++ b/src/primitives/ball.jl
@@ -66,3 +66,5 @@ end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Ball{Dim}}) where {Dim} =
   Ball(rand(rng, Point{Dim}), rand(rng, Met{Float64}))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Ball}) = rand(rng, Ball{3})

--- a/src/primitives/bezier.jl
+++ b/src/primitives/bezier.jl
@@ -114,6 +114,8 @@ end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{BezierCurve{Dim}}) where {Dim} = BezierCurve(rand(rng, Point{Dim}, 5))
 
+Random.rand(rng::Random.AbstractRNG, ::Type{BezierCurve}) = rand(rng, BezierCurve{3})
+
 # -----------
 # IO METHODS
 # -----------

--- a/src/primitives/box.jl
+++ b/src/primitives/box.jl
@@ -60,3 +60,5 @@ function Random.rand(rng::Random.AbstractRNG, ::Type{Box{Dim}}) where {Dim}
   max = min + rand(rng, Vec{Dim,Met{Float64}})
   Box(min, max)
 end
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Box}) = rand(rng, Box{3})

--- a/src/primitives/line.jl
+++ b/src/primitives/line.jl
@@ -26,3 +26,5 @@ Base.isapprox(l₁::Line, l₂::Line; atol=atol(lentype(l₁)), kwargs...) =
 (l::Line)(t) = l.a + t * (l.b - l.a)
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Line{Dim}}) where {Dim} = Line(rand(rng, Point{Dim}), rand(rng, Point{Dim}))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Line}) = rand(rng, Line{3})

--- a/src/primitives/point.jl
+++ b/src/primitives/point.jl
@@ -128,6 +128,8 @@ See <https://en.wikipedia.org/wiki/Atan2>.
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Point{Dim}}) where {Dim} = Point(rand(rng, Cartesian{NoDatum,Dim}))
 
+Random.rand(rng::Random.AbstractRNG, ::Type{Point}) = rand(rng, Point{3})
+
 # -----------
 # IO METHODS
 # -----------

--- a/src/primitives/ray.jl
+++ b/src/primitives/ray.jl
@@ -32,3 +32,5 @@ end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Ray{Dim}}) where {Dim} =
   Ray(rand(rng, Point{Dim}), rand(rng, Vec{Dim,Met{Float64}}))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Ray}) = rand(rng, Ray{3})

--- a/src/primitives/sphere.jl
+++ b/src/primitives/sphere.jl
@@ -101,3 +101,5 @@ end
 
 Random.rand(rng::Random.AbstractRNG, ::Type{Sphere{Dim}}) where {Dim} =
   Sphere(rand(rng, Point{Dim}), rand(rng, Met{Float64}))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{Sphere}) = rand(rng, Sphere{3})

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -73,6 +73,10 @@
     @test s isa Segment
     @test embeddim(s) == 3
     @test Meshes.lentype(s) === Meshes.Met{Float64}
+    s = rand(Segment)
+    @test s isa Segment
+    @test embeddim(s) == 3
+    @test Meshes.lentype(s) === Meshes.Met{Float64}
 
     # datum propagation
     c1 = Cartesian{WGS84Latest}(T(0), T(0))
@@ -253,12 +257,20 @@
     @test r isa Rope
     @test embeddim(r) == 3
     @test Meshes.lentype(r) === Meshes.Met{Float64}
+    r = rand(Rope)
+    @test r isa Rope
+    @test embeddim(r) == 3
+    @test Meshes.lentype(r) === Meshes.Met{Float64}
 
     r = rand(Ring{2})
     @test r isa Ring
     @test embeddim(r) == 2
     @test Meshes.lentype(r) === Meshes.Met{Float64}
     r = rand(Ring{3})
+    @test r isa Ring
+    @test embeddim(r) == 3
+    @test Meshes.lentype(r) === Meshes.Met{Float64}
+    r = rand(Ring)
     @test r isa Ring
     @test embeddim(r) == 3
     @test Meshes.lentype(r) === Meshes.Met{Float64}
@@ -331,6 +343,10 @@
       @test embeddim(n) == 2
       @test Meshes.lentype(n) === Meshes.Met{Float64}
       n = rand(NGON{3})
+      @test n isa NGON
+      @test embeddim(n) == 3
+      @test Meshes.lentype(n) === Meshes.Met{Float64}
+      n = rand(NGON)
       @test n isa NGON
       @test embeddim(n) == 3
       @test Meshes.lentype(n) === Meshes.Met{Float64}
@@ -722,6 +738,10 @@
     @test p isa PolyArea
     @test embeddim(p) == 3
     @test Meshes.lentype(p) === Meshes.Met{Float64}
+    p = rand(PolyArea)
+    @test p isa PolyArea
+    @test embeddim(p) == 3
+    @test Meshes.lentype(p) === Meshes.Met{Float64}
 
     outer = cart.([(0, 0), (1, 0), (1, 1), (0, 1)])
     hole1 = cart.([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)])
@@ -779,6 +799,10 @@
     isapproxtest(t)
 
     t = rand(Tetrahedron{3})
+    @test t isa Tetrahedron
+    @test embeddim(t) == 3
+    @test Meshes.lentype(t) === Meshes.Met{Float64}
+    t = rand(Tetrahedron)
     @test t isa Tetrahedron
     @test embeddim(t) == 3
     @test Meshes.lentype(t) === Meshes.Met{Float64}
@@ -905,6 +929,10 @@
     @test h isa Hexahedron
     @test embeddim(h) == 3
     @test Meshes.lentype(h) === Meshes.Met{Float64}
+    h = rand(Hexahedron)
+    @test h isa Hexahedron
+    @test embeddim(h) == 3
+    @test Meshes.lentype(h) === Meshes.Met{Float64}
 
     # datum propagation
     c1 = Cartesian{WGS84Latest}(T(0), T(0), T(0))
@@ -975,6 +1003,10 @@
     @test p isa Pyramid
     @test embeddim(p) == 3
     @test Meshes.lentype(p) === Meshes.Met{Float64}
+    p = rand(Pyramid)
+    @test p isa Pyramid
+    @test embeddim(p) == 3
+    @test Meshes.lentype(p) === Meshes.Met{Float64}
 
     p = Pyramid(cart(0, 0, 0), cart(1, 0, 0), cart(1, 1, 0), cart(0, 1, 0), cart(0, 0, 1))
     @test sprint(show, p) == "Pyramid((x: 0.0 m, y: 0.0 m, z: 0.0 m), ..., (x: 0.0 m, y: 0.0 m, z: 1.0 m))"
@@ -1015,6 +1047,10 @@
     isapproxtest(w)
 
     w = rand(Wedge{3})
+    @test w isa Wedge
+    @test embeddim(w) == 3
+    @test Meshes.lentype(w) === Meshes.Met{Float64}
+    w = rand(Wedge)
     @test w isa Wedge
     @test embeddim(w) == 3
     @test Meshes.lentype(w) === Meshes.Met{Float64}

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -48,9 +48,11 @@
     @test embeddim(rand(Point{1})) == 1
     @test embeddim(rand(Point{2})) == 2
     @test embeddim(rand(Point{3})) == 3
+    @test embeddim(rand(Point)) == 3
     @test Meshes.lentype(rand(Point{1})) == Meshes.Met{Float64}
     @test Meshes.lentype(rand(Point{2})) == Meshes.Met{Float64}
     @test Meshes.lentype(rand(Point{3})) == Meshes.Met{Float64}
+    @test Meshes.lentype(rand(Point)) == Meshes.Met{Float64}
 
     @test cart(1) ≈ cart(1 + eps(T))
     @test cart(1, 2) ≈ cart(1 + eps(T), T(2))
@@ -234,10 +236,13 @@
 
     r2 = rand(Ray{2})
     r3 = rand(Ray{3})
+    r = rand(Ray)
     @test r2 isa Ray
     @test r3 isa Ray
+    @test r isa Ray
     @test embeddim(r2) == 2
     @test embeddim(r3) == 3
+    @test embeddim(r) == 3
 
     r = Ray(cart(0, 0), vector(1, 1))
     @test sprint(show, r) == "Ray(p: (x: 0.0 m, y: 0.0 m), v: (1.0 m, 1.0 m))"
@@ -273,10 +278,13 @@
 
     l2 = rand(Line{2})
     l3 = rand(Line{3})
+    l = rand(Line)
     @test l2 isa Line
     @test l3 isa Line
+    @test l isa Line
     @test embeddim(l2) == 2
     @test embeddim(l3) == 3
+    @test embeddim(l) == 3
 
     l = Line(cart(0, 0), cart(1, 1))
     @test sprint(show, l) == "Line(a: (x: 0.0 m, y: 0.0 m), b: (x: 1.0 m, y: 1.0 m))"
@@ -399,10 +407,13 @@
 
     b2 = rand(BezierCurve{2})
     b3 = rand(BezierCurve{3})
+    b = rand(BezierCurve)
     @test b2 isa BezierCurve
     @test b3 isa BezierCurve
+    @test b isa BezierCurve
     @test embeddim(b2) == 2
     @test embeddim(b3) == 3
+    @test embeddim(b) == 3
 
     # datum propagation
     c1 = Cartesian{WGS84Latest}(T(0), T(0))
@@ -517,12 +528,15 @@
     b1 = rand(Box{1})
     b2 = rand(Box{2})
     b3 = rand(Box{3})
+    b = rand(Box)
     @test b1 isa Box
     @test b2 isa Box
     @test b3 isa Box
+    @test b isa Box
     @test embeddim(b1) == 1
     @test embeddim(b2) == 2
     @test embeddim(b3) == 3
+    @test embeddim(b) == 3
 
     @test_throws AssertionError Box(cart(1), cart(0))
     @test_throws AssertionError Box(cart(1, 1), cart(0, 0))
@@ -630,12 +644,15 @@
     b1 = rand(Ball{1})
     b2 = rand(Ball{2})
     b3 = rand(Ball{3})
+    b = rand(Ball)
     @test b1 isa Ball
     @test b2 isa Ball
     @test b3 isa Ball
+    @test b isa Ball
     @test embeddim(b1) == 1
     @test embeddim(b2) == 2
     @test embeddim(b3) == 3
+    @test embeddim(b) == 3
 
     b = Ball(cart(0, 0), T(1))
     @test sprint(show, b) == "Ball(center: (x: 0.0 m, y: 0.0 m), radius: 1.0 m)"
@@ -739,12 +756,15 @@
     s1 = rand(Sphere{1})
     s2 = rand(Sphere{2})
     s3 = rand(Sphere{3})
+    s = rand(Sphere)
     @test s1 isa Sphere
     @test s2 isa Sphere
     @test s3 isa Sphere
+    @test s isa Sphere
     @test embeddim(s1) == 1
     @test embeddim(s2) == 2
     @test embeddim(s3) == 3
+    @test embeddim(s) == 3
 
     s = Sphere(cart(0, 0, 0), T(1))
     @test sprint(show, s) == "Sphere(center: (x: 0.0 m, y: 0.0 m, z: 0.0 m), radius: 1.0 m)"


### PR DESCRIPTION
By default, when `Dim` is not passed, it will be equal to 3.