### PR TITLE
Refactor regular grid constructors

### DIFF
--- a/src/domains/meshes/cartesiangrid.jl
+++ b/src/domains/meshes/cartesiangrid.jl
@@ -56,10 +56,10 @@ See also [`RegularGrid`](@ref).
 """
 const CartesianGrid{M<:𝔼,C<:Cartesian} = RegularGrid{M,C}
 
-CartesianGrid(args...; kwargs...) = RegularGrid(cartesian.(args)...; kwargs...)
+CartesianGrid(args...; kwargs...) = RegularGrid(_cartesian.(args)...; kwargs...)
 
 # enforce Cartesian coordinates for all Point arguments
-cartesian(p::Point) = Point(convert(Cartesian, coords(p)))
+_cartesian(p::Point) = Point(convert(Cartesian, coords(p)))
 
 # forward all other arguments without change
-cartesian(o) = o
+_cartesian(o) = o

--- a/src/domains/meshes/cartesiangrid.jl
+++ b/src/domains/meshes/cartesiangrid.jl
@@ -3,54 +3,12 @@
 # ------------------------------------------------------------------
 
 """
-    CartesianGrid(dims, origin, spacing)
+    CartesianGrid(args...; kwargs...)
 
-A Cartesian grid with dimensions `dims`, lower left corner at `origin`
-and cell spacing `spacing`. The three arguments must have the same length.
-
-    CartesianGrid(dims, origin, spacing, offset)
-
-A Cartesian grid with dimensions `dims`, with lower left corner of element
-`offset` at `origin` and cell spacing `spacing`.
-
-    CartesianGrid(start, finish, dims=dims)
-
-Alternatively, construct a Cartesian grid from a `start` point (lower left)
-to a `finish` point (upper right).
-
-    CartesianGrid(start, finish, spacing)
-
-Alternatively, construct a Cartesian grid from a `start` point to a `finish`
-point using a given `spacing`.
-
-    CartesianGrid(dims)
-    CartesianGrid(dim1, dim2, ...)
-
-Finally, a Cartesian grid can be constructed by only passing the dimensions
-`dims` as a tuple, or by passing each dimension `dim1`, `dim2`, ... separately.
-In this case, the origin and spacing default to (0,0,...) and (1,1,...).
-
-`CartesianGrid` is an alias to [`RegularGrid`](@ref) with `Cartesian` CRS.
-
-## Examples
-
-Create a 3D grid with 100x100x50 hexahedrons:
-
-```julia
-julia> CartesianGrid(100, 100, 50)
-```
-
-Create a 2D grid with 100 x 100 quadrangles and origin at (10.0, 20.0):
-
-```julia
-julia> CartesianGrid((100, 100), (10.0, 20.0), (1.0, 1.0))
-```
-
-Create a 1D grid from -1 to 1 with 100 segments:
-
-```julia
-julia> CartesianGrid((-1.0,), (1.0,), dims=(100,))
-```
+A Cartesian grid is a [`RegularGrid`](@ref) where all arguments
+are forced to have `Cartesian` coordinates. Please check the
+docstring of [`RegularGrid`](@ref) for more information on
+possible `args` and `kwargs`.
 
 See also [`RegularGrid`](@ref).
 """

--- a/src/domains/meshes/cartesiangrid.jl
+++ b/src/domains/meshes/cartesiangrid.jl
@@ -56,53 +56,10 @@ See also [`RegularGrid`](@ref).
 """
 const CartesianGrid{M<:𝔼,C<:Cartesian} = RegularGrid{M,C}
 
-CartesianGrid(
-  origin::Point{𝔼{Dim}},
-  spacing::NTuple{Dim,Number},
-  offset::Dims{Dim},
-  topology::GridTopology{Dim}
-) where {Dim} = RegularGrid(_cartpoint(origin), spacing, offset, topology)
+CartesianGrid(args...; kwargs...) = RegularGrid(cartesian.(args)...; kwargs...)
 
