### PR TITLE
Fix parameterization of `Segement` with ellipsoid manifold

### DIFF
--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -26,12 +26,22 @@ Base.extrema(s::Segment) = s.vertices[1], s.vertices[2]
 Base.isapprox(s₁::Segment, s₂::Segment; atol=atol(lentype(s₁)), kwargs...) =
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))
 
-function (s::Segment)(t)
+function (s::Segment{<:𝔼})(t)
   if t < 0 || t > 1
     throw(DomainError(t, "s(t) is not defined for t outside [0, 1]."))
   end
   a, b = s.vertices
   a + t * (b - a)
+end
+
+function (s::Segment{<:🌐})(t)
+  if t < 0 || t > 1
+    throw(DomainError(t, "s(t) is not defined for t outside [0, 1]."))
+  end
+  verts = convert.(LatLon, coords.(s.vertices))
+  a, b = CoordRefSystems.values.(verts)
+  vals = a .+ t .* (b .- a)
+  withcrs(s, vals, LatLon)
 end
 
 Base.reverse(s::Segment) = Segment(reverse(extrema(s)))

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -82,6 +82,14 @@
   s = Segment(latlon(0, 135), latlon(0, 45))
   @test_broken measure(s) ≈ 3C / 4
 
+  # parameterization
+  s = Segment(latlon(45, 0), latlon(45, 90))
+  @test s(T(0)) == latlon(45, 0)
+  @test s(T(0.25)) == latlon(45, 22.5)
+  @test s(T(0.5)) == latlon(45, 45)
+  @test s(T(0.75)) == latlon(45, 67.5)
+  @test s(T(1)) == latlon(45, 90)
+
   s = Segment(cart(0, 0), cart(1, 1))
   @test sprint(show, s) == "Segment((x: 0.0 m, y: 0.0 m), (x: 1.0 m, y: 1.0 m))"
   if T === Float32


### PR DESCRIPTION
Code:
```julia
julia> using Meshes, CoordRefSystems

julia> latlon(args...) = Point(LatLon(args...))
latlon (generic function with 1 method)

julia> s = Segment(latlon(45, 0), latlon(45, 90))
Segment
├─ Point(lat: 45.0°, lon: 0.0°)
└─ Point(lat: 45.0°, lon: 90.0°)
```

master:
```julia
julia> s(0)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 44.99999999999999°
└─ lon: 0.0°

julia> s(0.25)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 51.69172630922252°
└─ lon: 18.434948822922014°

julia> s(0.5)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 54.76375232553122°
└─ lon: 45.0°

julia> s(0.75)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 51.69172630922252°
└─ lon: 71.56505117707799°

julia> s(1)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 44.99999999999999°
└─ lon: 90.0°
```
PR:
```julia
julia> s(0)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 45.0°
└─ lon: 0.0°

julia> s(0.25)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 45.0°
└─ lon: 22.5°

julia> s(0.5)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 45.0°
└─ lon: 45.0°

julia> s(0.75)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 45.0°
└─ lon: 67.5°

julia> s(1)
Point with GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 45.0°
└─ lon: 90.0°
```

Plotting segments:
```julia
julia> b = Box(latlon(0, 90), latlon(45, 180))
Box
├─ min: Point(lat: 0.0°, lon: 90.0°)
└─ max: Point(lat: 45.0°, lon: 180.0°)

julia> viz(b, showsegments=true)
```
master:
![image](https://github.com/user-attachments/assets/01f235ec-9957-44f6-b5af-bb786ece44a1)

PR:
![image](https://github.com/user-attachments/assets/b6b9e93f-a151-404a-aa17-210bbb1da54b)

