### PR TITLE
Reorganize CI into conditional hierarchy

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -1,13 +1,21 @@
 name: Benchmarks
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
   pull_request_target:
     branches: [ master ]
+  workflow_dispatch:
+  
 permissions:
   pull-requests: write
 
 jobs:
   bench:
     runs-on: ubuntu-latest
+    # Only run if CI workflow succeeded or if manually triggered
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'pull_request_target' }}
     strategy:
       matrix:
         version:
@@ -17,4 +25,4 @@ jobs:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
           julia-version: ${{ matrix.version }}
-          bench-on: ${{ github.event.pull_request.head.sha }}
+          bench-on: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -3,12 +3,49 @@ on:
   pull_request_target:
     types: [labeled]
     branches: [ master ]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [ master ]
   workflow_dispatch:
   
 permissions:
   pull-requests: write
 
 jobs:
+  add-benchmark-label:
+    name: Add benchmark label
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Add benchmarkable label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get the PR associated with this workflow run
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'master',
+              head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
+              state: 'open'
+            });
+
+            if (prs.length === 0) {
+              console.log('No open PR found for this workflow run');
+              return;
+            }
+
+            const pr = prs[0];
+            console.log(`Adding benchmarkable label to PR #${pr.number}`);
+
+            await github.rest.issues.addLabels({
+              issue_number: pr.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['benchmarkable']
+            });
+
   bench:
     runs-on: ubuntu-latest
     # Only run if benchmarkable label was added or if manually triggered

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -1,10 +1,7 @@
 name: Benchmarks
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
   pull_request_target:
+    types: [labeled]
     branches: [ master ]
   workflow_dispatch:
   
@@ -14,8 +11,8 @@ permissions:
 jobs:
   bench:
     runs-on: ubuntu-latest
-    # Only run if CI workflow succeeded or if manually triggered
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'pull_request_target' }}
+    # Only run if benchmarkable label was added or if manually triggered
+    if: ${{ contains(github.event.label.name, 'benchmarkable') || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         version:
@@ -25,4 +22,19 @@ jobs:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
           julia-version: ${{ matrix.version }}
-          bench-on: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+          bench-on: ${{ github.event.pull_request.head.sha }}
+      - name: Remove benchmarkable label
+        if: ${{ success() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'benchmarkable'
+              });
+            } catch (error) {
+              console.log('Label may not exist or already removed');
+            }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,8 +5,8 @@ on:
       - master
     paths:
       - 'src/'
-      - 'test/'
       - 'ext/'
+      - 'test/'
       - 'Project.toml'
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
       - 'ext/'
       - 'test/'
       - 'Project.toml'
-      - '.github/CI.yml'
+      - '.github/workflows/CI.yml'
   push:
     branches:
       - master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,10 +3,17 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - 'src/'
+      - 'test/'
+      - 'ext/'
+      - 'Project.toml'
   push:
     branches:
       - master
     tags: ['*']
+  workflow_dispatch:
+
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.
@@ -14,6 +21,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 env:
   JULIA_NUM_THREADS: 2
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.float }} - ${{ github.event_name }}
@@ -49,25 +57,3 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: |
-          julia --project=docs -e '
-            using Documenter: doctest
-            using Meshes
-            doctest(Meshes)'
-      - run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,21 +59,3 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  add-benchmark-label:
-    name: Add benchmark label
-    runs-on: ubuntu-latest
-    needs: test
-    if: ${{ github.event_name == 'pull_request' && success() }}
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add benchmarkable label
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['benchmarkable']
-            })

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,3 +58,22 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  add-benchmark-label:
+    name: Add benchmark label
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ github.event_name == 'pull_request' && success() }}
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add benchmarkable label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['benchmarkable']
+            })

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
       - 'ext/'
       - 'test/'
       - 'Project.toml'
+      - '.github/CI.yml'
   push:
     branches:
       - master

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,50 @@
+name: Documentation
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docs/'
+  push:
+    branches:
+      - master
+    tags: ['*']
+  workflow_dispatch:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+env:
+  JULIA_NUM_THREADS: 2
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    # Only run if CI workflow succeeded, or if manually triggered, or on push/tags, or docs-only PR
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: doctest
+            using Meshes
+            doctest(Meshes)'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
The general CI structure should be as follows:

- Anything can be triggered manually (`workflow_dispatch`)
- Style/format suggestions always runs
- Tests run for pushes to `master` and tags, and only run in PRs if there are modifications to `Project.toml` or within `src`, `ext`, or `test`
- Benchmarks always runs following successful tests (and transitively by anything that triggers tests)
- Documentation runs for pushes to `master` and tags, and runs in PRs if:
  - Tests workflow successfully ran (catches changed docstrings)
  - Anything was modified in `docs` (catches anything else that could affect docs builds)

I don't have a great idea on how to test some of these without just merging this and then submitting some test PRs to trigger specific behaviors.