### PR TITLE
Added Documentation for lat/lon initialization of structuredgrid

### DIFF
--- a/docs/src/domains/meshes.md
+++ b/docs/src/domains/meshes.md
@@ -63,6 +63,42 @@ grid = StructuredGrid(X, Y)
 
 viz(grid, showsegments = true)
 ```
+Grids can be initialized using a CRS (from `CoordinateRefSystems.jl`) and the 🌐 manifold to represent points on the globe: 
+```@example meshes
+# Grid based on latitude and longitude coordinates with unit annotation
+lat = repeat(collect(0:2:90), 1,46)
+lon = repeat(collect(0:2:90), 1, size(lat)[1])
+C = typeof(GeodeticLatLon(0,0))
+
+grid = StructuredGrid{🌐,C}(lat', lon)
+viz(grid, showsegments = true)
+```
+
+With a different geodetic datum:
+```@example meshes
+# Grid based on latitude and longitude coordinates with unit annotation
+lat = repeat(collect(0:2:90), 1,46)
+lon = repeat(collect(0:2:90), 1, size(lat)[1])
+C = typeof(LatLon{NAD83}(0,0))
+
+grid = StructuredGrid{🌐,C}(lat', lon)
+viz(grid, showsegments = true)
+```
+
+The topology can also be specified separately. 
+Note that the topology needs to be smaller than each dimension by 1 to avoid a
+bounds error.
+
+```@example meshes
+# Grid based on latitude and longitude coordinates with unit annotation
+lat = repeat(collect(0:2:90), 1,46)
+lon = repeat(collect(0:2:90), 1, size(lat)[1])
+C = typeof(LatLon{NAD83}(0,0))
+topo = GridTopology((45,45), (false, true))
+
+grid = StructuredGrid{🌐,C}((lat', lon), topo)
+viz(grid, showsegments = true)
+```
 
 ```@docs
 SimpleMesh

--- a/docs/src/domains/meshes.md
+++ b/docs/src/domains/meshes.md
@@ -63,40 +63,22 @@ grid = StructuredGrid(X, Y)
 
 viz(grid, showsegments = true)
 ```
-Grids can be initialized using a CRS (from `CoordinateRefSystems.jl`) and the 🌐 manifold to represent points on the globe: 
-```@example meshes
-# Grid based on latitude and longitude coordinates with unit annotation
-lat = repeat(collect(0:2:90), 1,46)
-lon = repeat(collect(0:2:90), 1, size(lat)[1])
-C = typeof(GeodeticLatLon(0,0))
 
-grid = StructuredGrid{🌐,C}(lat', lon)
+```@example meshes
+# grid with latitude and longitude coordinates
+LAT = [i for i in 0:90, j in 0:90]
+LON = [j for i in 0:90, j in 0:90]
+C = typeof(LatLon(0, 0))
+grid = StructuredGrid{🌐,C}(LAT, LON)
+
 viz(grid, showsegments = true)
 ```
 
-With a different geodetic datum:
 ```@example meshes
-# Grid based on latitude and longitude coordinates with unit annotation
-lat = repeat(collect(0:2:90), 1,46)
-lon = repeat(collect(0:2:90), 1, size(lat)[1])
-C = typeof(LatLon{NAD83}(0,0))
+# grid with custom datum
+C = typeof(LatLon{NAD83}(0, 0))
+grid = StructuredGrid{🌐,C}(LAT, LON)
 
-grid = StructuredGrid{🌐,C}(lat', lon)
-viz(grid, showsegments = true)
-```
-
-The topology can also be specified separately. 
-Note that the topology needs to be smaller than each dimension by 1 to avoid a
-bounds error.
-
-```@example meshes
-# Grid based on latitude and longitude coordinates with unit annotation
-lat = repeat(collect(0:2:90), 1,46)
-lon = repeat(collect(0:2:90), 1, size(lat)[1])
-C = typeof(LatLon{NAD83}(0,0))
-topo = GridTopology((45,45), (false, true))
-
-grid = StructuredGrid{🌐,C}((lat', lon), topo)
 viz(grid, showsegments = true)
 ```
 


### PR DESCRIPTION
This PR adds three examples of initializing a `StructuredGrid` with latitudes and longitudes as values, including a basic example, an example of choosing a nondefault geodetic datum, and one passing in a topology explicitly.

Fix #1177 