### PR TITLE
Rename roundcoords -> coordround for consistency with other utils

### DIFF
--- a/src/utils/basic.jl
+++ b/src/utils/basic.jl
@@ -55,17 +55,3 @@ Generate the coordinate arrays `XYZ` from the coordinate vectors `xyz`.
   end
   Expr(:tuple, exprs...)
 end
-
-"""
-    roundcoords(point, r=RoundNearest; digits=0, base=10)
-    roundcoords(point, r=RoundNearest; sigdigits=0)
-
-Rounds the coordinates of a `point` to specified presicion.
-"""
-function roundcoords(p::Point, r::RoundingMode=RoundNearest; kwargs...)
-  c = coords(p)
-  x = CoordRefSystems.values(c)
-  x′ = round.(eltype(x), x, r; kwargs...)
-  c′ = CoordRefSystems.constructor(c)(x′...)
-  Point(c′)
-end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -58,7 +58,7 @@
   # round
   p₁ = cart(1, 1)
   p₂ = cart(1.0000000000004, 0.9999999999996)
-  @test Meshes.roundcoords(p₁, sigdigits=5) == p₁
-  @test Meshes.roundcoords(p₂, digits=10) == p₁
-  @inferred Meshes.roundcoords(p₁, digits=10)
+  @test Meshes.coordround(p₁, sigdigits=5) == p₁
+  @test Meshes.coordround(p₂, digits=10) == p₁
+  @inferred Meshes.coordround(p₁, digits=10)
 end


### PR DESCRIPTION
Also moved the definition to the utils/crs.jl to improve discoverability.

cc: @souma4 