### PR TITLE
Viz geometries with globe manifold and `paramdim=1` using `MaxLengthDiscretization`

### DIFF
--- a/ext/geometryset.jl
+++ b/ext/geometryset.jl
@@ -26,6 +26,21 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val{0}, ::Val, geoms::ObservableVector
   Makie.scatter!(plot, coords, color=colorant, marker=pointmarker, markersize=pointsize, overdraw=true)
 end
 
+function vizgset!(plot, ::Type{<:🌐}, ::Val{1}, ::Val, geoms, colorant)
+  showpoints = plot[:showpoints]
+
+  meshes = Makie.@lift begin
+    T = numtype(Meshes.lentype(first($geoms)))
+    method = MaxLengthDiscretization(T(1e6))
+    [discretize(g, method) for g in $geoms]
+  end
+  vizmany!(plot, meshes, colorant)
+
+  if showpoints[]
+    vizfacets!(plot, geoms)
+  end
+end
+
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{1}, ::Val, geoms, colorant)
   showpoints = plot[:showpoints]
 


### PR DESCRIPTION
The default maximum length I chose is `1e6 m`.