### PR TITLE
Fix `Proj` methods & Add `MaxLengthDiscretization` method for `TransformedGeometry`

### DIFF
--- a/src/discretization/maxlength.jl
+++ b/src/discretization/maxlength.jl
@@ -29,6 +29,9 @@ discretize(chain::Chain, method::MaxLengthDiscretization) =
 
 discretize(multi::Multi, method::MaxLengthDiscretization) = _iterativerefinement(multi, method)
 
+discretize(geometry::TransformedGeometry, method::MaxLengthDiscretization) =
+  transform(geometry)(discretize(parent(geometry), method))
+
 discretize(geometry::Geometry, method::MaxLengthDiscretization) = _iterativerefinement(geometry, method)
 
 # -----------------

--- a/src/transforms/morphological.jl
+++ b/src/transforms/morphological.jl
@@ -30,10 +30,10 @@ applycoord(::Morphological, v::Vec) = v
 # SPECIAL CASES
 # --------------
 
+applycoord(t::Morphological, g::Geometry) = TransformedGeometry(g, t)
+
 # method to fix ambiguities
 applycoord(t::Morphological, g::TransformedGeometry) = TransformedGeometry(g, t)
-
-applycoord(t::Morphological, g::Geometry) = TransformedGeometry(g, t)
 
 applycoord(t::Morphological, g::RegularGrid) = TransformedGrid(g, t)
 

--- a/src/transforms/morphological.jl
+++ b/src/transforms/morphological.jl
@@ -30,6 +30,9 @@ applycoord(::Morphological, v::Vec) = v
 # SPECIAL CASES
 # --------------
 
+# method to fix ambiguities
+applycoord(t::Morphological, m::TransformedGeometry) = TransformedGeometry(m, t)
+
 applycoord(t::Morphological, g::Geometry) = TransformedGeometry(g, t)
 
 applycoord(t::Morphological, g::RegularGrid) = TransformedGrid(g, t)

--- a/src/transforms/morphological.jl
+++ b/src/transforms/morphological.jl
@@ -31,7 +31,7 @@ applycoord(::Morphological, v::Vec) = v
 # --------------
 
 # method to fix ambiguities
-applycoord(t::Morphological, m::TransformedGeometry) = TransformedGeometry(m, t)
+applycoord(t::Morphological, g::TransformedGeometry) = TransformedGeometry(g, t)
 
 applycoord(t::Morphological, g::Geometry) = TransformedGeometry(g, t)
 

--- a/src/transforms/proj.jl
+++ b/src/transforms/proj.jl
@@ -51,9 +51,9 @@ applycoord(::Proj, v::Vec) = v
 # SPECIAL CASES
 # --------------
 
-applycoord(t::Proj{<:Projected}, g::Primitive{<:🌐}) = TransformedGeometry(g, t)
+applycoord(t::Proj{<:Projected}, g::Geometry{<:🌐}) = TransformedGeometry(g, t)
 
-applycoord(t::Proj{<:Geographic}, g::Primitive{<:𝔼}) = TransformedGeometry(g, t)
+applycoord(t::Proj{<:Geographic}, g::Geometry{<:𝔼}) = TransformedGeometry(g, t)
 
 applycoord(t::Proj, g::RegularGrid) = TransformedGrid(g, t)
 

--- a/src/transforms/proj.jl
+++ b/src/transforms/proj.jl
@@ -51,13 +51,13 @@ applycoord(::Proj, v::Vec) = v
 # SPECIAL CASES
 # --------------
 
-# methods to fix ambiguities
-applycoord(t::Proj{<:Projected}, g::TransformedGeometry{<:🌐}) = TransformedGeometry(g, t)
-applycoord(t::Proj{<:Geographic}, g::TransformedGeometry{<:𝔼}) = TransformedGeometry(g, t)
-
 applycoord(t::Proj{<:Projected}, g::Geometry{<:🌐}) = TransformedGeometry(g, t)
 
 applycoord(t::Proj{<:Geographic}, g::Geometry{<:𝔼}) = TransformedGeometry(g, t)
