### PR TITLE
Remove bbox optimization in vizgrid

### DIFF
--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -28,7 +28,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
     Makie.image!(plot, C, interpolate=true)
   else
     # visualize as built-in image without interpolation
-    C = Makie.@lift reshape($colorant, $sz)
+    C = Makie.@lift $nc == 1 ? fill($colorant, $sz) : reshape($colorant, $sz)
     Makie.image!(plot, C, interpolate=false)
   end
 

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -30,7 +30,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
     else
       # visualize as built-in heatmap
       sz = Makie.@lift size($grid)
-      C = Makie.@lift reshape($colorant, $sz)
+      C = Makie.@lift $nc == 1 ? fill($colorant, $sz) : reshape($colorant, $sz)
       Makie.heatmap!(plot, xs, ys, C)
     end
 


### PR DESCRIPTION
It doesn't help performance-wise, and makes the call trace unnecessarily complex.