### PR TITLE
Viz: Reverse the connectivity of grids with CW orientation

### DIFF
--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -61,7 +61,7 @@ function vizgridfallback!(plot, M, pdim, edim)
   # or when there is a large number of elements
   if pdim == Val(2) && (ncolor[] == 1 || ncolor[] == nverts[] || nelems[] ≥ 1000)
     # decide whether or not to reverse connectivity list
-    rfunc = Makie.@lift _reverse(crs($grid))
+    rfunc = Makie.@lift _reverse(first($grid))
 
     verts = Makie.@lift map(asmakie, vertices($grid))
     quads = Makie.@lift [GB.QuadFace($rfunc(indices(e))) for e in elements(topology($grid))]
@@ -94,8 +94,7 @@ function vizgridfallback!(plot, M, pdim, edim)
   end
 end
 
-_reverse(::Type{<:CRS}) = identity
-_reverse(::Type{<:LatLon}) = reverse
+_reverse(quad) = orientation(quad) == CW ? reverse : identity
 
 # helper functions to create a minimum number
 # of line segments within Cartesian/Rectilinear grid


### PR DESCRIPTION
This PR changes the "reverse" heuristic to check the orientation of the first element.

This fixes the following lighting bug in master:
```julia
grid = RegularGrid(Point(Robinson(-5.5e6, 6.4e6)), Point(Robinson(-5.4e6, 6.5e6)), (100, 50))
g = grid |> Proj(LatLon)
viz(g)
```
![image](https://github.com/user-attachments/assets/984ea3e5-cda2-4e34-abe9-7cc94720583c)


PR:
![image](https://github.com/user-attachments/assets/6d25e510-4f31-4215-9fb4-a5e2005cdf16)

The lighting of Natural Earth plots remains correct:
![image](https://github.com/user-attachments/assets/9f85c72e-51af-46ec-813a-01cfb26435b8)
