### PR TITLE
Implement a parametrization function for `Wedge`

### DIFF
--- a/src/geometries/polytopes/wedge.jl
+++ b/src/geometries/polytopes/wedge.jl
@@ -22,7 +22,7 @@ function (wedge::Wedge)(u, v, w)
   if (u < 0 || u > 1) || (v < 0 || v > 1) || (w < 0 || w > 1)
     throw(DomainError((u, v, w), "wedge(u, v, w) is not defined for u, v, w outside [0, 1]³."))
   end
-  a1, a2, a3, b1, b2, b3 = wedge.vertices
+  a1, a2, a3, b1, b2, b3 = vertices(wedge)
   a = Triangle(a1, a2, a3)
   b = Triangle(b1, b2, b3)
   s = Segment(a(T(u), T(v)), b(T(u), T(v)))

--- a/src/geometries/polytopes/wedge.jl
+++ b/src/geometries/polytopes/wedge.jl
@@ -15,3 +15,13 @@ nvertices(::Type{<:Wedge}) = 6
 
 Base.isapprox(t₁::Wedge, t₂::Wedge; atol=atol(lentype(t₁)), kwargs...) =
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(t₁.vertices, t₂.vertices))
+
+function (w::Wedge)(u, v, w)
+  if t < 0 || t > 1
+    throw(DomainError(t, "w(u, v, w) is not defined for coordinates outside [0, 1]."))
+  end
+  a1, a2, a3, b1, b2, b3 = w.vertices
+  a = Triangle(a1, a2, a3)
+  b = Triangle(b1, b2, b3)
+  Segment(a(u, v), b(u, v))(w)
+end

--- a/src/geometries/polytopes/wedge.jl
+++ b/src/geometries/polytopes/wedge.jl
@@ -17,11 +17,14 @@ Base.isapprox(t₁::Wedge, t₂::Wedge; atol=atol(lentype(t₁)), kwargs...) =
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(t₁.vertices, t₂.vertices))
 
 function (w::Wedge)(u, v, w)
-  if t < 0 || t > 1
-    throw(DomainError(t, "w(u, v, w) is not defined for coordinates outside [0, 1]."))
+  ℒ = lentype(w)
+  T = numtype(ℒ)
+  if (u < 0 || u > 1) || (v < 0 || v > 1) || (w < 0 || w > 1)
+    throw(DomainError((u, v, w), "w(u, v, w) is not defined for u, v, w outside [0, 1]³."))
   end
   a1, a2, a3, b1, b2, b3 = w.vertices
   a = Triangle(a1, a2, a3)
   b = Triangle(b1, b2, b3)
-  Segment(a(u, v), b(u, v))(w)
+  s = Segment(a(T(u), T(v)), b(T(u), T(v)))
+  s(T(w))
 end

--- a/src/geometries/polytopes/wedge.jl
+++ b/src/geometries/polytopes/wedge.jl
@@ -16,13 +16,13 @@ nvertices(::Type{<:Wedge}) = 6
 Base.isapprox(t₁::Wedge, t₂::Wedge; atol=atol(lentype(t₁)), kwargs...) =
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(t₁.vertices, t₂.vertices))
 
-function (w::Wedge)(u, v, w)
-  ℒ = lentype(w)
+function (wedge::Wedge)(u, v, w)
+  ℒ = lentype(wedge)
   T = numtype(ℒ)
   if (u < 0 || u > 1) || (v < 0 || v > 1) || (w < 0 || w > 1)
-    throw(DomainError((u, v, w), "w(u, v, w) is not defined for u, v, w outside [0, 1]³."))
+    throw(DomainError((u, v, w), "wedge(u, v, w) is not defined for u, v, w outside [0, 1]³."))
   end
-  a1, a2, a3, b1, b2, b3 = w.vertices
+  a1, a2, a3, b1, b2, b3 = wedge.vertices
   a = Triangle(a1, a2, a3)
   b = Triangle(b1, b2, b3)
   s = Segment(a(T(u), T(v)), b(T(u), T(v)))

--- a/src/geometries/polytopes/wedge.jl
+++ b/src/geometries/polytopes/wedge.jl
@@ -17,15 +17,12 @@ Base.isapprox(t₁::Wedge, t₂::Wedge; atol=atol(lentype(t₁)), kwargs...) =
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(t₁.vertices, t₂.vertices))
 
 function (wedge::Wedge)(u, v, w)
