### PR TITLE
Move error string creation behind function call to avoid allocations

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -32,9 +32,9 @@ SUITE["discretization"] = BenchmarkGroup()
 
 SUITE["discretization"]["simplexify"] = @benchmarkable simplexify($mesh)
 
-# --------
-# TOPOLOGIES
-# --------
+# ---------
+# TOPOLOGY
+# ---------
 
 SUITE["topology"] = BenchmarkGroup()
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -36,9 +36,9 @@ SUITE["discretization"]["simplexify"] = @benchmarkable simplexify($mesh)
 # TOPOLOGIES
 # --------
 
-SUITE["topologies"] = BenchmarkGroup()
+SUITE["topology"] = BenchmarkGroup()
 
-SUITE["topologies"]["half-edge"] = @benchmarkable convert(HalfEdgeTopology, topology($mesh))
+SUITE["topology"]["half-edge"] = @benchmarkable convert(HalfEdgeTopology, topology($mesh))
 
 # --------
 # WINDING

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -33,6 +33,14 @@ SUITE["discretization"] = BenchmarkGroup()
 SUITE["discretization"]["simplexify"] = @benchmarkable simplexify($mesh)
 
 # --------
+# TOPOLOGIES
+# --------
+
+SUITE["topologies"] = BenchmarkGroup()
+
+SUITE["topologies"]["half-edge"] = @benchmarkable convert(HalfEdgeTopology, topology($mesh))
+
+# --------
 # WINDING
 # --------
 

--- a/src/topologies/halfedge.jl
+++ b/src/topologies/halfedge.jl
@@ -208,10 +208,7 @@ function HalfEdgeTopology(elems::AbstractVector{<:Connectivity}; sort=true)
         if isnothing(he.elem)
           he.elem = oelem
         else
-          assertion(
-            he.elem === oelem,
-            lazy"duplicate edge $((u, v)) for element $(oelem) is inconsistent with previous edge $he"
-          )
+          he.elem === oelem || inconsistentedgeerror(u, v, oelem, he)
         end
         half = get!(() -> HalfEdge(v, nothing), half4pair, (v, u))
         he.half = half
@@ -437,3 +434,6 @@ end
 # integer addition mod1
 add0(i, n) = i
 add1(i, n) = mod1(i + 1, n)
+
+inconsistentedgeerror(u, v, elem, he) =
+  throw(AssertionError("duplicate edge $((u, v)) for element $(elem) is inconsistent with previous edge $he"))


### PR DESCRIPTION
Benchmark script:

```julia
sphere = simplexify(Sphere(Point(0,0,0), 1))
t = topology(sphere)

@benchmark convert(HalfEdgeTopology, t)
```

Master:
```
BenchmarkTools.Trial: 841 samples with 1 evaluation per sample.
 Range (min … max):  5.089 ms … 17.074 ms  ┊ GC (min … max):  0.00% … 67.71%
 Time  (median):     5.267 ms              ┊ GC (median):     0.00%
 Time  (mean ± σ):   5.942 ms ±  2.149 ms  ┊ GC (mean ± σ):  10.31% ± 15.81%

  █▇▅▂
  ████▇▅▁▁▄▆▄▁▅█▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▆▅▅▅▅▇█▇█▆▅▁▁▁▄ ▇
  5.09 ms      Histogram: log(frequency) by time     14.1 ms <

 Memory estimate: 5.87 MiB, allocs estimate: 40963.
```

PR:
```
BenchmarkTools.Trial: 913 samples with 1 evaluation per sample.
 Range (min … max):  4.761 ms … 16.267 ms  ┊ GC (min … max): 0.00% … 58.65%
 Time  (median):     4.873 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.463 ms ±  1.896 ms  ┊ GC (mean ± σ):  9.79% ± 15.44%

  █▅▃
  ███▆▅▁▁▁▁▇▆▁▅▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▅▄▁▁▄▆▇▇█▅▄▁▄▄▄▄▄▅ ▇
  4.76 ms      Histogram: log(frequency) by time     12.9 ms <

 Memory estimate: 5.17 MiB, allocs estimate: 25669.
```

Not a huge performance delta, but it is slightly faster and has fewer allocs. Every little bit helps!