-CartesianGrid(
-  dims::Dims{Dim},
-  origin::Point{𝔼{Dim}},
-  spacing::NTuple{Dim,Number},
-  offset::Dims{Dim}=ntuple(i -> 1, Dim)
-) where {Dim} = RegularGrid(dims, _cartpoint(origin), spacing, offset)
+# enforce Cartesian coordinates for all Point arguments
+cartesian(p::Point) = Point(convert(Cartesian, coords(p)))
 
-CartesianGrid(
-  dims::Dims{Dim},
-  origin::NTuple{Dim,Number},
-  spacing::NTuple{Dim,Number},
-  offset::Dims{Dim}=ntuple(i -> 1, Dim)
-) where {Dim} = CartesianGrid(dims, Point(origin), spacing, offset)
-
-CartesianGrid(start::Point{𝔼{Dim}}, finish::Point{𝔼{Dim}}, spacing::NTuple{Dim,Number}) where {Dim} =
-  RegularGrid(_cartpoint(start), _cartpoint(finish), spacing)
-
-CartesianGrid(start::NTuple{Dim,Number}, finish::NTuple{Dim,Number}, spacing::NTuple{Dim,Number}) where {Dim} =
-  CartesianGrid(Point(start), Point(finish), spacing)
-
-CartesianGrid(start::Point{𝔼{Dim}}, finish::Point{𝔼{Dim}}; dims::Dims{Dim}=ntuple(i -> 100, Dim)) where {Dim} =
-  RegularGrid(_cartpoint(start), _cartpoint(finish); dims)
-
-CartesianGrid(
-  start::NTuple{Dim,Number},
-  finish::NTuple{Dim,Number};
-  dims::Dims{Dim}=ntuple(i -> 100, Dim)
-) where {Dim} = CartesianGrid(Point(start), Point(finish); dims)
-
-function CartesianGrid(dims::Dims{Dim}) where {Dim}
-  origin = ntuple(i -> 0.0, Dim)
-  spacing = ntuple(i -> 1.0, Dim)
-  offset = ntuple(i -> 1, Dim)
-  CartesianGrid(dims, origin, spacing, offset)
-end
-
-CartesianGrid(dims::Int...) = CartesianGrid(dims)
-
-# -----------------
-# HELPER FUNCTIONS
-# -----------------
-
-_cartpoint(p) = Point(convert(Cartesian, coords(p)))
+# forward all other arguments without change
+cartesian(o) = o

--- a/src/domains/meshes/regulargrid.jl
+++ b/src/domains/meshes/regulargrid.jl
@@ -23,6 +23,13 @@ with dimensions `dims`.
 Alternatively, construct a regular grid from a `start` point to a `finish`
 point using a given `spacing`.
 
