### PR TITLE
Fix GJK implementation for 3D case

### DIFF
--- a/src/predicates/intersects.jl
+++ b/src/predicates/intersects.jl
@@ -196,6 +196,7 @@ function _gjk!(::Val{3}, O, points)
       d = ABCᵀ
     elseif ispositive(ADBᵀ ⋅ AO)
       popat!(points, 2) # pop C
+      points[1], points[2] = points[2], points[1]
       d = ADBᵀ
     elseif ispositive(ACDᵀ ⋅ AO)
       popat!(points, 3) # pop B

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -416,6 +416,15 @@ end
   @test intersects(t, b)
   @test intersects(b, t)
 
+  # https://github.com/JuliaGeometry/Meshes.jl/issues/810
+  b = Box(cart(-130, -18.78, 46.25), cart(-110.75, -5.05, 60.0))
+  s = Segment(cart(-70,-50,0), cart(-130, 0, 50))
+  r = Ray(cart(-70,-50,0), cart(-130, 0, 50)-cart(-70,-50,0))
+  @test !intersects(b, s)
+  @test !intersects(s, b)
+  @test !intersects(b, r)
+  @test !intersects(r, b)
+
   t = Triangle(cart(0, 0, 0), cart(2, 0, 0), cart(1, 2, 0))
   r1 = Ray(cart(1, 1, 1), vector(0, 0, -1))
   r2 = Ray(cart(1, 1, 1), vector(0, 0, 1))

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -410,6 +410,12 @@ end
   @test intersects(r, b)
   @test intersects(b, r)
 
+  # https://github.com/JuliaGeometry/Meshes.jl/issues/809
+  t = Triangle(cart(-60.0, -35.0, 55.0), cart(-68.75, -33.43333, 54.90143), cart(-68.75, -35.0, 55.0))
+  b = Box(cart(-77.5, -35.0, 54.6073), cart(-68.75, -31.8914, 55.0))
+  @test intersects(t, b)
+  @test intersects(b, t)
+
   t = Triangle(cart(0, 0, 0), cart(2, 0, 0), cart(1, 2, 0))
   r1 = Ray(cart(1, 1, 1), vector(0, 0, -1))
   r2 = Ray(cart(1, 1, 1), vector(0, 0, 1))


### PR DESCRIPTION
Fixes #809 

The GJK implementation for the 3D case assumes a position for each point in the point array that represents the tetrahedron. The point array is [D, C, B, A] with faces ABC, ADB, BDC and ACD. Each face is a triangle with points in the counterclockwise ordering whose normal vector points outwards. At the end of every iteration, the implementation should remove a point and leave the points that will form the triangle BDC of the next iteration.

When the point C was removed in the second case, the remaining points were not in the correct order. Thus, swapping the points fixed the issue.

Also, add test case for issue #810 