+
+# methods to fix ambiguities
+applycoord(t::Proj{<:Projected}, g::TransformedGeometry{<:🌐}) = TransformedGeometry(g, t)
+applycoord(t::Proj{<:Geographic}, g::TransformedGeometry{<:𝔼}) = TransformedGeometry(g, t)
 
 applycoord(t::Proj, g::RegularGrid) = TransformedGrid(g, t)
 

--- a/src/transforms/proj.jl
+++ b/src/transforms/proj.jl
@@ -51,6 +51,9 @@ applycoord(::Proj, v::Vec) = v
 # SPECIAL CASES
 # --------------
 
+# method to fix ambiguities
+applycoord(t::Proj, m::TransformedGeometry) = TransformedGeometry(m, t)
+
 applycoord(t::Proj{<:Projected}, g::Geometry{<:🌐}) = TransformedGeometry(g, t)
 
 applycoord(t::Proj{<:Geographic}, g::Geometry{<:𝔼}) = TransformedGeometry(g, t)

--- a/src/transforms/proj.jl
+++ b/src/transforms/proj.jl
@@ -52,7 +52,7 @@ applycoord(::Proj, v::Vec) = v
 # --------------
 
 # method to fix ambiguities
-applycoord(t::Proj, m::TransformedGeometry) = TransformedGeometry(m, t)
+applycoord(t::Proj, g::TransformedGeometry) = TransformedGeometry(g, t)
 
 applycoord(t::Proj{<:Projected}, g::Geometry{<:🌐}) = TransformedGeometry(g, t)
 

--- a/src/transforms/proj.jl
+++ b/src/transforms/proj.jl
@@ -51,8 +51,9 @@ applycoord(::Proj, v::Vec) = v
 # SPECIAL CASES
 # --------------
 
-# method to fix ambiguities
-applycoord(t::Proj, g::TransformedGeometry) = TransformedGeometry(g, t)
+# methods to fix ambiguities
+applycoord(t::Proj{<:Projected}, g::TransformedGeometry{<:🌐}) = TransformedGeometry(g, t)
+applycoord(t::Proj{<:Geographic}, g::TransformedGeometry{<:𝔼}) = TransformedGeometry(g, t)
 
 applycoord(t::Proj{<:Projected}, g::Geometry{<:🌐}) = TransformedGeometry(g, t)
 

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -519,6 +519,14 @@ end
   @test nelements(mesh) == 256
   @test eltype(mesh) <: Triangle
   @test nvertices.(mesh) ⊆ [3]
+
+  box = Box(latlon(0, 0), latlon(45, 45))
+  tbox = TransformedGeometry(box, Proj(Mercator))
+  mesh = discretize(tbox, MaxLengthDiscretization(T(1e5)))
+  @test nvertices(mesh) == 52 * 52
+  @test nelements(mesh) == 51 * 51
+  @test eltype(mesh) <: Quadrangle
+  @test nvertices.(mesh) ⊆ [4]
 end
 
 @testitem "Discretize" setup = [Setup] begin

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -30,10 +30,8 @@
   q = Quadrangle(latlon(0, 0), latlon(0, 1), latlon(1, 1), latlon(1, 0)) |> Proj(WebMercator)
   geoms = [s, t, q]
   gset = GeometrySet(geoms)
-  @test eltype(gset) <: Geometry
   @test crs(gset) <: LatLon
   gset = GeometrySet(g for g in geoms)
-  @test eltype(gset) <: Geometry
   @test crs(gset) <: LatLon
   geoms = [t, s, q]
   gset = GeometrySet(geoms)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -30,24 +30,24 @@
   q = Quadrangle(latlon(0, 0), latlon(0, 1), latlon(1, 1), latlon(1, 0)) |> Proj(WebMercator)
   geoms = [s, t, q]
   gset = GeometrySet(geoms)
-  @test eltype(gset) <: Polytope
+  @test eltype(gset) <: Geometry
   @test crs(gset) <: LatLon
   gset = GeometrySet(g for g in geoms)
-  @test eltype(gset) <: Polytope
+  @test eltype(gset) <: Geometry
   @test crs(gset) <: LatLon
   geoms = [t, s, q]
   gset = GeometrySet(geoms)
