### PR TITLE
`applycoord` hotfix

### DIFF
--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -81,9 +81,8 @@ applycoord(t::CoordinateTransform, m::TransformedMesh) = TransformedMesh(m, t)
 
 # special treatment for lists of geometries
 applycoord(t::CoordinateTransform, g::NTuple{<:Any,<:Geometry}) = map(gᵢ -> applycoord(t, gᵢ), g)
-applycoord(t::CoordinateTransform, g::AbstractVector{<:Geometry}) = tcollect(applycoord(t, gᵢ) for gᵢ in g)
-applycoord(t::CoordinateTransform, g::CircularVector{<:Geometry}) =
-  CircularVector(tcollect(applycoord(t, gᵢ) for gᵢ in g))
+applycoord(t::CoordinateTransform, g::AbstractVector{<:Geometry}) = [applycoord(t, gᵢ) for gᵢ in g]
+applycoord(t::CoordinateTransform, g::CircularVector{<:Geometry}) = CircularVector([applycoord(t, gᵢ) for gᵢ in g])
 
 # ----------------
 # IMPLEMENTATIONS


### PR DESCRIPTION
The addition of Manifold to types caused problems with the `Transducers.tcollect` function which crashes the compiler when used with very complex types.
MWE:
```
julia> using Meshes

julia> using Random; Random.seed!(123);

julia> r = rand(Ring);

julia> gset = GeometrySet([Multi([PolyArea(r)])]);

julia> gset |> Translate(1, 1, 1)
```
In this PR, I replace the `tcollect` function with a vector comprehension as a temporary solution.