### PR TITLE
Implement Repair{0} for Mesh

### DIFF
--- a/src/transforms/repair.jl
+++ b/src/transforms/repair.jl
@@ -40,7 +40,29 @@ Repair(K) = Repair{K}()
 
 apply(::Repair{0}, geom::Polytope) = unique(geom), nothing
 
-apply(::Repair{0}, mesh::Mesh) = error("not implemented")
+function apply(::Repair{0}, mesh::Mesh)
+  # retrieve vertices and connectivities
+  verts = vertices(mesh)
+  elems = elements(topology(mesh))
+
+  # remove duplicate vertices
+  uverts = unique(verts)
+  uindex = indexin(verts, uverts)
+
+  # update indices of connectivities
+  uelems = map(elems) do elem
+    newinds = map(i -> uindex[i], indices(elem))
+    connect(newinds, pltype(elem))
+  end
+
+  # remove duplicate connectivities
+  uconnec = unique(elem -> Set(indices(elem)), uelems)
+
+  # repaired mesh without duplicates
+  rmesh = SimpleMesh(uverts, uconnec)
+
+  rmesh, nothing
+end
 
 # --------------
 # OPERATION (1)

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -2146,11 +2146,14 @@ end
   @test nvertices(rpoly) == 4
   @test vertices(rpoly) == cart.([(0, 0), (1, 0), (1, 1), (0, 1)])
 
-  repair = Repair(0)
-  @test sprint(show, repair) == "Repair(K: 0)"
-  @test sprint(show, MIME"text/plain"(), repair) == """
-  Repair transform
-  └─ K: 0"""
+  points = cart.([(0, 0), (1, 0), (0, 1), (1, 1), (1, 0), (2, 0), (1, 1), (2, 1)])
+  connec = connect.([(1, 2, 4, 3), (5, 6, 8, 7)], Quadrangle)
+  mesh = SimpleMesh(points, connec)
+  rmesh = mesh |> Repair(0)
+  @test nvertices(rmesh) == 6
+  @test nelements(rmesh) == 2
+  @test vertices(rmesh) == cart.([(0, 0), (1, 0), (0, 1), (1, 1), (2, 0), (2, 1)])
+  @test collect(topology(rmesh)) == connect.([(1, 2, 4, 3), (2, 5, 6, 4)], Quadrangle)
 end
 
 @testitem "Repair(1)" setup = [Setup] begin
@@ -2278,6 +2281,16 @@ end
   repair = Repair(11)
   rgset, cache = TB.apply(repair, gset)
   @test rgset == GeometrySet([repair(poly1), repair(poly2)])
+end
+
+@testitem "Repair IO" setup = [Setup] begin
+  for K in 0:12
+    repair = Repair(K)
+    @test sprint(show, repair) == "Repair(K: $K)"
+    @test sprint(show, MIME"text/plain"(), repair) == """
+    Repair transform
+    └─ K: $K"""
+  end
 end
 
 @testitem "Bridge" setup = [Setup] begin


### PR DESCRIPTION
Remove duplicate vertices and connectivities.

Although the last `unique` call compares connectivity indices as sets (ignoring the polytope type), I believe this is enough for most practical applications.