### PR TITLE
Improving isconvex robustness

### DIFF
--- a/src/predicates/isconvex.jl
+++ b/src/predicates/isconvex.jl
@@ -60,7 +60,11 @@ isconvex(::Tetrahedron) = true
 
 isconvex(p::Polygon) = _isconvex(p, Val(embeddim(p)))
 
-_isconvex(p::Polygon, ::Val{2}) = Set(eachvertex(convexhull(p))) == Set(eachvertex(p))
+function _isconvex(p::Polygon, ::Val{2})
+  hasholes(p) && return false
+  r = first(rings(p))
+  all(θ -> θ ≤ oftype(θ, π), innerangles(r))
+end
 
 _isconvex(p::Polygon, ::Val{3}) = isconvex(proj2D(p))
 

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -247,6 +247,11 @@ end
   @test !isconvex(poly2)
   poly = PolyArea(cart.([(0, 0), (1, 0), (1, 1), (0.5, 0.5), (0, 1)]))
   @test !isconvex(poly)
+  poly1 = PolyArea(cart.([(0, 0), (4, 0), (0, 4), (4, 4)]))
+  poly2 = PolyArea(cart.([(0, 0), (4, 0), (4, 4), (2, 3), (0, 4)]))
+  @test !isconvex(poly1)
+  @test !isconvex(poly2)
+
   h = Hexahedron(
     cart(0, 0, 0),
     cart(1, 0, 0),


### PR DESCRIPTION
The current version of `isconvex` uses the convex hull to determine convexity. This works for all polygons except for pathological self-intersecting cases (e.g. a square where the top two vertices are flipped, leading to an hourglass). The proposed fix uses the primary definition of convexity, which is that all interior angles are <= 180 degrees and that a chord bisecting the polygon will only intersect 2 sides (e.g. no holes). This new implementation ends up being significantly faster too, as a plus.