### PR TITLE
Fix point in triangle in 3D

### DIFF
--- a/src/predicates/in.jl
+++ b/src/predicates/in.jl
@@ -124,25 +124,24 @@ end
 Base.in(p::Point, poly::Polygon{𝔼{3}}) = any(Δ -> p ∈ Δ, simplexify(poly))
 
 function Base.in(p::Point, t::Triangle{𝔼{3}})
-  # given coordinates
+  # triangle vertices
   a, b, c = vertices(t)
 
-  # evaluate vectors defining geometry
+  # relevant vectors
   v₁ = b - a
   v₂ = c - a
   v₃ = p - a
 
-  # calculate required dot products
+  # check if point is on the same plane
+  isapproxzero(umixed(v₁, v₂, v₃)) || return false
+
+  # barycentric coordinates
   d₁₁ = v₁ ⋅ v₁
   d₁₂ = v₁ ⋅ v₂
   d₂₂ = v₂ ⋅ v₂
   d₃₁ = v₃ ⋅ v₁
   d₃₂ = v₃ ⋅ v₂
-
-  # calculate reused denominator
   d = d₁₁ * d₂₂ - d₁₂ * d₁₂
-
-  # barycentric coordinates
   λ₂ = (d₂₂ * d₃₁ - d₁₂ * d₃₂) / d
   λ₃ = (d₁₁ * d₃₂ - d₁₂ * d₃₁) / d
 

--- a/src/utils/units.jl
+++ b/src/utils/units.jl
@@ -23,6 +23,8 @@ ucross(a::Vec{Dim,ℒ₁}, b::Vec{Dim,ℒ₂}) where {Dim,ℒ₁,ℒ₂} = ucros
 
 ucross(a::Vec{Dim,ℒ}, b::Vec{Dim,ℒ}, c::Vec{Dim,ℒ}) where {Dim,ℒ} = Vec(ustrip.(a × b × c) * unit(ℒ))
 
+umixed(a::Vec{Dim,ℒ}, b::Vec{Dim,ℒ}, c::Vec{Dim,ℒ}) where {Dim,ℒ} = ustrip(a ⋅ (b × c)) * unit(ℒ)
+
 urotbetween(u::Vec, v::Vec) = rotation_between(ustrip.(u), ustrip.(v))
 
 urotapply(R::Rotation, v::Vec{Dim,ℒ}) where {Dim,ℒ} = Vec(R * ustrip.(v) * unit(ℒ))

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -182,7 +182,7 @@ end
   @test merc(0.75, 0.75) ∈ poly
 
   # https://github.com/JuliaGeometry/Meshes.jl/issues/1170
-  t = Triangle(cart(1, 0, 0), cart(0, 1, 0), (0, 0, 1))
+  t = Triangle(cart(1, 0, 0), cart(0, 1, 0), cart(0, 0, 1))
   @test cart(1, 0, 0) ∈ t
   @test cart(0, 1, 0) ∈ t
   @test cart(0, 0, 1) ∈ t

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -180,6 +180,18 @@ end
   @test merc(0.25, 0.25) ∉ poly
   @test merc(0.75, 0.25) ∉ poly
   @test merc(0.75, 0.75) ∈ poly
+
+  # https://github.com/JuliaGeometry/Meshes.jl/issues/1170
+  t = Triangle(cart(1, 0, 0), cart(0, 1, 0), (0, 0, 1))
+  @test cart(1, 0, 0) ∈ t
+  @test cart(0, 1, 0) ∈ t
+  @test cart(0, 0, 1) ∈ t
+  @test cart(1/2, 1/2, 0) ∈ t
+  @test cart(1/2, 0, 1/2) ∈ t
+  @test cart(0, 1/2, 1/2) ∈ t
+  @test cart(1/3, 1/3, 1/3) ∈ t
+  @test cart(0, 0, 0) ∉ t
+  @test cart(1, 1, 1) ∉ t
 end
 
 @testitem "issubset" setup = [Setup] begin

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -186,10 +186,10 @@ end
   @test cart(1, 0, 0) ∈ t
   @test cart(0, 1, 0) ∈ t
   @test cart(0, 0, 1) ∈ t
-  @test cart(1/2, 1/2, 0) ∈ t
-  @test cart(1/2, 0, 1/2) ∈ t
-  @test cart(0, 1/2, 1/2) ∈ t
-  @test cart(1/3, 1/3, 1/3) ∈ t
+  @test cart(1 / 2, 1 / 2, 0) ∈ t
+  @test cart(1 / 2, 0, 1 / 2) ∈ t
+  @test cart(0, 1 / 2, 1 / 2) ∈ t
+  @test cart(1 / 3, 1 / 3, 1 / 3) ∈ t
   @test cart(0, 0, 0) ∉ t
   @test cart(1, 1, 1) ∉ t
 end


### PR DESCRIPTION
Check zero volume before checking barycentric coordinates. I used a new `umixed` helper to retain the length units and therefore the `atol` used in `isapproxzero`. By default the `atol(L^3) = atol(L)^3`, which is quite small (1^e-30).

Fix #1170 