### PR TITLE
Add no-op `topology(::Topology)` method

### DIFF
--- a/src/topologies.jl
+++ b/src/topologies.jl
@@ -15,6 +15,8 @@ A data structure for constructing topological relations in a [`Mesh`](@ref).
 """
 abstract type Topology end
 
+topology(t::Topology) = t
+
 """
     vertex(topology, ind)
 


### PR DESCRIPTION
This allows calling `adjacencymatrix` on a `Topology`, which should be fine since the only other use of the `mesh` argument in `adjacencymatrix` is a call to `nfaces`, which already has a method for `Topology`s.