### PR TITLE
Make sideof(::Point, ::Ring) serial when convenient

### DIFF
--- a/src/sideof.jl
+++ b/src/sideof.jl
@@ -160,7 +160,7 @@ function _sideof_hao_core(point::Point, pᵢ::Point, pⱼ::Point)
       # case 2
       return ISON
     end 
-end
+  end
   # case 5, 6, 7, 8, 12, 13, 14, 15, 22, 23, 24, 25
   return UNCHANGED
 end

--- a/src/sideof.jl
+++ b/src/sideof.jl
@@ -72,7 +72,7 @@ function _sideof_hao_threads(point::Point, r::Ring)
   k = Threads.Atomic{Int}(0)
   ison = Threads.Atomic{Bool}(false)
   Threads.@threads for i in eachindex(v)
-    _ison, increment_k = _sideof_hao_core(point, v[i], v[i+1])
+    _ison, increment_k = _sideof_hao_core(point, v[i], v[i + 1])
     (ison[] = _ison) && break
     increment_k && Threads.atomic_add!(k, 1)
   end
@@ -83,7 +83,7 @@ function _sideof_hao_serial(point::Point, r::Ring)
   v = vertices(r)
   k = 0
   for i in eachindex(v)
-    ison, increment_k = _sideof_hao_core(point, v[i], v[i+1])
+    ison, increment_k = _sideof_hao_core(point, v[i], v[i + 1])
     ison && return ON
     k += increment_k
   end
@@ -105,7 +105,7 @@ function _sideof_hao_core(point::Point, pᵢ::Point, pⱼ::Point)
   pⱼ = flat(coords(pⱼ))
   xᵢ, yᵢ = pᵢ.x, pᵢ.y
   xⱼ, yⱼ = pⱼ.x, pⱼ.y
-  
+
   v₁ = yᵢ - yₚ
   v₂ = yⱼ - yₚ
 
@@ -121,47 +121,47 @@ function _sideof_hao_core(point::Point, pᵢ::Point, pⱼ::Point)
     # case 3, 9, 16, 21, 13, 24
     f = u₁ * v₂ - u₂ * v₁
     if ispositive(f)
-    # case 3, 9
+      # case 3, 9
       return INCREMENT_K
     elseif isequalzero(f)
-    # case 16, 21
+      # case 16, 21
       return ISON
     end
   elseif ispositive(v₁) && isnonpositive(v₂)
     # case 4, 10, 19, 20, 12, 25
     f = u₁ * v₂ - u₂ * v₁
     if isnegative(f)
-    # case 4, 10
+      # case 4, 10
       return INCREMENT_K
     elseif isequalzero(f)
-    # case 19, 20
+      # case 19, 20
       return ISON
     end
   elseif isequalzero(v₂) && isnegative(v₁)
     # case 7, 14, 17
     f = u₁ * v₂ - u₂ * v₁
     if isequalzero(f)
-    # case 17
+      # case 17
       return ISON
     end
   elseif isequalzero(v₁) && isnegative(v₂)
     # case 8, 15, 18
     f = u₁ * v₂ - u₂ * v₁
     if isequalzero(f)
-    # case 18
+      # case 18
       return ISON
     end
   elseif isequalzero(v₁) && isequalzero(v₂)
     # case 1, 2, 5, 6, 22, 23
     if isnonpositive(u₂) && isnonnegative(u₁)
-    # case 1
+      # case 1
       return ISON
     elseif isnonpositive(u₁) && isnonnegative(u₂)
-    # case 2
+      # case 2
       return ISON
     end 
 end
-# case 5, 6, 7, 8, 12, 13, 14, 15, 22, 23, 24, 25
+  # case 5, 6, 7, 8, 12, 13, 14, 15, 22, 23, 24, 25
   return UNCHANGED
 end
 

--- a/src/sideof.jl
+++ b/src/sideof.jl
@@ -159,12 +159,11 @@ function _sideof_hao_core(point::Point, pᵢ::Point, pⱼ::Point)
     elseif isnonpositive(u₁) && isnonnegative(u₂)
       # case 2
       return ISON
-    end 
+    end
   end
   # case 5, 6, 7, 8, 12, 13, 14, 15, 22, 23, 24, 25
   return UNCHANGED
 end
-
 
 # -----
 # MESH

--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -66,7 +66,7 @@
   # sideof serial vs parallel
   r = randpoint2(500) |> Ring
   p = Point(2, 2)
-  serial = Meshes._sideof_hao_serial(p, r)
-  parallel = Meshes._sideof_hao_threads(p, r)
+  serial = Meshes._sideofserial(p, r)
+  parallel = Meshes._sideofthreads(p, r)
   @test serial === parallel
 end

--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -62,4 +62,11 @@
   connec = connect.([(1, 2, 3, 4)], [Tetrahedron])
   mesh = SimpleMesh(points, connec)
   @test_throws AssertionError("winding number only defined for surface meshes") sideof(cart(0, 0, 0), mesh)
+
+  # sideof serial vs parallel
+  r = randpoint2(500) |> Ring
+  p = Point(2,2)
+  serial = Meshes._sideof_hao_serial(p, r)
+  parallel = Meshes._sideof_hao_threads(p, r)
+  @test serial === parallel
 end

--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -65,7 +65,7 @@
 
   # sideof serial vs parallel
   r = randpoint2(500) |> Ring
-  p = Point(2,2)
+  p = Point(2, 2)
   serial = Meshes._sideof_hao_serial(p, r)
   parallel = Meshes._sideof_hao_threads(p, r)
   @test serial === parallel

