### PR TITLE
Make VoronoiTessellation respect input order and improve performance

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -24,7 +24,7 @@ using NearestNeighbors: KDTree, BallTree
 using NearestNeighbors: knn, inrange
 using DelaunayTriangulation: triangulate, voronoi
 using DelaunayTriangulation: each_solid_triangle
-using DelaunayTriangulation: each_polygon
+using DelaunayTriangulation: get_polygons 
 using DelaunayTriangulation: get_polygon_points
 using ScopedValues: ScopedValue
 using Base.Cartesian: @nloops, @nref, @ntuple

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -24,7 +24,7 @@ using NearestNeighbors: KDTree, BallTree
 using NearestNeighbors: knn, inrange
 using DelaunayTriangulation: triangulate, voronoi
 using DelaunayTriangulation: each_solid_triangle
-using DelaunayTriangulation: get_polygons 
+using DelaunayTriangulation: get_polygons
 using DelaunayTriangulation: get_polygon_points
 using ScopedValues: ScopedValue
 using Base.Cartesian: @nloops, @nref, @ntuple

--- a/src/tesselation/voronoi.jl
+++ b/src/tesselation/voronoi.jl
@@ -39,9 +39,12 @@ function tesselate(pset::PointSet, method::VoronoiTesselation)
     coords = CoordRefSystems.reconstruct(C, T.(xy))
     Point(coords)
   end
-  polygs = each_polygon(vorono)
-  tuples = [Tuple(inds[begin:(end - 1)]) for inds in polygs]
-  connec = connect.(tuples)
+  polygs = get_polygons(vorono)
+  connec = Vector{Connectivity}(undef, length(polygs))
+  for (idx, poly) in polygs
+    tup = ntuple(i -> poly[i], length(poly) - 1)
+    connec[idx] = connect(tup, Ngon)
+  end
   mesh = SimpleMesh(points, connec)
 
   # remove unused points

--- a/src/tesselation/voronoi.jl
+++ b/src/tesselation/voronoi.jl
@@ -41,9 +41,9 @@ function tesselate(pset::PointSet, method::VoronoiTesselation)
   end
   polygs = get_polygons(vorono)
   connec = Vector{Connectivity}(undef, length(polygs))
-  for (idx, poly) in polygs
-    tup = ntuple(i -> poly[i], length(poly) - 1)
-    connec[idx] = connect(tup, Ngon)
+  for (order_idx, vertices_inds) in polygs
+    tup = ntuple(i -> vertices_inds[i], length(vertices_inds) - 1)
+    connec[order_idx] = connect(tup, Ngon)
   end
   mesh = SimpleMesh(points, connec)
 

--- a/src/tesselation/voronoi.jl
+++ b/src/tesselation/voronoi.jl
@@ -41,9 +41,9 @@ function tesselate(pset::PointSet, method::VoronoiTesselation)
   end
   polygs = get_polygons(vorono)
   connec = Vector{Connectivity}(undef, length(polygs))
-  for (order_idx, vertices_inds) in polygs
-    tup = ntuple(i -> vertices_inds[i], length(vertices_inds) - 1)
-    connec[order_idx] = connect(tup, Ngon)
+  for (i, inds) in polygs
+    tup = ntuple(j -> inds[j], length(inds) - 1)
+    connec[i] = connect(tup, Ngon)
   end
   mesh = SimpleMesh(points, connec)
 

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -45,5 +45,12 @@
     pts = randpoint3(10)
     pset = PointSet(pts)
     @test_throws AssertionError tesselate(pset, VoronoiTesselation(StableRNG(2024)))
+
+    # Test polygon order is the same as input points order
+    pts = randpoint2(10)
+    mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
+    @test all(zip(pts, mesh)) do (pt, poly)
+        pt in poly || pt ∉ mesh # The pt ∉ mesh is because some points are on the border of the respective polygon and return false from `pt in poly` due to floating point precision. So if that happens we check that the point is not in any other polygon
+    end
   end
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -50,7 +50,7 @@
     pts = randpoint2(10)
     mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
     @test all(zip(pts, mesh)) do (pt, poly)
