### PR TITLE
reject Point construction with more than 3 dimensions

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -14,7 +14,7 @@ using Random
 
 using Bessels: gamma
 using Unitful: AbstractQuantity, numtype
-using CoordRefSystems: Basic, Geographic, Projected
+using CoordRefSystems: Basic, Geographic, Projected, ncoords
 using Distances: PreMetric, Euclidean, Mahalanobis
 using Distances: Haversine, SphericalAngle
 using Distances: evaluate, result_type

--- a/src/geometries/primitives/point.jl
+++ b/src/geometries/primitives/point.jl
@@ -35,6 +35,12 @@ Point(1m, 2m, 3m) # integer is converted to float by design
 """
 struct Point{M<:Manifold,C<:CRS} <: Primitive{M,C}
   coords::C
+  # here the inner constuctor ensures the point does not have more than 3 dimensions
+  function Point{M,C}(coords::C) where {M<:Manifold,C<:CRS}
+    ndim = ncoords(coords)
+    ndim > 3 && error("Points can only be constructed with up to 3 dimensions, but got $ndim.")
+    new{M,C}(coords)
+  end
 end
 
 Point{M}(coords::C) where {M<:Manifold,C<:CRS} = Point{M,C}(coords)


### PR DESCRIPTION
This small change throws an error if `Point` primitives are constructed with more than three dimensions/coordinates.

closes #1151 