### PR TITLE
Fix show of big meshes

### DIFF
--- a/src/ioutils.jl
+++ b/src/ioutils.jl
@@ -11,26 +11,21 @@ function prettyname(T::Type)
   replace(name, r".+\." => "")
 end
 
-# helper function to print a large indexable collection
-# in multiple lines with a given tabulation
-function printelms(io::IO, elms, tab="")
-  N = length(elms)
-  I, J = N > 10 ? (5, N - 4) : (N - 1, N)
+# helper function to print the elements of an object
+# in multiple lines with a given number of elements, getter and tabulation
+function printelms(io::IO, obj; nelms=length(obj), getelm=getindex, tab="")
+  I, J = nelms > 10 ? (5, nelms - 4) : (nelms - 1, nelms)
   for i in 1:I
-    println(io, "$(tab)├─ $(elms[i])")
+    println(io, "$(tab)├─ $(getelm(obj, i))")
   end
-  if N > 10
+  if nelms > 10
     println(io, "$(tab)⋮")
   end
-  for i in J:(N - 1)
-    println(io, "$(tab)├─ $(elms[i])")
+  for i in J:(nelms - 1)
+    println(io, "$(tab)├─ $(getelm(obj, i))")
   end
-  print(io, "$(tab)└─ $(elms[N])")
+  print(io, "$(tab)└─ $(getelm(obj, nelms))")
 end
-
-# helper function to print a large iterable
-# calling the printelms function
-printitr(io::IO, itr, tab="") = printelms(io, collect(itr), tab)
 
 # helper function to print the polygons vertices
 function printverts(io::IO, verts)

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -126,17 +126,15 @@ topoconvert(TP::Type{<:Topology}, m::Mesh) = SimpleMesh(vertices(m), convert(TP,
 
 function Base.show(io::IO, ::MIME"text/plain", m::Mesh)
   t = topology(m)
-  verts = vertices(m)
-  elems = elements(t)
   nvert = nvertices(m)
   nelms = nelements(m)
   summary(io, m)
   println(io)
   println(io, "  $nvert vertices")
-  printelms(io, verts, "  ")
+  printelms(io, m, nelms=nvert, getelm=vertex, tab="  ")
   println(io)
   println(io, "  $nelms elements")
-  printitr(io, elems, "  ")
+  printelms(io, t, nelms=nelms, getelm=element, tab="  ")
 end
 
 """

--- a/src/polytopes/polyarea.jl
+++ b/src/polytopes/polyarea.jl
@@ -69,6 +69,6 @@ function Base.show(io::IO, ::MIME"text/plain", p::PolyArea)
   if length(rings) > 1
     println(io)
     println(io, "  inner")
-    printelms(io, @view(rings[2:end]), "  ")
+    printelms(io, @view(rings[2:end]), tab="  ")
   end
 end


### PR DESCRIPTION
This PR updates the `printelms` function to avoid collecting all mesh vertices and all topology elements, which causes a very slow show for large meshes.

MWE:
```
julia> using Meshes

julia> grid = CartesianGrid(10_000, 10_000)
10000×10000 CartesianGrid
├─ minimum: Point(x: 0.0 m, y: 0.0 m)
├─ maximum: Point(x: 10000.0 m, y: 10000.0 m)
└─ spacing: (1.0 m, 1.0 m)

julia> tgrid = grid |> Rotate(π/2) # slow on master
```