### PR TITLE
Implement a parametrization function for `Frustum`

### DIFF
--- a/src/geometries/primitives/frustum.jl
+++ b/src/geometries/primitives/frustum.jl
@@ -40,3 +40,12 @@ axis(f::Frustum) = axis(boundary(f))
 
 Base.isapprox(f₁::Frustum, f₂::Frustum; atol=atol(lentype(f₁)), kwargs...) =
   isapprox(boundary(f₁), boundary(f₂); atol, kwargs...)
+
+function (frustum::Frustum)(r, φ, h)
+  if (r < 0 || r > 1) || (φ < 0 || φ > 1) || (h < 0 || h > 1)
+    throw(DomainError((r, φ, h), "frustum(r, φ, h) is not defined for r, φ, h outside [0, 1]³."))
+  end
+  a = bottom(frustum)(r, φ)
+  b = top(frustum)(r, φ)
+  Segment(a, b)(h)
+end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1252,6 +1252,7 @@ end
   @test norm(f(T(1), T(0), T(0)) - f(T(0), T(0), T(0))) ≈ radius(db)
   @test f(T(0), T(0), T(1)) == center(dt)
   @test norm(f(T(1), T(0), T(1)) - f(T(0), T(0), T(1))) ≈ radius(db)
+  @test_throws DomainError f(T(0), T(0), T(1.5))
 
   @test_throws AssertionError Frustum(db, db)
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1248,6 +1248,10 @@ end
   @test crs(f) <: Cartesian{NoDatum}
   @test Meshes.lentype(f) == ℳ
   @test boundary(f) == FrustumSurface(db, dt)
+  @test f(T(0), T(0), T(0)) == center(db)
+  @test norm(f(T(1), T(0), T(0)) - f(T(1), T(0), T(0))) ≈ radius(db)
+  @test f(T(0), T(0), T(1)) == center(dt)
+  @test norm(f(T(1), T(0), T(1)) - f(T(1), T(0), T(1))) ≈ radius(db)
 
   @test_throws AssertionError Frustum(db, db)
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1251,7 +1251,7 @@ end
   @test f(T(0), T(0), T(0)) == center(db)
   @test norm(f(T(1), T(0), T(0)) - f(T(0), T(0), T(0))) ≈ radius(db)
   @test f(T(0), T(0), T(1)) == center(dt)
-  @test norm(f(T(1), T(0), T(1)) - f(T(0), T(0), T(1))) ≈ radius(db)
+  @test norm(f(T(1), T(0), T(1)) - f(T(0), T(0), T(1))) ≈ radius(dt)
   @test_throws DomainError f(T(0), T(0), T(1.5))
 
   @test_throws AssertionError Frustum(db, db)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1249,9 +1249,9 @@ end
   @test Meshes.lentype(f) == ℳ
   @test boundary(f) == FrustumSurface(db, dt)
   @test f(T(0), T(0), T(0)) == center(db)
-  @test norm(f(T(1), T(0), T(0)) - f(T(1), T(0), T(0))) ≈ radius(db)
+  @test norm(f(T(1), T(0), T(0)) - f(T(0), T(0), T(0))) ≈ radius(db)
   @test f(T(0), T(0), T(1)) == center(dt)
-  @test norm(f(T(1), T(0), T(1)) - f(T(1), T(0), T(1))) ≈ radius(db)
+  @test norm(f(T(1), T(0), T(1)) - f(T(0), T(0), T(1))) ≈ radius(db)
 
   @test_throws AssertionError Frustum(db, db)
 


### PR DESCRIPTION
## Changes
- Implements a parametrization function for `Frustum`, `frustum(r, φ, h)`:
  - Use `(r, φ)` to locate a pair of points on the top and bottom disks.
  - Use `(h)` to locate a point on the segment between these two points.
- Adds five `@test`s on this parametrization function:
  - check whether function can locate the centers of each disk properly via `(r, φ)`.
  - check whether function can locate the disk rims properly via `(h)`.
  - check whether out-of-bounds parametric coordinates throw an error.