-        pt in poly || pt ∉ mesh # The pt ∉ mesh is because some points are on the border of the respective polygon and return false from `pt in poly` due to floating point precision. So if that happens we check that the point is not in any other polygon
+      pt in poly || pt ∉ mesh # The pt ∉ mesh is because some points are on the border of the respective polygon and return false from `pt in poly` due to floating point precision. So if that happens we check that the point is not in any other polygon
     end
   end
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -50,7 +50,13 @@
     pts = randpoint2(10)
     mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
     @test all(zip(pts, mesh)) do (pt, poly)
-      pt in poly || pt ∉ mesh # The pt ∉ mesh is because some points are on the border of the respective polygon and return false from `pt in poly` due to floating point precision. So if that happens we check that the point is not in any other polygon
+      pt in poly && return true
+      # Point is not in poly, might be to a rounding error. We check if the target polygon's centroid is the closest of all
+      centroid_dists = map(mesh) do element
+        norm(centroid(element) - pt)
+      end
+      this_dist = norm(centroid(poly) - pt)
+      all(<=(this_dist), centroid_dists)
     end
   end
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -36,7 +36,7 @@
     mesh = tesselate(pset, VoronoiTesselation(StableRNG(2024)))
     @test crs(mesh) === crs(pset)
 
-    coords = [LatLon(rand(-80:T(0.1):80), rand(-180:T(0.1):180)) for _ in 1:10]
+    coords = [LatLon(rand(-20:T(0.1):20), rand(-180:T(0.1):180)) for _ in 1:10]
     pset = PointSet(Point.(coords))
     mesh = tesselate(pset, VoronoiTesselation(StableRNG(2024)))
     @test crs(mesh) === crs(pset)

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -47,8 +47,9 @@
     @test_throws AssertionError tesselate(pset, VoronoiTesselation(StableRNG(2024)))
 
     # Test polygon order is the same as input points order
+    rng = StableRNG(2024)
     pts = randpoint2(10)
-    mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
+    mesh = tesselate(pts, VoronoiTesselation(rng))
     @test all(zip(pts, mesh)) do (pt, poly)
       pt in poly || pt ∉ mesh # The pt ∉ mesh is because some points are on the border of the respective polygon and return false from `pt in poly` due to floating point precision. So if that happens we check that the point is not in any other polygon
     end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -44,6 +44,6 @@
     # Test polygon order is the same as input points order
     pts = randpoint2(10)
     mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
-    @test issameorder(pts, mesh)
+    @test all(sideof(p, boundary(poly)) ∈ (IN, ON) for (p, poly) in zip(pts, mesh))
   end
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -56,7 +56,7 @@
         norm(centroid(element) - pt)
       end
       this_dist = norm(centroid(poly) - pt)
-      all(<=(this_dist), centroid_dists)
+      all(>=(this_dist), centroid_dists)
     end
   end
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -47,9 +47,8 @@
     @test_throws AssertionError tesselate(pset, VoronoiTesselation(StableRNG(2024)))
 
     # Test polygon order is the same as input points order
-    rng = StableRNG(2024)
     pts = randpoint2(10)
-    mesh = tesselate(pts, VoronoiTesselation(rng))
+    mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024))
     @test all(zip(pts, mesh)) do (pt, poly)
       pt in poly || pt ∉ mesh # The pt ∉ mesh is because some points are on the border of the respective polygon and return false from `pt in poly` due to floating point precision. So if that happens we check that the point is not in any other polygon
     end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -48,7 +48,7 @@
 
     # Test polygon order is the same as input points order
     pts = randpoint2(10)
-    mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024))
+    mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
     @test all(zip(pts, mesh)) do (pt, poly)
       pt in poly || pt ∉ mesh # The pt ∉ mesh is because some points are on the border of the respective polygon and return false from `pt in poly` due to floating point precision. So if that happens we check that the point is not in any other polygon
     end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -50,8 +50,6 @@
     pts = randpoint2(10)
     mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
     @test all(zip(pts, mesh)) do (p, poly)
