### PR TITLE
Add `MinDistanceSampling` for 3D Ball

### DIFF
--- a/src/sampling/mindistance.jl
+++ b/src/sampling/mindistance.jl
@@ -37,7 +37,11 @@ MinDistanceSampling(α, ρ, δ, metric) = MinDistanceSampling(addunit(α, u"m"),
 
 MinDistanceSampling(α::T; ρ=T(0.65), δ=100, metric=Euclidean()) where {T} = MinDistanceSampling(α, ρ, δ, metric)
 
-function sample(rng::AbstractRNG, obj::GeometryOrDomain, method::MinDistanceSampling)
+sample(rng::AbstractRNG, d::Domain, method::MinDistanceSampling) = _sample(rng, d, method)
+
+sample(rng::AbstractRNG, b::Ball, method::MinDistanceSampling) = _sample(rng, b, method)
+
+function _sample(rng::AbstractRNG, obj, method::MinDistanceSampling)
   # retrieve parameters
   α = method.α
   ρ = method.ρ

--- a/src/sampling/mindistance.jl
+++ b/src/sampling/mindistance.jl
@@ -37,7 +37,10 @@ MinDistanceSampling(α, ρ, δ, metric) = MinDistanceSampling(addunit(α, u"m"),
 
 MinDistanceSampling(α::T; ρ=T(0.65), δ=100, metric=Euclidean()) where {T} = MinDistanceSampling(α, ρ, δ, metric)
 
-function sample(rng::AbstractRNG, d::Domain, method::MinDistanceSampling)
+_measure(d::Domain) = sum(measure, d)
+_measure(d::Ball) = measure(d)
+
+function sample(rng::AbstractRNG, d::Union{Domain, Ball}, method::MinDistanceSampling)
   # retrieve parameters
   α = method.α
   ρ = method.ρ
@@ -45,7 +48,7 @@ function sample(rng::AbstractRNG, d::Domain, method::MinDistanceSampling)
   m = method.metric
 
   # total volume/area of the object
-  V = sum(measure, d)
+  V = _measure(d)
 
   # expected number of Poisson samples
   # for relative radius (Lagae & Dutré 2007)

--- a/src/sampling/mindistance.jl
+++ b/src/sampling/mindistance.jl
@@ -37,10 +37,7 @@ MinDistanceSampling(α, ρ, δ, metric) = MinDistanceSampling(addunit(α, u"m"),
 
 MinDistanceSampling(α::T; ρ=T(0.65), δ=100, metric=Euclidean()) where {T} = MinDistanceSampling(α, ρ, δ, metric)
 
-_measure(d::Domain) = sum(measure, d)
-_measure(d::Ball) = measure(d)
-
-function sample(rng::AbstractRNG, d::Union{Domain,Ball}, method::MinDistanceSampling)
+function sample(rng::AbstractRNG, obj::GeometryOrDomain, method::MinDistanceSampling)
   # retrieve parameters
   α = method.α
   ρ = method.ρ
@@ -48,7 +45,7 @@ function sample(rng::AbstractRNG, d::Union{Domain,Ball}, method::MinDistanceSamp
   m = method.metric
 
   # total volume/area of the object
-  V = _measure(d)
+  V = measure(obj)
 
   # expected number of Poisson samples
   # for relative radius (Lagae & Dutré 2007)
@@ -58,7 +55,7 @@ function sample(rng::AbstractRNG, d::Union{Domain,Ball}, method::MinDistanceSamp
   O = ceil(Int, δ * ustrip(N))
 
   # oversample the object
-  points = sample(rng, d, HomogeneousSampling(O))
+  points = sample(rng, obj, HomogeneousSampling(O))
 
   # collect points into point set
   𝒫 = PointSet(collect(points))

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -392,6 +392,12 @@ end
   poly = PolyArea(cart.([(-44.20065308, -21.12284851), (-44.20324135, -21.122799875), (-44.20582962, -21.12275124)]))
   ps = sample(poly, MinDistanceSampling(3.2423333333753135e-5))
   @test length(ps) > 0
+
+  ball = Ball(cart(10, 10), T(3))
+  ps = sample(ball, MinDistanceSampling(1.0))
+  n = length(ps)
+  @test all(∈(ball), ps)
+  @test all(norm(ps[i] - ps[j]) ≥ T(1.0) * u"m" for i in 1:n for j in (i + 1):n)
 end
 
 @testitem "FibonacciSampling" setup = [Setup] begin


### PR DESCRIPTION
Currently, `MinDistanceSampling` for a 3D Ball is not supported. To support it, there are two different options: 1. Properly support `RegularDiscretization` for a 3D Ball by adding `Pyramid` elements in the center similarly as in [here](https://github.com/JuliaGeometry/Meshes.jl/blob/ed1d9c9b96a48caeb5b02cee5e662e628bfd9c23/src/discretization/regular.jl#L46) and then use the [fallback](https://github.com/JuliaGeometry/Meshes.jl/blob/master/src/sampling.jl#L59) or 2. add a specialized method for `Ball`. This PR follows the second approach as it is quite straightforward to add, but allowing support for `RegularDiscretization` of a 3D Ball would still be nice (s.t. `discretize(ball::Ball{𝔼{3})` could use that).

TODO:
- [x] Add test