-  @test eltype(gset) <: Polytope
+  @test eltype(gset) <: TransformedGeometry
   @test crs(gset) <: PlateCarree
   gset = GeometrySet(g for g in geoms)
-  @test eltype(gset) <: Polytope
+  @test eltype(gset) <: TransformedGeometry
   @test crs(gset) <: PlateCarree
   geoms = [q, s, t]
   gset = GeometrySet(geoms)
-  @test eltype(gset) <: Polytope
+  @test eltype(gset) <: TransformedGeometry
   @test crs(gset) <: WebMercator
   gset = GeometrySet(g for g in geoms)
-  @test eltype(gset) <: Polytope
+  @test eltype(gset) <: TransformedGeometry
   @test crs(gset) <: WebMercator
 
   # conversion

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1221,6 +1221,16 @@ end
   r, c = TB.apply(f, g)
   @test r ≈ Cylinder(Point(Cylindrical(T(0), T(0), T(0))), Point(Cylindrical(T(√2), T(π / 4), T(1))))
 
+  # --------------------
+  # TRANSFORMEDGEOMETRY
+  # --------------------
+
+  f = Proj(Polar)
+  b = Box(cart(0, 0), cart(1, 1))
+  g = TransformedGeometry(b, Identity())
+  r, c = TB.apply(f, g)
+  @test r ≈ Box(Point(Polar(T(0), T(0))), Point(Polar(T(√2), T(π / 4))))
+
   # ---------
   # POINTSET
   # ---------
@@ -1387,6 +1397,16 @@ end
   g = Multi([t, t])
   r, c = TB.apply(f, g)
   @test r ≈ Multi([f(t), f(t)])
+
+  # --------------------
+  # TRANSFORMEDGEOMETRY
+  # --------------------
+
+  f = Morphological(c -> Cartesian(c.x, c.y, zero(c.x)))
+  b = Box(cart(0, 0), cart(1, 1))
+  g = TransformedGeometry(b, Identity())
+  r, c = TB.apply(f, g)
+  @test r ≈ Quadrangle(cart(0, 0, 0), cart(1, 0, 0), cart(1, 1, 0), cart(0, 1, 0))
 
   # ---------
   # POINTSET

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1225,11 +1225,17 @@ end
   # TRANSFORMEDGEOMETRY
   # --------------------
 
-  f = Proj(Polar)
-  b = Box(cart(0, 0), cart(1, 1))
+  f = Proj(Mercator)
+  b = Box(latlon(0, 0), latlon(45, 45))
   g = TransformedGeometry(b, Identity())
   r, c = TB.apply(f, g)
-  @test r ≈ Box(Point(Polar(T(0), T(0))), Point(Polar(T(√2), T(π / 4))))
+  @test r ≈ Box(f(minimum(b)), f(maximum(b)))
+
+  f = Proj(LatLon)
+  b = Box(merc(0, 0), merc(1, 1))
+  g = TransformedGeometry(b, Identity())
+  r, c = TB.apply(f, g)
+  @test r ≈ Box(f(minimum(b)), f(maximum(b)))
 
   # ---------
   # POINTSET


### PR DESCRIPTION
`Proj` methods should use `Geometry` instead of `Primitive` for correctness.

The `MaxLengthDiscretization` method for `TransformedGeometry` has been added to fix ambiguities:
```julia
julia> discretize(geom, MaxLengthDiscretization(1e6))
ERROR: MethodError: discretize(::TransformedGeometry{𝔼{…}, Robinson{…}, Box{…}, Proj{…}}, ::MaxLengthDiscretization{Unitful.Quantity{…}}) is ambiguous.

Candidates:
  discretize(tgeom::TransformedGeometry, method::DiscretizationMethod)
    @ Meshes ~/Documentos/JuliaDev/Meshes.jl/src/discretization.jl:82
  discretize(geometry::Geometry, method::MaxLengthDiscretization)
    @ Meshes ~/Documentos/JuliaDev/Meshes.jl/src/discretization/maxlength.jl:32

Possible fix, define
  discretize(::TransformedGeometry, ::MaxLengthDiscretization)
  ```