### PR TITLE
Implement a parametrization function for `Pyramid`

### DIFF
--- a/src/geometries/polytopes/pyramid.jl
+++ b/src/geometries/polytopes/pyramid.jl
@@ -15,3 +15,15 @@ nvertices(::Type{<:Pyramid}) = 5
 
 Base.isapprox(p₁::Pyramid, p₂::Pyramid; atol=atol(lentype(p₁)), kwargs...) =
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(p₁.vertices, p₂.vertices))
+
+function (pyramid::Pyramid)(u, v, w)
+  ℒ = lentype(pyramid)
+  T = numtype(ℒ)
+  if (u < 0 || u > 1) || (v < 0 || v > 1) || (w < 0 || w > 1)
+    throw(DomainError((u, v, w), "pyramid(u, v, w) is not defined for u, v, w outside [0, 1]³."))
+  end
+  a, b, c, d, vertex = vertices(pyramid)
+  base = Quadrangle(a, b, c, d)
+  s = Segment(base(T(u), T(v)), vertex)
+  s(T(w))
+end

--- a/src/geometries/polytopes/pyramid.jl
+++ b/src/geometries/polytopes/pyramid.jl
@@ -17,13 +17,11 @@ Base.isapprox(p₁::Pyramid, p₂::Pyramid; atol=atol(lentype(p₁)), kwargs...)
   all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(p₁.vertices, p₂.vertices))
 
 function (pyramid::Pyramid)(u, v, w)
-  ℒ = lentype(pyramid)
-  T = numtype(ℒ)
   if (u < 0 || u > 1) || (v < 0 || v > 1) || (w < 0 || w > 1)
     throw(DomainError((u, v, w), "pyramid(u, v, w) is not defined for u, v, w outside [0, 1]³."))
   end
-  a, b, c, d, vertex = vertices(pyramid)
-  base = Quadrangle(a, b, c, d)
-  s = Segment(base(T(u), T(v)), vertex)
-  s(T(w))
+  a, b, c, d, o = vertices(pyramid)
+  q = Quadrangle(a, b, c, d)
+  s = Segment(q(u, v), o)
+  s(w)
 end

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -939,6 +939,9 @@ end
   @test crs(p) <: Cartesian{NoDatum}
   @test Meshes.lentype(p) == ℳ
   @test volume(p) ≈ T(1 / 3) * u"m^3"
+  @test p(T(1), T(1), T(0)) == vertices(w)[3]
+  @test p(T(0), T(0), T(1)) == vertices(w)[5]
+  @test_throws DomainError p(T(0), T(0), T(1.5))
   m = boundary(p)
   @test m isa Mesh
   @test nelements(m) == 5

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -939,8 +939,8 @@ end
   @test crs(p) <: Cartesian{NoDatum}
   @test Meshes.lentype(p) == ℳ
   @test volume(p) ≈ T(1 / 3) * u"m^3"
-  @test p(T(1), T(1), T(0)) == vertices(w)[3]
-  @test p(T(0), T(0), T(1)) == vertices(w)[5]
+  @test p(T(1), T(1), T(0)) == vertices(p)[3]
+  @test p(T(0), T(0), T(1)) == vertices(p)[5]
   @test_throws DomainError p(T(0), T(0), T(1.5))
   m = boundary(p)
   @test m isa Mesh


### PR DESCRIPTION
## Changes
- Implements a parametrization function for `Pyramid`, `pyramid(u, v, w)`:
  - Use vertices to generate a `Quadrangle` base and locate the vertex.
  - Use `(u, v)` to locate a point on the base quadrangle.
  - Use `(w)` to locate a point on the segment between this base quadrangle point and the vertex.
- Adds three `@test`s on this parametrization function:
  - check whether function produced an expected result.
  - check whether out-of-bounds parametric coordinates throw an error.