### PR TITLE
Remove WeightedEuclidean from MetricBall

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -15,8 +15,8 @@ using Random
 using Bessels: gamma
 using Unitful: AbstractQuantity, numtype
 using CoordRefSystems: Basic, Geographic, Projected
-using Distances: PreMetric, Euclidean, WeightedEuclidean
-using Distances: Mahalanobis, Haversine, SphericalAngle
+using Distances: PreMetric, Euclidean, Mahalanobis
+using Distances: Haversine, SphericalAngle
 using Distances: evaluate, result_type
 using Rotations: Rotation, QuatRotation, Angle2d
 using Rotations: rotation_between

--- a/test/neighborhoods.jl
+++ b/test/neighborhoods.jl
@@ -56,7 +56,7 @@
 
   # make sure the correct constructor is called
   m = metric(MetricBall(T.((1.0, 0.5, 0.2)), RotXYX(T(0), T(0), T(0))))
-  @test m isa WeightedEuclidean
+  @test m isa Mahalanobis
 
   # make sure the angle is clockwise
   m = metric(MetricBall(T.((20.0, 5.0)), Angle2d(T(π / 2))))


### PR DESCRIPTION
Reverts #1212 and replace `'` by `transpose`.

I did some benchmarks with BenchmarkTools.jl and Chairmarks.jl and had the illusion that `WeightedEuclidean` was faster. After careful interpolation of variables in the benchmarks there is no practical difference with static arrays.

Therefore, we can always return `Mahalanobis` for type stability.