### PR TITLE
Use `MaxLengthDiscretization` to visualize geometries with globe manifold

### DIFF
--- a/ext/geometryset.jl
+++ b/ext/geometryset.jl
@@ -26,25 +26,10 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val{0}, ::Val, geoms::ObservableVector
   Makie.scatter!(plot, coords, color=colorant, marker=pointmarker, markersize=pointsize, overdraw=true)
 end
 
-function vizgset!(plot, ::Type{<:🌐}, ::Val{1}, ::Val, geoms, colorant)
-  showpoints = plot[:showpoints]
-
-  meshes = Makie.@lift begin
-    T = numtype(Meshes.lentype(first($geoms)))
-    method = MaxLengthDiscretization(T(1000) * u"km")
-    [discretize(g, method) for g in $geoms]
-  end
-  vizmany!(plot, meshes, colorant)
-
-  if showpoints[]
-    vizfacets!(plot, geoms)
-  end
-end
-
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{1}, ::Val, geoms, colorant)
   showpoints = plot[:showpoints]
 
-  meshes = Makie.@lift discretize.($geoms)
+  meshes = Makie.@lift _discretize.($geoms)
   vizmany!(plot, meshes, colorant)
 
   if showpoints[]
@@ -75,7 +60,7 @@ end
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val, geoms, colorant)
   showsegments = plot[:showsegments]
 
-  meshes = Makie.@lift discretize.($geoms)
+  meshes = Makie.@lift _discretize.($geoms)
   vizmany!(plot, meshes, colorant)
 
   if showsegments[]
@@ -102,23 +87,8 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, geoms::ObservableVec
   end
 end
 
-function vizgset!(plot, ::Type{<:🌐}, ::Val{2}, ::Val, geoms::ObservableVector{<:Box}, colorant)
-  showsegments = plot[:showsegments]
-
-  meshes = Makie.@lift begin
-    T = numtype(Meshes.lentype(first($geoms)))
-    method = MaxLengthDiscretization(T(100) * u"km")
-    [discretize(g, method) for g in $geoms]
-  end
-  vizmany!(plot, meshes, colorant)
-
-  if showsegments[]
-    vizfacets!(plot, geoms)
-  end
-end
-
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{3}, ::Val, geoms, colorant)
-  meshes = Makie.@lift discretize.(boundary.($geoms))
+  meshes = Makie.@lift _discretize.(boundary.($geoms))
   vizmany!(plot, meshes, colorant)
 end
 

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -156,7 +156,7 @@ function vizmesh!(plot, ::Type{<:𝔼}, ::Val{3}, ::Val)
   meshes = Makie.@lift let
     geoms = elements($mesh)
     bounds = boundary.(geoms)
-    discretize.(bounds)
+    _discretize.(bounds)
   end
   vizmany!(plot, meshes, color)
 end

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -58,5 +58,3 @@ function _discretize(geom::Geometry{🌐})
   T = numtype(Meshes.lentype(geom))
   discretize(geom, MaxLengthDiscretization(T(1000) * u"km"))
 end
-
-_discretize(multi::Multi) = mapreduce(_discretize, merge, parent(multi))

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -46,3 +46,17 @@ end
 asmakie(p::Point) = Makie.Point{embeddim(p),numtype(lentype(p))}(ustrip.(Tuple(to(p))))
 
 asmakie(v::Vec) = Makie.Vec{length(v),numtype(eltype(v))}(ustrip.(Tuple(v)))
+
+_discretize(geom) = discretize(geom)
+
+function _discretize(box::Box{🌐})
+  T = numtype(Meshes.lentype(box))
+  discretize(box, MaxLengthDiscretization(T(100) * u"km"))
+end
+
+function _discretize(geom::Geometry{🌐})
+  T = numtype(Meshes.lentype(geom))
+  discretize(geom, MaxLengthDiscretization(T(1000) * u"km"))
+end
+
+_discretize(multi::Multi) = mapreduce(_discretize, merge, parent(multi))


### PR DESCRIPTION
# Examples

## Setup
```julia
using Meshes, CoordRefSystems
import GLMakie as Mke
latlon(args...) = Point(LatLon(args...))
```

```julia
box = Box(latlon(0, 0), latlon(45, 45))
viz(box)
```
![image](https://github.com/user-attachments/assets/a604fd27-beaa-4f9f-9cc6-ad43f9d744d3)

```julia
ring = Ring(latlon(-45, 90), latlon(45, 90), latlon(45, -90), latlon(-45, -90))
viz(ring)
```
![image](https://github.com/user-attachments/assets/9f64e298-ba7e-4f42-91b9-ddc58512bf32)

```julia
quad1 = Quadrangle(latlon(0, 0), latlon(0, 45), latlon(45, 45), latlon(45, 0))
quad2 = Quadrangle(latlon(0, 0), latlon(-45, 0), latlon(-45, 45), latlon(0, 45))
multi = Multi([quad1, quad2])
viz(multi)
```
![image](https://github.com/user-attachments/assets/8a79a8b2-f380-42d3-b351-dfba8f236bab)
