### PR TITLE
Add default refine method for meshes

### DIFF
--- a/src/refinement.jl
+++ b/src/refinement.jl
@@ -10,11 +10,19 @@ A method for refining meshes.
 abstract type RefinementMethod end
 
 """
-    refine(mesh, method)
+    refine(mesh, [method])
 
 Refine `mesh` with refinement `method`.
+
+If the `method` is omitted, a default is used as a
+function of the `mesh`. Grids are refined into finer
+grids using regular refinement with a factor of two.
 """
 function refine end
+
+refine(mesh::Mesh) = refine(mesh, TriRefinement())
+
+refine(grid::Grid) = refine(grid, RegularRefinement(2))
 
 # ----------------
 # IMPLEMENTATIONS

--- a/test/refinement.jl
+++ b/test/refinement.jl
@@ -105,3 +105,17 @@ end
   rmesh = refine(mesh, MaxLengthRefinement(T(0.5) * u"m"))
   @test all(e -> perimeter(e) / 3 ≤ T(0.5) * u"m", rmesh)
 end
+
+@testitem "Refine" setup = [Setup] begin
+  # 2D grids
+  grid = cartgrid(10, 10)
+  rgrid = refine(grid)
+  @test size(rgrid) == (20, 20)
+
+  # general meshes
+  grid = cartgrid(10, 10)
+  mesh = topoconvert(SimpleTopology, grid)
+  rmesh = refine(mesh)
+  @test eltype(rmesh) <: Triangle
+  @test nelements(rmesh) == 200
+end


### PR DESCRIPTION
Will be needed for generic max-length refinement.