### PR TITLE
Improve memory access and allocation patterns in HalfEdgeTopology construction

### DIFF
--- a/src/topologies/halfedge.jl
+++ b/src/topologies/halfedge.jl
@@ -97,12 +97,13 @@ struct HalfEdgeTopology <: Topology
   edge4pair::Dict{Tuple{Int,Int},Int}
 end
 
-function HalfEdgeTopology(halves::AbstractVector{Tuple{HalfEdge,HalfEdge}})
+function HalfEdgeTopology(halves::AbstractVector{Tuple{HalfEdge,HalfEdge}}, nelems::Int)
   halfedges = Vector{HalfEdge}(undef, 2 * length(halves))
   edge4pair = Dict{Tuple{Int,Int},Int}()
   half4elem = Dict{Int,Int}()
   half4vert = Dict{Int,Int}()
   sizehint!(edge4pair, length(halves))
+  sizehint!(half4elem , nelems)
 
   # flatten pairs of half-edges into a vector
   for (i, (h₁, h₂)) in enumerate(halves)
@@ -214,7 +215,7 @@ function HalfEdgeTopology(elems::AbstractVector{<:Connectivity}; sort=true)
     end
   end
 
-  HalfEdgeTopology(halves)
+  HalfEdgeTopology(halves, length(elems))
 end
 
 function adjsort(elems::AbstractVector{<:Connectivity})

--- a/src/topologies/halfedge.jl
+++ b/src/topologies/halfedge.jl
@@ -122,8 +122,7 @@ function HalfEdgeTopology(halves::AbstractVector{Tuple{HalfEdge,HalfEdge}})
   edge4pair = Dict{Tuple{Int,Int},Int}()
   for (i, (h₁, h₂)) in enumerate(ordered)
     u, v = h₁.head, h₂.head
-    edge4pair[(u, v)] = i
-    edge4pair[(v, u)] = i
+    edge4pair[minmax(u, v)] = i
   end
 
   HalfEdgeTopology(halfedges, half4elem, half4vert, edge4pair)
@@ -208,10 +207,9 @@ function HalfEdgeTopology(elems::AbstractVector{<:Connectivity}; sort=true)
   halves = Vector{Tuple{HalfEdge,HalfEdge}}()
   visited = Set{Tuple{Int,Int}}()
   for ((u, v), he) in half4pair
-    if (u, v) ∉ visited
+    if minmax(u, v) ∉ visited
       push!(halves, (he, he.half))
-      push!(visited, (u, v))
-      push!(visited, (v, u))
+      push!(visited, minmax(u, v))
     end
   end
 
