### PR TITLE
Viz boxes with globe manifold using `MaxLengthDiscretization`

### DIFF
--- a/ext/geometryset.jl
+++ b/ext/geometryset.jl
@@ -102,6 +102,21 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, geoms::ObservableVec
   end
 end
 
+function vizgset!(plot, ::Type{<:🌐}, ::Val{2}, ::Val, geoms::ObservableVector{<:Box}, colorant)
+  showsegments = plot[:showsegments]
+
+  meshes = Makie.@lift begin
+    T = numtype(Meshes.lentype(first($geoms)))
+    method = MaxLengthDiscretization(T(100) * u"km")
+    [discretize(g, method) for g in $geoms]
+  end
+  vizmany!(plot, meshes, colorant)
+
+  if showsegments[]
+    vizfacets!(plot, geoms)
+  end
+end
+
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{3}, ::Val, geoms, colorant)
   meshes = Makie.@lift discretize.(boundary.($geoms))
   vizmany!(plot, meshes, colorant)


### PR DESCRIPTION
The default maximum length I chose is `100 km`.

Example:
```julia
b = Box(Point(LatLon(0, 170)), Point(LatLon(45, 90)))
viz(b)
```

master:
```
julia> viz(b)
ERROR: StackOverflowError:
```

PR:
![image](https://github.com/user-attachments/assets/dde02e21-30b1-40a7-b0d2-1f4889f5306a)
