### PR TITLE
Avoid unnecessary work in `SimpleTopology` constructor when Connectivity eltype is concrete

### DIFF
--- a/src/topologies/simple.jl
+++ b/src/topologies/simple.jl
@@ -23,8 +23,7 @@ struct SimpleTopology{C<:Connectivity} <: Topology
   elems::Vector{Int}
 
   function SimpleTopology{C}(connec) where {C}
-    # TODO: Handle Union's too?
-    if typeof(C) <: DataType # one concrete Connectivity type
+    if isconcretetype(C) # single concrete connectivity type
       ranks = fill(paramdim(first(connec)), length(connec))
       elems = collect(eachindex(connec))
     else # mixed connectivity types
@@ -45,7 +44,7 @@ paramdim(t::SimpleTopology) = paramdim(t.connec[first(t.elems)])
     connec4elem(t, e)
 
 Return linear indices of vertices of `e`-th element of
-the full topology `t`.
+the simple topology `t`.
 """
 connec4elem(t::SimpleTopology, e) = indices(t.connec[t.elems[e]])
 

--- a/src/topologies/simple.jl
+++ b/src/topologies/simple.jl
@@ -23,8 +23,14 @@ struct SimpleTopology{C<:Connectivity} <: Topology
   elems::Vector{Int}
 
   function SimpleTopology{C}(connec) where {C}
-    ranks = [paramdim(c) for c in connec]
-    elems = findall(isequal(maximum(ranks)), ranks)
+    # TODO: Handle Union's too?
+    if typeof(C) <: DataType # one concrete Connectivity type
+      ranks = fill(paramdim(first(connec)), length(connec))
+      elems = collect(eachindex(connec))
+    else # mixed connectivity types
+      ranks = [paramdim(c) for c in connec]
+      elems = findall(isequal(maximum(ranks)), ranks)
+    end
     new(connec, ranks, elems)
   end
 end


### PR DESCRIPTION
Didn't benchmark with mixed Connectivity eltypes, but performance for those cases should be
the same (same code for that case).

Benchmarks:

Master:
```julia
master = @benchmark SimpleTopology(faces) setup=(faces=topology(msh)[deleteat!([1:nfaces(msh, 2);], sort!(sample(1:nfaces(msh, 2), round(Int, nfaces(msh, 2)*0.2); replace=false)))]) seconds=10
```
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):   99.356 μs …   3.460 ms  ┊ GC (min … max):  0.00% … 95.25%
 Time  (median):     112.651 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   155.806 μs ± 311.846 μs  ┊ GC (mean ± σ):  24.92% ± 11.78%

  █                                                             ▁
  ██▄▁▁▁▁▁▁▁▁▁▇▆▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▆█ █
  99.4 μs       Histogram: log(frequency) by time       2.55 ms <

 Memory estimate: 1.34 MiB, allocs estimate: 11.
```

PR:
```julia
PR = @benchmark SimpleTopology(faces) setup=(faces=topology(msh)[deleteat!([1:nfaces(msh, 2);], sort!(sample(1:nfaces(msh, 2), round(Int, nfaces(msh, 2)*0.2); replace=false)))]) seconds=10
```
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):   77.014 μs …   3.144 ms  ┊ GC (min … max):  0.00% … 80.44%
 Time  (median):      89.718 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   135.432 μs ± 319.938 μs  ┊ GC (mean ± σ):  30.72% ± 12.39%

  █                                                             ▁
  ██▁▃▁▁▁▁▁▁▁▁▇▆▄▃▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇█ █
  77 μs         Histogram: log(frequency) by time       2.51 ms <

 Memory estimate: 1.33 MiB, allocs estimate: 7.
```

```julia
BenchmarkTools.judge(median(PR), median(master))
```
```
BenchmarkTools.TrialJudgement:
  time:   -20.36% => improvement (5.00% tolerance)
  memory: -0.78% => invariant (1.00% tolerance)
```