--- a/test/sideof.jl
+++ b/test/sideof.jl
@@ -63,10 +63,10 @@
   mesh = SimpleMesh(points, connec)
   @test_throws AssertionError("winding number only defined for surface meshes") sideof(cart(0, 0, 0), mesh)
 
-  # sideof serial vs parallel
-  r = randpoint2(500) |> Ring
-  p = Point(2, 2)
+  # sideof serial vs threads
+  p = first(randpoint2(1))
+  r = Ring(randpoint2(500))
   serial = Meshes._sideofserial(p, r)
-  parallel = Meshes._sideofthreads(p, r)
-  @test serial === parallel
+  threads = Meshes._sideofthreads(p, r)
+  @test serial == threads
 end


### PR DESCRIPTION
This PR refactor the code of `sideof` in order to separate into a serial and a parallel verision. The new function will call the serial version when `n <= 1000` or when `Threads.nthreads() == 1`, significantly reducing the overhead for rings with few points (especially relevant when starting julia with many cores).

This should close #988.

# Benchmarks
The benchmarks are generated with the following helper functions:

```julia
using Meshes, Chairmarks

sampledcircle(n) = sample(Sphere((0, 0), 1), RegularSampling(n)) |> splat(Ring)
function compactversion()
    println("#===== Version Info ====#")
    println("Julia Version: $VERSION")
    println("OS: ", Sys.iswindows() ? "Windows" : Sys.isapple() ?
        "macOS" : Sys.KERNEL, " (", Sys.MACHINE, ")")
    cpu = Sys.cpu_info()
    println("CPU: ", length(cpu), " × ", cpu[1].model)
    println("Threads: $(Threads.nthreads()) (on $(Sys.CPU_THREADS) virtual cores)")
end
function bench(ns, p)
    printed = false
    compactversion()
    println("#===== Benchmarks ====#")
    for n in ns
        if printed
            sleep(.5) # coolodown to prevent CPU throttling
        else
            printed = true
        end
        s = sampledcircle(n)
        b = @b sideof($p, $s)
        bres = sprint(show, MIME"text/plain"(), b)
        println("n = $n, $bres")
    end
end

bench([100, 1000, 3000, 5000, 10000, 20000], Point(2, 2))
```

## After this PR
### 1 thread
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 1 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 395.775 ns
n = 1000, 3.800 μs
n = 3000, 11.400 μs
n = 5000, 19.000 μs
n = 10000, 38.200 μs
n = 20000, 76.300 μs
```
### 4 threads
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 4 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 395.890 ns
n = 1000, 3.800 μs
n = 3000, 5.167 μs (24 allocs: 2.625 KiB)
n = 5000, 7.000 μs (24 allocs: 2.625 KiB)
n = 10000, 11.900 μs (24 allocs: 2.625 KiB)
n = 20000, 21.700 μs (24 allocs: 2.625 KiB)
```
### 8 threads
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 8 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 398.649 ns
n = 1000, 3.840 μs
n = 3000, 5.650 μs (44 allocs: 5.156 KiB)
n = 5000, 6.400 μs (44 allocs: 5.156 KiB)
n = 10000, 11.500 μs (44 allocs: 5.156 KiB)
n = 20000, 19.900 μs (44 allocs: 5.156 KiB)
```
### 16 threads
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 16 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 402.817 ns
n = 1000, 3.900 μs
n = 3000, 7.200 μs (84 allocs: 10.219 KiB)
n = 5000, 9.100 μs (84 allocs: 10.219 KiB)
n = 10000, 10.500 μs (84 allocs: 10.219 KiB)
n = 20000, 14.800 μs (84 allocs: 10.219 KiB)
```
## Before this PR (v0.48.2)
### 1 thread
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 1 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 1.243 μs (9 allocs: 752 bytes)
n = 1000, 4.700 μs (9 allocs: 752 bytes)
n = 3000, 12.600 μs (9 allocs: 752 bytes)
n = 5000, 20.400 μs (9 allocs: 752 bytes)
n = 10000, 39.900 μs (9 allocs: 752 bytes)
n = 20000, 78.900 μs (9 allocs: 752 bytes)
```
### 4 threads
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 4 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 2.633 μs (24 allocs: 2.688 KiB)
n = 1000, 3.000 μs (24 allocs: 2.688 KiB)
n = 3000, 4.900 μs (24 allocs: 2.688 KiB)
n = 5000, 6.800 μs (24 allocs: 2.688 KiB)
n = 10000, 11.800 μs (24 allocs: 2.688 KiB)
n = 20000, 21.800 μs (24 allocs: 2.688 KiB)
```
### 8 threads
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 8 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 3.900 μs (44 allocs: 5.281 KiB)
n = 1000, 4.567 μs (44 allocs: 5.281 KiB)
n = 3000, 5.200 μs (44 allocs: 5.281 KiB)
n = 5000, 6.800 μs (44 allocs: 5.281 KiB)
n = 10000, 10.900 μs (44 allocs: 5.281 KiB)
n = 20000, 20.400 μs (44 allocs: 5.281 KiB)
```
### 16 threads
```julia-repl
#===== Version Info ====#
Julia Version: 1.11.0-rc2
OS: Windows (x86_64-w64-mingw32)
CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12800H
Threads: 16 (on 20 virtual cores)
#===== Benchmarks ====#
n = 100, 8.700 μs (84 allocs: 10.469 KiB)
n = 1000, 6.600 μs (84 allocs: 10.469 KiB)
n = 3000, 7.800 μs (84 allocs: 10.469 KiB)
n = 5000, 7.700 μs (84 allocs: 10.469 KiB)
n = 10000, 11.850 μs (84 allocs: 10.469 KiB)
n = 20000, 15.800 μs (84 allocs: 10.469 KiB)
```