-  ℒ = lentype(wedge)
-  T = numtype(ℒ)
   if (u < 0 || u > 1) || (v < 0 || v > 1) || (w < 0 || w > 1)
     throw(DomainError((u, v, w), "wedge(u, v, w) is not defined for u, v, w outside [0, 1]³."))
   end
-  a1, a2, a3, b1, b2, b3 = vertices(wedge)
-  a = Quadrangle(a1, b1, b2, a2)
-  b = Quadrangle(a1, b1, b3, a3)
-  uv = T(u), T(v)
-  s = Segment(a(uv...), b(uv...))
-  s(T(w))
+  a₁, a₂, a₃, b₁, b₂, b₃ = vertices(wedge)
+  q₁ = Quadrangle(a₁, b₁, b₂, a₂)
+  q₂ = Quadrangle(a₁, b₁, b₃, a₃)
+  s = Segment(q₁(u, v), q₂(u, v))
+  s(w)
 end

--- a/src/geometries/polytopes/wedge.jl
+++ b/src/geometries/polytopes/wedge.jl
@@ -23,8 +23,9 @@ function (wedge::Wedge)(u, v, w)
     throw(DomainError((u, v, w), "wedge(u, v, w) is not defined for u, v, w outside [0, 1]³."))
   end
   a1, a2, a3, b1, b2, b3 = vertices(wedge)
-  a = Triangle(a1, a2, a3)
-  b = Triangle(b1, b2, b3)
-  s = Segment(a(T(u), T(v)), b(T(u), T(v)))
+  a = Quadrangle(a1, b1, b2, a2)
+  b = Quadrangle(a1, b1, b3, a3)
+  uv = T(u), T(v)
+  s = Segment(a(uv...), b(uv...))
   s(T(w))
 end

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -979,7 +979,7 @@ end
   @test Meshes.lentype(w) == ℳ
   @test volume(w) ≈ T(1 / 2) * u"m^3"
   @test w(T(0), T(0), T(1)) == vertices(w)[4]
-  @test_throws ArgumentError w(T(0), T(0), T(1.5))
+  @test_throws DomainError w(T(0), T(0), T(1.5))
   m = boundary(w)
   @test m isa Mesh
   @test nelements(m) == 5

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -978,7 +978,7 @@ end
   @test crs(w) <: Cartesian{NoDatum}
   @test Meshes.lentype(w) == ℳ
   @test volume(w) ≈ T(1 / 2) * u"m^3"
-  @test w(T(0), T(0), T(1)) == vertices(w)[4]
+  @test w(T(1), T(1), T(1)) == vertices(w)[6]
   @test_throws DomainError w(T(0), T(0), T(1.5))
   m = boundary(w)
   @test m isa Mesh

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -978,6 +978,7 @@ end
   @test crs(w) <: Cartesian{NoDatum}
   @test Meshes.lentype(w) == ℳ
   @test volume(w) ≈ T(1 / 2) * u"m^3"
+  @test w(0, 0, 1) == vertices(w)[4]
   m = boundary(w)
   @test m isa Mesh
   @test nelements(m) == 5

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -978,7 +978,8 @@ end
   @test crs(w) <: Cartesian{NoDatum}
   @test Meshes.lentype(w) == ℳ
   @test volume(w) ≈ T(1 / 2) * u"m^3"
-  @test w(0, 0, 1) == vertices(w)[4]
+  @test w(T(0), T(0), T(1)) == vertices(w)[4]
+  @test_throws ArgumentError w(T(0), T(0), T(1.5))
   m = boundary(w)
   @test m isa Mesh
   @test nelements(m) == 5


### PR DESCRIPTION
## Changes
- Implements a parametrization function for `Wedge`, `wedge(u, v, w)`:
  - Use vertices to generate two quadrangle faces with consistent point order.
  - Use `(u, v)` to locate corresponding points on each quadrangle.
  - Use `(w)` to locate a point on the segment between those points.
- Adds two `@test`s on this parametrization function:
  - check whether function produced an expected result.
  - check whether out-of-bounds parametric coordinates throw an error.