### PR TITLE
escape underscore in docstring link

### DIFF
--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -36,7 +36,7 @@ end
     CoordinateTransform
 
 A method to transform the coordinates of objects.
-See [https://en.wikipedia.org/wiki/List_of_common_coordinate_transformations]
+See [https://en.wikipedia.org/wiki/List\\_of\\_common\\_coordinate\\_transformations]
 (https://en.wikipedia.org/wiki/List_of_common_coordinate_transformations).
 """
 abstract type CoordinateTransform <: GeometricTransform end

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -36,8 +36,7 @@ end
     CoordinateTransform
 
 A method to transform the coordinates of objects.
-See [https://en.wikipedia.org/wiki/List\\_of\\_common\\_coordinate\\_transformations]
-(https://en.wikipedia.org/wiki/List_of_common_coordinate_transformations).
+See <https://en.wikipedia.org/wiki/List_of_common_coordinate_transformations>.
 """
 abstract type CoordinateTransform <: GeometricTransform end
 


### PR DESCRIPTION
Simply escape underscore in docstring link to avoid markdown messing the displayed link