### PR TITLE
Fixup CI triggers, take #2

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -23,13 +23,7 @@ jobs:
         with:
           script: |
             // Get the PR associated with this workflow run
-            const { data: prs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: 'master',
-              head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
-              state: 'open'
-            });
+            const prs = context.payload.workflow_run.pull_requests;
 
             if (prs.length === 0) {
               console.log('No open PR found for this workflow run');

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -3,43 +3,9 @@ on:
   pull_request_target:
     types: [labeled]
     branches: [ master ]
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [ master ]
   workflow_dispatch:
-  
-permissions:
-  pull-requests: write
 
 jobs:
-  add-benchmark-label:
-    name: Add benchmark label
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Add benchmarkable label
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Get the PR associated with this workflow run
-            const prs = context.payload.workflow_run.pull_requests;
-
-            if (prs.length === 0) {
-              console.log('No open PR found for this workflow run');
-              return;
-            }
-
-            const pr = prs[0];
-            console.log(`Adding benchmarkable label to PR #${pr.number}`);
-
-            await github.rest.issues.addLabels({
-              issue_number: pr.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['benchmarkable']
-            });
-
   bench:
     runs-on: ubuntu-latest
     # Only run if benchmarkable label was added or if manually triggered

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 jobs:
   bench:
     runs-on: ubuntu-latest

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,10 +1,7 @@
 name: Documentation
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - master
     paths:
@@ -28,7 +25,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     # Only run if CI workflow succeeded, or if manually triggered, or on push/tags, or docs-only PR
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event.label.name == 'build-docs' }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -48,3 +45,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - name: Remove benchmarkable label
+        if: ${{ success() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'build-docs'
+              });
+            } catch (error) {
+              console.log('Label may not exist or already removed');
+            }

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - name: Remove benchmarkable label
+      - name: Remove build-docs label
         if: ${{ success() }}
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -1,0 +1,37 @@
+name: Labeler
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [ master ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-labels:
+    name: Add labels
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Add labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get the PR associated with this workflow run
+            const prs = context.payload.workflow_run.pull_requests;
+
+            if (prs.length === 0) {
+              console.log('No open PR found for this workflow run');
+              return;
+            }
+
+            const pr = prs[0];
+            console.log(`Adding benchmarkable label to PR #${pr.number}`);
+
+            await github.rest.issues.addLabels({
+              issue_number: pr.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['benchmarkable', 'build-docs']
+            });

--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -5,9 +5,6 @@ on:
     types: [completed]
     branches: [ master ]
 
-permissions:
-  pull-requests: write
-
 jobs:
   add-labels:
     name: Add labels
@@ -21,7 +18,7 @@ jobs:
             // Get the PR associated with this workflow run
             const prs = context.payload.workflow_run.pull_requests;
 
-            if (prs.length === 0) {
+            if (!prs || prs.length === 0) {
               console.log('No open PR found for this workflow run');
               return;
             }


### PR DESCRIPTION
Two issues:

1. The add "benchmarks" label step wasn't working; I think/hope the new script in the (also
   new) Labeling workflow will work as originally intended.
2. Documentation wasn't building the PR commit as intended (for `workflow_run` the
   SHA/commit defaults to master, not the PR). I switched the CI-dependent documentation
   build to the same label triggered setup so that it triggers from a `pull_request` context to have the right SHA/commit.
3. I moved the labeling job to its own workflow file to simplify some checks in the
   benchmarks and documentation workflows. The trigger `if` checks are slightly simpler when
   they don't have to deal with the `workflow_run` event trigger.

Sorry for the noise; hopefully this will be worth it in the end.
