### PR TITLE
Add MultiChain type alias for dispatch purposes

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -261,6 +261,7 @@ export
   Multi,
   MultiPoint,
   MultiSegment,
+  MultiChain,
   MultiRope,
   MultiRing,
   MultiPolygon,

--- a/src/geometries/multigeoms.jl
+++ b/src/geometries/multigeoms.jl
@@ -25,6 +25,7 @@ Multi(geoms) = Multi(collect(geoms))
 # type aliases for convenience
 const MultiPoint{M<:Manifold,C<:CRS} = Multi{M,C,<:Point{M,C}}
 const MultiSegment{M<:Manifold,C<:CRS} = Multi{M,C,<:Segment{M,C}}
+const MultiChain{M<:Manifold,C<:CRS} = Multi{M,C,<:Chain{M,C}}
 const MultiRope{M<:Manifold,C<:CRS} = Multi{M,C,<:Rope{M,C}}
 const MultiRing{M<:Manifold,C<:CRS} = Multi{M,C,<:Ring{M,C}}
 const MultiPolygon{M<:Manifold,C<:CRS} = Multi{M,C,<:Polygon{M,C}}

--- a/test/multigeoms.jl
+++ b/test/multigeoms.jl
@@ -72,6 +72,7 @@
   poly = PolyArea(cart.([(0, 0), (1, 0), (1, 1), (0, 1)]))
   @test Multi([p, p]) isa MultiPoint
   @test Multi([segm, segm]) isa MultiSegment
+  @test Multi([rope, ring]) isa MultiChain
   @test Multi([rope, rope]) isa MultiRope
   @test Multi([ring, ring]) isa MultiRing
   @test Multi([tri, tri]) isa MultiPolygon


### PR DESCRIPTION
Some file formats allow mixed setups with rings and ropes in the same multi-geometry.