### PR TITLE
Fix docstring rendering

### DIFF
--- a/src/transforms/smoothing.jl
+++ b/src/transforms/smoothing.jl
@@ -66,7 +66,7 @@ function _smooth(mesh, L, n, λ, μ; revert=false)
 end
 
 """
-LaplaceSmoothing(n, λ=0.5)
+    LaplaceSmoothing(n, λ=0.5)
 
 Perform `n` iterations of Laplace smoothing with parameter `λ`.
 
@@ -78,7 +78,7 @@ Perform `n` iterations of Laplace smoothing with parameter `λ`.
 LaplaceSmoothing(n, λ=0.5) = LambdaMuSmoothing(n, λ, zero(λ))
 
 """
-TaubinSmoothing(n, λ=0.5)
+    TaubinSmoothing(n, λ=0.5)
 
 Perform `n` iterations of Taubin smoothing with parameter `0 < λ < 1`.
 


### PR DESCRIPTION
Some white spaces were missing to render the docstring correctly, see, e.g. https://juliageometry.github.io/MeshesDocs/stable/transforms/#Meshes.LaplaceSmoothing.