+    RegularGrid(dims)
+    RegularGrid(dim1, dim2, ...)
+
+Finally, a Cartesian grid can be constructed by only passing the dimensions
+`dims` as a tuple, or by passing each dimension `dim1`, `dim2`, ... separately.
+In this case, the origin and spacing default to (0,0,...) and (1,1,...).
+
 ## Examples
 
 ```
@@ -82,6 +89,13 @@ function RegularGrid(
   RegularGrid(origin, spacing, offset, GridTopology(dims))
 end
 
+RegularGrid(
+  dims::Dims{Dim},
+  origin::NTuple{Dim,Number},
+  spacing::NTuple{Dim,Number},
+  offset::Dims{Dim}=ntuple(i -> 1, Dim)
+) where {Dim} = RegularGrid(dims, Point(origin), spacing, offset)
+
 function RegularGrid(start::Point, finish::Point, spacing::NTuple{N,Number}) where {N}
   _checkorigin(start)
   svals, fvals = _startfinish(start, finish)
@@ -90,12 +104,30 @@ function RegularGrid(start::Point, finish::Point, spacing::NTuple{N,Number}) whe
   RegularGrid(dims, start, spac)
 end
 
+RegularGrid(start::NTuple{Dim,Number}, finish::NTuple{Dim,Number}, spacing::NTuple{Dim,Number}) where {Dim} =
+  RegularGrid(Point(start), Point(finish), spacing)
+
 function RegularGrid(start::Point, finish::Point; dims::Dims=ntuple(i -> 100, CoordRefSystems.ncoords(crs(start))))
   _checkorigin(start)
   svals, fvals = _startfinish(start, finish)
   spacing = (fvals .- svals) ./ dims
   RegularGrid(dims, start, spacing)
 end
+
+RegularGrid(
+  start::NTuple{Dim,Number},
+  finish::NTuple{Dim,Number};
+  dims::Dims{Dim}=ntuple(i -> 100, Dim)
+) where {Dim} = RegularGrid(Point(start), Point(finish); dims)
+
+function RegularGrid(dims::Dims{Dim}) where {Dim}
+  origin = ntuple(i -> 0.0, Dim)
+  spacing = ntuple(i -> 1.0, Dim)
+  offset = ntuple(i -> 1, Dim)
+  RegularGrid(dims, origin, spacing, offset)
+end
+
+RegularGrid(dims::Int...) = RegularGrid(dims)
 
 spacing(g::RegularGrid) = g.spacing
 

--- a/src/domains/meshes/regulargrid.jl
+++ b/src/domains/meshes/regulargrid.jl
@@ -32,11 +32,22 @@ In this case, the origin and spacing default to (0,0,...) and (1,1,...).
 
 ## Examples
 
+Create a 3D grid with 100x100x50 hexahedrons:
+
+```julia
+julia> RegularGrid(100, 100, 50)
 ```
-RegularGrid((10, 20), Point(LatLon(30.0°, 60.0°)), (1.0, 1.0)) # add coordinate units to spacing
-RegularGrid((10, 20), Point(Polar(0.0cm, 0.0rad)), (10.0mm, 1.0rad)) # convert spacing units to coordinate units
-RegularGrid((10, 20), Point(Mercator(0.0, 0.0)), (1.5, 1.5))
-RegularGrid((10, 20, 30), Point(Cylindrical(0.0, 0.0, 0.0)), (3.0, 2.0, 1.0))
+
+Create a 2D grid with 100 x 100 quadrangles and origin at (10.0, 20.0):
+
+```julia
+julia> RegularGrid((100, 100), (10.0, 20.0), (1.0, 1.0))
+```
+
+Create a 1D grid from -1 to 1 with 100 segments:
+
+```julia
+julia> RegularGrid((-1.0,), (1.0,), dims=(100,))
 ```
 
 See also [`CartesianGrid`](@ref).

--- a/src/domains/meshes/regulargrid.jl
+++ b/src/domains/meshes/regulargrid.jl
@@ -26,7 +26,7 @@ point using a given `spacing`.
     RegularGrid(dims)
     RegularGrid(dim1, dim2, ...)
 
-Finally, a Cartesian grid can be constructed by only passing the dimensions
+Finally, a regular grid can be constructed by only passing the dimensions
 `dims` as a tuple, or by passing each dimension `dim1`, `dim2`, ... separately.
 In this case, the origin and spacing default to (0,0,...) and (1,1,...).
 

--- a/src/domains/meshes/regulargrid.jl
+++ b/src/domains/meshes/regulargrid.jl
@@ -114,11 +114,8 @@ function RegularGrid(start::Point, finish::Point; dims::Dims=ntuple(i -> 100, Co
   RegularGrid(dims, start, spacing)
 end
 
-RegularGrid(
-  start::NTuple{Dim,Number},
-  finish::NTuple{Dim,Number};
-  dims::Dims{Dim}=ntuple(i -> 100, Dim)
-) where {Dim} = RegularGrid(Point(start), Point(finish); dims)
+RegularGrid(start::NTuple{Dim,Number}, finish::NTuple{Dim,Number}; dims::Dims{Dim}=ntuple(i -> 100, Dim)) where {Dim} =
+  RegularGrid(Point(start), Point(finish); dims)
 
 function RegularGrid(dims::Dims{Dim}) where {Dim}
   origin = ntuple(i -> 0.0, Dim)


### PR DESCRIPTION
I believe this is cleaner and retains the exact same behavior for `CartesianGrid`. It also adds some missing constructors for `RegularGrid`.