### PR TITLE
Replace Base.OneTo(n) by 1:n for consistency

### DIFF
--- a/src/domains.jl
+++ b/src/domains.jl
@@ -48,7 +48,7 @@ Base.iterate(d::Domain, state=1) = state > nelements(d) ? nothing : (d[state], s
 
 Base.eltype(d::Domain) = eltype([d[i] for i in 1:nelements(d)])
 
-Base.keys(d::Domain) = Base.OneTo(nelements(d))
+Base.keys(d::Domain) = 1:nelements(d)
 
 Base.parent(d::Domain) = d
 

--- a/src/topologies.jl
+++ b/src/topologies.jl
@@ -150,7 +150,7 @@ Base.iterate(t::Topology, state=1) = state > nelements(t) ? nothing : (t[state],
 
 Base.eltype(t::Topology) = eltype([t[i] for i in 1:nelements(t)])
 
-Base.keys(t::Topology) = Base.OneTo(nelements(t))
+Base.keys(t::Topology) = 1:nelements(t)
 
 # ----------------
 # IMPLEMENTATIONS


### PR DESCRIPTION
@JoshuaLampert I believe that these are the only two places in the code base where this internal function from Base is used. In order to be 100% consistent, I am proposing that we stick to the range syntax used elsewhere. Is that ok?