@@ -294,14 +292,14 @@ vertices `uv`.
 
 Always return the half-edge to the "left".
 """
-half4pair(t::HalfEdgeTopology, uv::Tuple{Int,Int}) = half4edge(t, t.edge4pair[uv])
+half4pair(t::HalfEdgeTopology, uv::Tuple{Int,Int}) = half4edge(t, edge4pair(t, uv))
 
 """
     edge4pair(t, uv)
 
 Return the edge of the half-edge topology `t` for the pair of vertices `uv`.
 """
-edge4pair(t, uv) = t.edge4pair[uv]
+edge4pair(t, uv) = t.edge4pair[minmax(uv...)]
 
 # ---------------------
 # HIGH-LEVEL INTERFACE

--- a/src/topologies/halfedge.jl
+++ b/src/topologies/halfedge.jl
@@ -209,9 +209,10 @@ function HalfEdgeTopology(elems::AbstractVector{<:Connectivity}; sort=true)
   halves = Vector{Tuple{HalfEdge,HalfEdge}}()
   visited = Set{Tuple{Int,Int}}()
   for ((u, v), he) in half4pair
-    if minmax(u, v) ∉ visited
+    uv = minmax(u, v)
+    if uv ∉ visited
       push!(halves, (he, he.half))
-      push!(visited, minmax(u, v))
+      push!(visited, uv)
     end
   end
 

--- a/test/topologies.jl
+++ b/test/topologies.jl
@@ -411,7 +411,7 @@ end
   h9.prev = h7
   h9.next = h4
   halves = [(h1, h2), (h3, h4), (h5, h6), (h7, h8), (h9, h10)]
-  struc = HalfEdgeTopology(halves)
+  struc = HalfEdgeTopology(halves, 2)
   @test half4elem(struc, 1) == h1
   @test half4elem(struc, 2) == h4
   @test half4vert(struc, 1) == h1


### PR DESCRIPTION
The key change here is changing the `edge4pair` field to use sorted tuples for the keys,
which reduces the size of that `Dict` by half.

To limit the effect of unchanged code on the benchmarks (since the
`HalfEdgeTopology(::Vector{Tuple{HalfEdge,HalfEdge}})` function isn't convenient to call
directly), I benchmarked HalfEdgeTopology construction with pre-sorted Connectivity vectors
(i.e. `HalfEdgeTopology(::Vector{<:Connectivity}; sort=false)`).

<details><summary>Benchmarking setup</summary>
<p>

Using the two meshes from [this gist](https://gist.github.com/halleysfifthinc/5b0d45a44f4dd451daca097aa35b9846).

```julia
quads = GeoIO.load("quads.obj").geometry;
mixed = GeoIO.load("quads_tris.obj").geometry;
quads_connec = collect(faces(topology(quads), 2))
mixed_connec = collect(faces(topology(mixed), 2))
```

</p>
</details>

Using a 72 quad torus:

<details><summary>master</summary>
<p>

```julia
@benchmark HalfEdgeTopology(faces; sort=false) setup=(faces=Meshes.adjsort(quads_connec)) seconds=15 evals=1 samples=15000
```
```
BenchmarkTools.Trial: 15000 samples with 1 evaluation per sample.
 Range (min … max):  377.829 μs …   8.002 ms  ┊ GC (min … max): 0.00% … 93.56%
 Time  (median):     403.748 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   435.979 μs ± 415.441 μs  ┊ GC (mean ± σ):  7.04% ±  6.86%

                 ▁▃▅▇▇█▇██▆▄▃▁
  ▁▁▁▁▁▁▂▂▃▄▄▄▅▅▇██████████████▆▆▅▄▄▃▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  378 μs           Histogram: frequency by time          450 μs <

 Memory estimate: 250.05 KiB, allocs estimate: 3762.
```

</p>
</details>


<details><summary>PR</summary>
<p>

```julia
@benchmark HalfEdgeTopology(faces; sort=false) setup=(faces=Meshes.adjsort(quads_connec)) seconds=15 evals=1 samples=15000
```
```
BenchmarkTools.Trial: 15000 samples with 1 evaluation per sample.
 Range (min … max):  377.148 μs …  12.239 ms  ┊ GC (min … max): 0.00% … 95.93%
 Time  (median):     403.527 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   423.298 μs ± 341.083 μs  ┊ GC (mean ± σ):  4.03% ±  4.78%

              ▃▇██▇▇▄▂
  ▁▁▁▁▁▁▁▁▁▂▃▇█████████▆▄▄▃▂▂▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  377 μs           Histogram: frequency by time          475 μs <

 Memory estimate: 194.45 KiB, allocs estimate: 3732.
```

</p>
</details>

Judgement:
```
BenchmarkTools.TrialJudgement:
  time:   -0.05% => invariant (5.00% tolerance)
  memory: -22.24% => improvement (1.00% tolerance)
```

Using a 72 tri, 36 quad torus:

<details><summary>master</summary>
<p>

```julia
@benchmark HalfEdgeTopology(faces; sort=false) setup=(faces=Meshes.adjsort(mixed_connec)) seconds=15 evals=1 samples=15000
```
```
BenchmarkTools.Trial: 10161 samples with 1 evaluation per sample.
 Range (min … max):  530.115 μs …  15.791 ms  ┊ GC (min … max): 0.00% … 95.31%
 Time  (median):     561.554 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   598.624 μs ± 473.388 μs  ┊ GC (mean ± σ):  5.83% ±  6.84%

          ▁▂▅▇██▆▂
  ▂▂▂▃▄▅▆▇█████████▆▅▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▁▂▂▂▂▂▂▂ ▃
  530 μs           Histogram: frequency by time          683 μs <

 Memory estimate: 303.91 KiB, allocs estimate: 5060.
 ```

</p>
</details>


<details><summary>PR</summary>
<p>

```julia
@benchmark HalfEdgeTopology(faces; sort=false) setup=(faces=Meshes.adjsort(mixed_connec)) seconds=15 evals=1 samples=15000
```
```
BenchmarkTools.Trial: 10078 samples with 1 evaluation per sample.
 Range (min … max):  542.959 μs …  13.229 ms  ┊ GC (min … max): 0.00% … 94.66%
 Time  (median):     563.046 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   593.128 μs ± 423.579 μs  ┊ GC (mean ± σ):  4.64% ±  6.01%

         ▂▅▆█▇▅▃
  ▁▁▁▂▃▅█████████▆▅▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  543 μs           Histogram: frequency by time          654 μs <

 Memory estimate: 273.76 KiB, allocs estimate: 5036.
 ```

</p>
</details>

Judgement:
```
BenchmarkTools.TrialJudgement:
  time:   +0.27% => invariant (5.00% tolerance)
  memory: -9.92% => improvement (1.00% tolerance)
```