-      p ∈ poly && return true
-      # point is not in poly due to a floating point error.
       # check if the target polygon's centroid is the closest
       dist(e) = evaluate(Euclidean(), p, centroid(e))
       all(mesh) do elem

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -52,11 +52,11 @@
     @test all(zip(pts, mesh)) do (pt, poly)
       pt in poly && return true
       # Point is not in poly, might be to a rounding error. We check if the target polygon's centroid is the closest of all
-      centroid_dists = map(mesh) do element
-        norm(centroid(element) - pt)
-      end
       this_dist = norm(centroid(poly) - pt)
-      all(>=(this_dist), centroid_dists)
+      all(mesh) do element
+        d = norm(centroid(element) - pt)
+        d >= this_dist
+      end
     end
   end
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -36,11 +36,6 @@
     mesh = tesselate(pset, VoronoiTesselation(StableRNG(2024)))
     @test crs(mesh) === crs(pset)
 
-    coords = [LatLon(rand(-20:T(0.1):20), rand(-180:T(0.1):180)) for _ in 1:10]
-    pset = PointSet(Point.(coords))
-    mesh = tesselate(pset, VoronoiTesselation(StableRNG(2024)))
-    @test crs(mesh) === crs(pset)
-
     # error: the number of coordinates of the points must be 2
     pts = randpoint3(10)
     pset = PointSet(pts)

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -36,7 +36,7 @@
     mesh = tesselate(pset, VoronoiTesselation(StableRNG(2024)))
     @test crs(mesh) === crs(pset)
 
-    coords = [LatLon(rand(-90:T(0.1):90), rand(-180:T(0.1):180)) for _ in 1:10]
+    coords = [LatLon(rand(-80:T(0.1):80), rand(-180:T(0.1):180)) for _ in 1:10]
     pset = PointSet(Point.(coords))
     mesh = tesselate(pset, VoronoiTesselation(StableRNG(2024)))
     @test crs(mesh) === crs(pset)
@@ -49,13 +49,13 @@
     # Test polygon order is the same as input points order
     pts = randpoint2(10)
     mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
-    @test all(zip(pts, mesh)) do (pt, poly)
-      pt in poly && return true
-      # Point is not in poly, might be to a rounding error. We check if the target polygon's centroid is the closest of all
-      this_dist = norm(centroid(poly) - pt)
-      all(mesh) do element
-        d = norm(centroid(element) - pt)
-        d >= this_dist
+    @test all(zip(pts, mesh)) do (p, poly)
+      p ∈ poly && return true
+      # point is not in poly due to a floating point error.
+      # check if the target polygon's centroid is the closest
+      dist(e) = evaluate(Euclidean(), p, centroid(e))
+      all(mesh) do elem
+        dist(elem) ≥ dist(poly)
       end
     end
   end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -44,12 +44,6 @@
     # Test polygon order is the same as input points order
     pts = randpoint2(10)
     mesh = tesselate(pts, VoronoiTesselation(StableRNG(2024)))
