### PR TITLE
Improve `Repair(1)` (remove unused vertices) performance

### DIFF
--- a/src/transforms/repair.jl
+++ b/src/transforms/repair.jl
@@ -47,9 +47,11 @@ apply(::Repair{0}, mesh::Mesh) = error("not implemented")
 # --------------
 
 function apply(::Repair{1}, mesh::Mesh)
-  count = Ref(0) # Ref to avoid boxing from map closure (JuliaLang/julia#15276)
+  # Ref to avoid boxing from map closure
+  # see https://github.com/JuliaLang/julia/issues/15276
+  count = Ref(0)
 
-  # ordered
+  # ordered list of indices
   seen = Int[]
   inds = Dict{Int,Int}()
 


### PR DESCRIPTION
Improves performance by:

- Avoid closure Box issue by making `count` a `Ref`
- sizehint to reduce number of allocs
- Check if indices have been seen using the `inds` Dict (quicker
  membership testing than the O(n) search in `seen`)

### Benchmarks

Using a mesh with 55k vertices and 110k tris:

Master:
```julia
# setup step randomly removes 20% of faces
master = @benchmark Repair(1)(_msh) setup=(_msh=SimpleMesh(vertices(msh), topology(msh)[deleteat!([1:nfaces(msh, 2);], sort!(sample(1:nfaces(msh, 2), round(Int, nfaces(msh, 2)*0.2); replace=false)))])) seconds=20
```
```
BenchmarkTools.Trial: 9 samples with 1 evaluation per sample.
 Range (min … max):  2.408 s …   2.458 s  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.435 s              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.437 s ± 16.217 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁                  ▁ ▁    ▁    ▁          █           ▁ ▁
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁█▁▁▁▁█▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁█ ▁
  2.41 s         Histogram: frequency by time        2.46 s <

 Memory estimate: 14.70 MiB, allocs estimate: 108216.
```

PR:
```julia
# setup step randomly removes 20% of faces
PR = @benchmark Repair(1)(_msh) setup=(_msh=SimpleMesh(vertices(msh), topology(msh)[deleteat!([1:nfaces(msh, 2);], sort!(sample(1:nfaces(msh, 2), round(Int, nfaces(msh, 2)*0.2); replace=false)))])) seconds=20
```
```
BenchmarkTools.Trial: 1263 samples with 1 evaluation per sample.
 Range (min … max):  5.941 ms …  20.586 ms  ┊ GC (min … max): 0.00% … 69.08%
 Time  (median):     6.205 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.589 ms ± 999.683 μs  ┊ GC (mean ± σ):  5.38% ±  9.90%

   ▂▄ █▂
  ▄█████▅▆▃▃▂▂▂▂▁▂▂▁▂▁▁▁▂▁▁▂▂▂▂▁▁▂▂▂▁▁▁▁▁▁▁▁▁▃▄▃▃▄▃▃▃▂▂▂▁▁▁▂▂ ▃
  5.94 ms         Histogram: frequency by time        9.27 ms <

 Memory estimate: 9.13 MiB, allocs estimate: 31.
```

```julia
BenchmarkTools.judge(median(PR), median(master))
```
```
BenchmarkTools.TrialJudgement:
  time:   -99.75% => improvement (5.00% tolerance)
  memory: -37.88% => improvement (1.00% tolerance)
```

