### PR TITLE
Add `isparametrized` for `Cone`

### DIFF
--- a/src/predicates/isparametrized.jl
+++ b/src/predicates/isparametrized.jl
@@ -43,6 +43,8 @@ isparametrized(::Type{<:Cylinder}) = true
 
 isparametrized(::Type{<:CylinderSurface}) = true
 
+isparametrized(::Type{<:Cone}) = true
+
 isparametrized(::Type{<:ConeSurface}) = true
 
 isparametrized(::Type{<:FrustumSurface}) = true

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -127,7 +127,7 @@ end
   @test isparametrized(Cylinder)
   @test isparametrized(CylinderSurface)
   @test isparametrized(ConeSurface)
-  @test isparametrized(ConeSurface)
+  @test isparametrized(Cone)
   @test isparametrized(ParaboloidSurface)
   @test isparametrized(Torus)
 

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -127,6 +127,7 @@ end
   @test isparametrized(Cylinder)
   @test isparametrized(CylinderSurface)
   @test isparametrized(ConeSurface)
+  @test isparametrized(ConeSurface)
   @test isparametrized(ParaboloidSurface)
   @test isparametrized(Torus)
 

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -126,8 +126,8 @@ end
   @test isparametrized(ParametrizedCurve)
   @test isparametrized(Cylinder)
   @test isparametrized(CylinderSurface)
-  @test isparametrized(ConeSurface)
   @test isparametrized(Cone)
+  @test isparametrized(ConeSurface)
   @test isparametrized(ParaboloidSurface)
   @test isparametrized(Torus)
 


### PR DESCRIPTION
`Cone` is parametrized, but `isparametrized(cone)` gave `false`. This PR fixes this by adding the missing method.