-    @test all(zip(pts, mesh)) do (p, poly)
-      # check if the target polygon's centroid is the closest
-      dist(e) = evaluate(Euclidean(), p, centroid(e))
-      all(mesh) do elem
-        dist(elem) ≥ dist(poly)
-      end
-    end
+    @test issameorder(pts, mesh)
   end
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -80,15 +80,6 @@ withprecision(T, geoms::CircularVector{<:Geometry}) = CircularVector([withprecis
   :($ctor($(exprs...)))
 end
 
-# check if the order of the mesh polygons is the same as the input points
-function issameorder(pts, mesh)
-  all(zip(pts, mesh)) do (p, poly)
-    # check if the target polygon's centroid is the closest
-    dist(e) = evaluate(Euclidean(), p, centroid(e))
-    all(dist(elem) ≥ dist(poly) for elem in mesh)
-  end
-end
-
 function equaltest(g)
   @test g == withprecision(Float64, g)
   @test g == withprecision(Float32, g)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -80,6 +80,15 @@ withprecision(T, geoms::CircularVector{<:Geometry}) = CircularVector([withprecis
   :($ctor($(exprs...)))
 end
 
+# check if the order of the mesh polygons is the same as the input points
+function issameorder(pts, mesh)
+  all(zip(pts, mesh)) do (p, poly)
+    # check if the target polygon's centroid is the closest
+    dist(e) = evaluate(Euclidean(), p, centroid(e))
+    all(dist(elem) ≥ dist(poly) for elem in mesh)
+  end
+end
+
 function equaltest(g)
   @test g == withprecision(Float64, g)
   @test g == withprecision(Float32, g)


### PR DESCRIPTION
This PR ensures that the order of the polygons in the mesh returned by `tessellate(pts, VoronoiTessellation)` respects the order of the inputs points `pts`, closing #974.

In the process of modifying the function, I also tried some benchmarks and did some slight modifications to the code to reduce un-necessaries allocation. 

The function now preallocates a vector of Connectivity objects and fill it in the correct order inside a for loop.
One modification that significantly reduced allocations was to use the `connect(idxs, NGon)` function rather than the generic `connect(idxs)` one, as I believe you would always have NGons as output of the voronoi tessellation.

Another small improvements in allocations was to use `ntuple` instead of `Tuple(idxs)` to create the temporary indices tuple as the latter allocates (I guess due to type instability since it can't know the tuple length just with the type if called with a vector as input).

I also added a test to verify that each point in the input is `inside` the respective polygon based on index.
Unfortunately I realized that probably due to floating point precision, some of the points would not fall inside the respective polygons. In all these cases, the culprit point seems to be in principle just on the polygons border, and it's considered `OUT` just because of floating point precision.
For this reason I added the second condition to ignore the result if the point is actually not inside any of the polygons of the resulting mesh.

If you have ideas on how to test this better (I do not seem to have found a way to consider tolerance for the `in` function) I believe that would actually be the best approach.

## Benchmarks
I have performed some benchmarks in Julia 1.11-rc2 under windows with the following code:
```julia
using Meshes
using BenchmarkTools
using Random
using StableRNGs

randpoint2(n) = [Point(ntuple(i -> rand(Float64), 2)) for _ in 1:n]

bench(ns) = for n in ns
    Random.seed!(n) # Ensure same points are generated for each n
    pts = randpoint2(n)
    b = @benchmark tesselate($pts, VoronoiTesselation(StableRNG(2024)))
    println("Results for $n points:")
    println()
    display(b)
    println()
end
```

which gives the following results:

### Current version (v0.47.8)
```julia-repl
julia> bench([10, 100, 1000, 10000])
Results for 10 points:

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  197.500 μs …  12.322 ms  ┊ GC (min … max): 0.00% … 96.35%
 Time  (median):     206.600 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   229.758 μs ± 234.335 μs  ┊ GC (mean ± σ):  3.52% ±  3.66%

  ▅█▇▅▄▄▄▄▃▂▂▁▁▁▁▁                                              ▂
  █████████████████████▇▆▆▇▆▆▇▆▆▇▇▇▆▇▆▆▆▅▅▅▆▇▇▅▅▅▆▃▅▅▅▅▆▅▅▅▅▄▄▄ █
  198 μs        Histogram: log(frequency) by time        435 μs <

 Memory estimate: 146.22 KiB, allocs estimate: 1954.

Results for 100 points:

BenchmarkTools.Trial: 2157 samples with 1 evaluation.
 Range (min … max):  2.046 ms …  12.608 ms  ┊ GC (min … max): 0.00% … 79.06%
 Time  (median):     2.131 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.311 ms ± 740.016 μs  ┊ GC (mean ± σ):  4.57% ±  9.95%

  █▇▅▄▃▂▁▁▁
  ██████████▇▇▇▆▆▅▃▅▃▅▅▅▅▅▅▁▅▃▁▃▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▄▅▇▇▅▅▅ █
  2.05 ms      Histogram: log(frequency) by time      6.07 ms <

 Memory estimate: 1.20 MiB, allocs estimate: 13821.

Results for 1000 points:

BenchmarkTools.Trial: 187 samples with 1 evaluation.
 Range (min … max):  22.325 ms … 44.705 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     25.416 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   26.812 ms ±  4.288 ms  ┊ GC (mean ± σ):  3.52% ± 6.40%

  ▇▅▄▃▆█▄█▂        ▂
  █████████▇▇█▃▇▆▆▇█▆▅▇▄▅▄▄▆▅▃▁▃▄▃▁▃▄▃▅▁▃▃▁▁▃▃▃▃▁▁▁▁▁▃▃▁▃▃▁▁▃ ▃
  22.3 ms         Histogram: frequency by time        40.9 ms <

 Memory estimate: 10.52 MiB, allocs estimate: 136009.

Results for 10000 points:

BenchmarkTools.Trial: 3 samples with 1 evaluation.
 Range (min … max):  2.066 s …  2.083 s  ┊ GC (min … max): 0.44% … 0.42%
 Time  (median):     2.069 s             ┊ GC (median):    0.42%
 Time  (mean ± σ):   2.073 s ± 9.602 ms  ┊ GC (mean ± σ):  0.29% ± 0.25%

  █        █                                             █
  █▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  2.07 s        Histogram: frequency by time        2.08 s <

 Memory estimate: 106.51 MiB, allocs estimate: 1360405.
```

### After this PR
```julia-repl
julia> bench([10, 100, 1000, 10000])
Results for 10 points:

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  143.500 μs …  17.926 ms  ┊ GC (min … max): 0.00% … 97.78%
 Time  (median):     150.100 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   167.550 μs ± 236.447 μs  ┊ GC (mean ± σ):  4.01% ±  3.31%

  ▆█▇▅▃▃▄▄▃▂▂▁▁▁                                                ▁
  ███████████████▇█▇▇▇▇▆▇▇▆▆▆▆▆▆▅▅▅▅▄▅▅▄▅▅▄▄▅▅▅▄▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅ █
  144 μs        Histogram: log(frequency) by time        336 μs <

 Memory estimate: 124.20 KiB, allocs estimate: 1476.

Results for 100 points:

BenchmarkTools.Trial: 2602 samples with 1 evaluation.
 Range (min … max):  1.637 ms …  19.856 ms  ┊ GC (min … max): 0.00% … 89.87%
 Time  (median):     1.711 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.918 ms ± 930.405 μs  ┊ GC (mean ± σ):  6.26% ± 10.52%

  █▆▄▃▂▂▁
  █████████▇█▇▆▅▇▁▄▁▃▃▁▁▁▃▃▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▃▃▅▅▆▃▅▃▁▅▃▁▃▁▃▁▁▃▅ █
  1.64 ms      Histogram: log(frequency) by time      7.05 ms <

 Memory estimate: 1021.17 KiB, allocs estimate: 9469.

Results for 1000 points:

BenchmarkTools.Trial: 242 samples with 1 evaluation.
 Range (min … max):  18.067 ms … 33.481 ms  ┊ GC (min … max): 0.00% … 42.22%
 Time  (median):     19.552 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   20.603 ms ±  2.643 ms  ┊ GC (mean ± σ):  4.60% ±  8.39%

     ▂▇█▂▅▅▁
  ▆▆▆███████▅▅▄▅▅▅▄▃▃▃▃▃▅▃▄▃▃▃▄▁▁▃▁▁▃▄▁▃▃▃▁▁▃▃▄▄▃▃▁▁▃▃▁▃▁▁▁▃▃ ▃
  18.1 ms         Histogram: frequency by time        29.3 ms <

 Memory estimate: 8.35 MiB, allocs estimate: 87556.

Results for 10000 points:

BenchmarkTools.Trial: 3 samples with 1 evaluation.
 Range (min … max):  2.053 s …   2.115 s  ┊ GC (min … max): 0.00% … 0.51%
 Time  (median):     2.064 s              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.077 s ± 32.766 ms  ┊ GC (mean ± σ):  0.17% ± 0.30%

  █         █                                             █
  █▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  2.05 s         Histogram: frequency by time        2.11 s <

 Memory estimate: 84.92 MiB, allocs estimate: 862476.
```