### PR TITLE
Refactor discretization in terms of refinemaxlen

### DIFF
--- a/docs/src/algorithms/refinement.md
+++ b/docs/src/algorithms/refinement.md
@@ -7,6 +7,7 @@ import CairoMakie as Mke # hide
 
 ```@docs
 refine
+refinemaxlen
 RefinementMethod
 ```
 

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -48,7 +48,7 @@ end
 # ---------------
 
 # fallback to visualization of discretized geometries
-function vizgset!(plot, ::Type, pdim::Val, ::Val, geoms::ObservableVector{<:Geometry}, colors)
+function vizgset!(plot, M::Type, pdim::Val, ::Val, geoms::ObservableVector{<:Geometry}, colors)
   showsegments = plot[:showsegments]
   showpoints = plot[:showpoints]
 
@@ -57,20 +57,27 @@ function vizgset!(plot, ::Type, pdim::Val, ::Val, geoms::ObservableVector{<:Geom
   # turning the quadrangles into triangles
   triangulate = simplexify ∘ discretize
 
+  # refine meshes over the 🌐 manifold until
+  # they satisfy the maximum length criterion
+  mayberefine = M === 🌐 ? refinemaxlen : identity
+
+  # final discretization pipeline
+  trirefine = mayberefine ∘ triangulate
+
   if pdim === Val(1)
-    meshes = Makie.@lift triangulate.($geoms)
+    meshes = Makie.@lift trirefine.($geoms)
     vizmany!(plot, meshes, colors)
     if showpoints[]
       vizfacets!(plot, geoms)
     end
   elseif pdim === Val(2)
-    meshes = Makie.@lift triangulate.($geoms)
+    meshes = Makie.@lift trirefine.($geoms)
     vizmany!(plot, meshes, colors)
     if showsegments[]
       vizfacets!(plot, geoms)
     end
   elseif pdim == Val(3)
-    meshes = Makie.@lift triangulate.(boundary.($geoms))
+    meshes = Makie.@lift trirefine.(boundary.($geoms))
     vizmany!(plot, meshes, colors)
   end
 end

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -582,6 +582,7 @@ export
   RegularRefinement,
   MaxLengthRefinement,
   refine,
+  refinemaxlen,
 
   # coarsening
   CoarseningMethod,

--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -243,4 +243,7 @@ boundarypoints(m::MultiPoint) = parent(m)
 
 boundarypoints(p::Polytope) = manifold(p) === 🌐 ? _boundarypoints(p) : vertices(p)
 
-_boundarypoints(g::Geometry) = vertices(discretize(embedboundary(g)))
+function _boundarypoints(g::Geometry)
+  mayberefine = manifold(g) === 🌐 ? refinemaxlen : identity
+  vertices(mayberefine(discretize(embedboundary(g))))
+end

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -20,11 +20,6 @@ abstract type TriangulationMethod <: DiscretizationMethod end
     discretize(geometry, [method])
 
 Discretize `geometry` with discretization `method`.
-
-If the `method` is omitted, a default is used as a
-function of the `geometry`. Geometries over the `🌐`
-manifold are refined until the segments are shorter
-than a maximum length.
 """
 function discretize end
 
@@ -46,49 +41,41 @@ function discretizewithin end
 # DISCRETIZE
 # -----------
 
-function discretize(geometry::Geometry)
-  if manifold(geometry) === 🌐
-    _discretize(geometry) |> _refinemaxlen
-  else
-    _discretize(geometry)
-  end
-end
+discretize(box::Box) = discretize(box, RegularDiscretization(1))
 
-_discretize(geometry::Geometry) = _simplexify(geometry)
+discretize(ball::Ball{𝔼{2}}) = discretize(ball, RegularDiscretization(2, 50))
 
-_discretize(box::Box) = discretize(box, RegularDiscretization(1))
+discretize(disk::Disk) = discretize(disk, RegularDiscretization(50))
 
-_discretize(ball::Ball{𝔼{2}}) = discretize(ball, RegularDiscretization(2, 50))
+discretize(sphere::Sphere{𝔼{3}}) = discretize(sphere, RegularDiscretization(50))
 
-_discretize(disk::Disk) = discretize(disk, RegularDiscretization(50))
+discretize(ellipsoid::Ellipsoid) = discretize(ellipsoid, RegularDiscretization(50))
 
-_discretize(sphere::Sphere{𝔼{3}}) = discretize(sphere, RegularDiscretization(50))
+discretize(torus::Torus) = discretize(torus, RegularDiscretization(50))
 
-_discretize(ellipsoid::Ellipsoid) = discretize(ellipsoid, RegularDiscretization(50))
+discretize(cyl::Cylinder) = discretize(cyl, RegularDiscretization(2, 50, 2))
 
-_discretize(torus::Torus) = discretize(torus, RegularDiscretization(50))
+discretize(cylsurf::CylinderSurface) = discretize(cylsurf, RegularDiscretization(50, 2))
 
-_discretize(cyl::Cylinder) = discretize(cyl, RegularDiscretization(2, 50, 2))
+discretize(consurf::ConeSurface) = discretize(consurf, RegularDiscretization(50, 2))
 
-_discretize(cylsurf::CylinderSurface) = discretize(cylsurf, RegularDiscretization(50, 2))
+discretize(frustsurf::FrustumSurface) = discretize(frustsurf, RegularDiscretization(50, 2))
 
-_discretize(consurf::ConeSurface) = discretize(consurf, RegularDiscretization(50, 2))
+discretize(parsurf::ParaboloidSurface) = discretize(parsurf, RegularDiscretization(50))
 
-_discretize(frustsurf::FrustumSurface) = discretize(frustsurf, RegularDiscretization(50, 2))
+discretize(quad::Quadrangle) = discretize(quad, RegularDiscretization(1))
 
-_discretize(parsurf::ParaboloidSurface) = discretize(parsurf, RegularDiscretization(50))
-
-_discretize(quad::Quadrangle) = discretize(quad, RegularDiscretization(1))
-
-_discretize(hexa::Hexahedron) = discretize(hexa, RegularDiscretization(1))
+discretize(hexa::Hexahedron) = discretize(hexa, RegularDiscretization(1))
 
 discretize(multi::Multi) = mapreduce(discretize, merge, parent(multi))
 
-function discretize(geometry::TransformedGeometry)
-  pmesh = discretize(parent(geometry))
-  tmesh = pmesh |> transform(geometry)
+function discretize(geom::TransformedGeometry)
+  pmesh = discretize(parent(geom))
+  tmesh = pmesh |> transform(geom)
   _mayberefinemaxlen(pmesh, tmesh)
 end
+
+discretize(geom::Geometry) = simplexify(geom)
 
 discretize(mesh::Mesh) = mesh
 
@@ -96,30 +83,24 @@ discretize(mesh::Mesh) = mesh
 # FALLBACKS
 # ----------
 
-discretize(geometry::Geometry, method::DiscretizationMethod) = _discretize(geometry, method)
-
 discretize(multi::Multi, method::DiscretizationMethod) =
   mapreduce(geom -> discretize(geom, method), merge, parent(multi))
 
-function discretize(geometry::TransformedGeometry, method::DiscretizationMethod)
-  pmesh = discretize(parent(geometry), method)
-  tmesh = pmesh |> transform(geometry)
+function discretize(geom::TransformedGeometry, method::DiscretizationMethod)
+  pmesh = discretize(parent(geom), method)
+  tmesh = pmesh |> transform(geom)
   _mayberefinemaxlen(pmesh, tmesh)
 end
 
-# -----------------
-# BOUNDARY METHODS
-# -----------------
-
-discretize(geometry::Geometry, method::BoundaryTriangulationMethod) = discretizewithin(boundary(geometry), method)
+discretize(geom::Geometry, method::BoundaryTriangulationMethod) = discretizewithin(boundary(geom), method)
 
 # this method exists to fix ambiguity
 discretize(multi::Multi, method::BoundaryTriangulationMethod) =
   mapreduce(geom -> discretize(geom, method), merge, parent(multi))
 
-function discretize(polygon::Polygon, method::BoundaryTriangulationMethod)
+function discretize(poly::Polygon, method::BoundaryTriangulationMethod)
   # clean up polygon if necessary
-  cpoly = polygon |> Repair(0) |> Repair(8)
+  cpoly = poly |> Repair(0) |> Repair(8)
 
   # handle degenerate polygons
   if nvertices(cpoly) == 1
@@ -130,7 +111,7 @@ function discretize(polygon::Polygon, method::BoundaryTriangulationMethod)
 
   # build bridges in case the polygon has holes,
   # i.e. reduce to a single outer boundary
-  bpoly, dups = apply(Bridge(2atol(lentype(polygon))), cpoly)
+  bpoly, dups = apply(Bridge(2atol(lentype(poly))), cpoly)
 
   # discretize using outer boundary
   mesh = discretizewithin(boundary(bpoly), method)
@@ -212,47 +193,37 @@ when the `object` has parametric dimension 2.
 """
 function simplexify end
 
-function simplexify(geometry::Geometry)
-  if manifold(geometry) == 🌐
-    _simplexify(geometry) |> _refinemaxlen
-  else
-    _simplexify(geometry)
-  end
-end
+simplexify(box::Box) = discretize(box, ManualSimplexification())
 
-_simplexify(geometry::Geometry) = _simplexify(_discretize(geometry))
+simplexify(bezier::BezierCurve) = discretize(bezier, RegularDiscretization(50))
 
-_simplexify(box::Box) = discretize(box, ManualSimplexification())
+simplexify(curve::ParametrizedCurve) = discretize(curve, RegularDiscretization(50))
 
-_simplexify(bezier::BezierCurve) = discretize(bezier, RegularDiscretization(50))
+simplexify(sphere::Sphere{𝔼{2}}) = discretize(sphere, RegularDiscretization(50))
 
-_simplexify(curve::ParametrizedCurve) = discretize(curve, RegularDiscretization(50))
+simplexify(circle::Circle) = discretize(circle, RegularDiscretization(50))
 
-_simplexify(sphere::Sphere{𝔼{2}}) = discretize(sphere, RegularDiscretization(50))
+simplexify(chain::Chain) = discretize(chain, ManualSimplexification())
 
-_simplexify(circle::Circle) = discretize(circle, RegularDiscretization(50))
+simplexify(tri::Triangle) = discretize(tri, ManualSimplexification())
 
-_simplexify(chain::Chain) = discretize(chain, ManualSimplexification())
+simplexify(quad::Quadrangle) = discretize(quad, ManualSimplexification())
 
-_simplexify(tri::Triangle) = discretize(tri, ManualSimplexification())
+simplexify(poly::Polygon) = discretize(poly, nvertices(poly) > 5000 ? DelaunayTriangulation() : DehnTriangulation())
 
-_simplexify(quad::Quadrangle) = discretize(quad, ManualSimplexification())
-
-_simplexify(poly::Polygon) = discretize(poly, nvertices(poly) > 5000 ? DelaunayTriangulation() : DehnTriangulation())
-
-_simplexify(poly::Polyhedron) = discretize(poly, ManualSimplexification())
+simplexify(poly::Polyhedron) = discretize(poly, ManualSimplexification())
 
 simplexify(multi::Multi) = mapreduce(simplexify, merge, parent(multi))
 
-function simplexify(geometry::TransformedGeometry)
-  pmesh = simplexify(parent(geometry))
-  tmesh = pmesh |> transform(geometry)
+function simplexify(geom::TransformedGeometry)
+  pmesh = simplexify(parent(geom))
+  tmesh = pmesh |> transform(geom)
   _mayberefinemaxlen(pmesh, tmesh)
 end
 
-simplexify(mesh::Mesh) = _simplexify(mesh)
+simplexify(geom::Geometry) = simplexify(discretize(geom))
 
-function _simplexify(mesh::Mesh)
+function simplexify(mesh::Mesh)
   # retrieve vertices and connectivities
   points = vertices(mesh)
   connec = elements(topology(mesh))
@@ -297,7 +268,7 @@ function _appendinds!(ginds, connec, points)
   inds = indices(connec)
 
   # simplexify element
-  mesh = _simplexify(elem)
+  mesh = simplexify(elem)
   topo = topology(mesh)
 
   # convert from local to global indices
@@ -333,7 +304,5 @@ function _mayberefinemaxlen(pmesh, tmesh)
   # maximum predefined length in physical units
   Mₚ, Mₜ = manifold(pmesh), manifold(tmesh)
   changed = (Mₚ === 🌐 && Mₜ !== 🌐) || (Mₚ !== 🌐 && Mₜ === 🌐)
-  changed ? _refinemaxlen(tmesh) : tmesh
+  changed ? refinemaxlen(tmesh) : tmesh
 end
-
-_refinemaxlen(tmesh) = refine(tmesh, MaxLengthRefinement(maxlen()))

--- a/src/discretization/manual.jl
+++ b/src/discretization/manual.jl
@@ -9,9 +9,9 @@ Simplexify convex geometries manually using indices of vertices.
 """
 struct ManualSimplexification <: DiscretizationMethod end
 
-_discretize(geometry::Geometry, ::ManualSimplexification) = SimpleMesh(_manualverts(geometry), _manualconnec(geometry))
+discretize(geom::Geometry, ::ManualSimplexification) = SimpleMesh(_manualverts(geom), _manualconnec(geom))
 
-function _discretize(chain::Chain, ::ManualSimplexification)
+function discretize(chain::Chain, ::ManualSimplexification)
   np = nvertices(chain) + isclosed(chain)
   ip = isperiodic(chain)
 

--- a/src/discretization/regular.jl
+++ b/src/discretization/regular.jl
@@ -7,9 +7,9 @@
 
 A method to discretize primitive geometries with
 `n1×n2×...×np` elements sampled regularly along
-each parametric dimensions. The adequate number
-of points is calculated for each type of geometry
-and passed to [`RegularSampling`](@ref).
+each parametric dimension. The adequate number of
+points is calculated for each type of geometry and
+forwarded to [`RegularSampling`](@ref).
 """
 struct RegularDiscretization{N} <: DiscretizationMethod
   sizes::Dims{N}
@@ -17,32 +17,32 @@ end
 
 RegularDiscretization(sizes::Vararg{Int,N}) where {N} = RegularDiscretization(sizes)
 
-function _discretize(geometry::Geometry, method::RegularDiscretization)
-  if isparametrized(geometry)
-    verts, tgrid = wrapgrid(geometry, method)
-    tmesh = appendtopo(geometry, tgrid)
+function discretize(geom::Geometry, method::RegularDiscretization)
+  if isparametrized(geom)
+    verts, tgrid = wrapgrid(geom, method)
+    tmesh = appendtopo(geom, tgrid)
     SimpleMesh(collect(verts), tmesh)
   else
-    _discretizewithinbox(geometry, method)
+    _discretizewithinbox(geom, method)
   end
 end
 
 # box is trivial to discretize into a regular grid
-function _discretize(box::Box, method::RegularDiscretization)
+function discretize(box::Box, method::RegularDiscretization)
   sz = fitdims(method.sizes, paramdim(box))
   RegularGrid(extrema(box)..., dims=sz)
 end
 
 # triangle is parametrized with barycentric coordinates, so we can't rely on regular sampling
-_discretize(triangle::Triangle, method::RegularDiscretization) = _discretizewithinbox(triangle, method)
+discretize(tri::Triangle, method::RegularDiscretization) = _discretizewithinbox(tri, method)
 
 # tetrahedron is parametrized with barycentric coordinates, so we can't rely on regular sampling
-_discretize(tetrahedron::Tetrahedron, method::RegularDiscretization) = _discretizewithinbox(tetrahedron, method)
+discretize(tetra::Tetrahedron, method::RegularDiscretization) = _discretizewithinbox(tetra, method)
 
-function _discretizewithinbox(geometry::Geometry, method::RegularDiscretization)
-  box = boundingbox(geometry)
-  grid = _discretize(box, method)
-  view(grid, geometry)
+function _discretizewithinbox(geom::Geometry, method::RegularDiscretization)
+  box = boundingbox(geom)
+  grid = discretize(box, method)
+  view(grid, geom)
 end
 
 # ----------------------

--- a/src/refinement.jl
+++ b/src/refinement.jl
@@ -13,16 +13,20 @@ abstract type RefinementMethod end
     refine(mesh, [method])
 
 Refine `mesh` with refinement `method`.
-
-If the `method` is omitted, a default is used as a
-function of the `mesh`. Grids are refined into finer
-grids using regular refinement with a factor of two.
 """
 function refine end
 
 refine(mesh::Mesh) = refine(mesh, QuadRefinement())
 
 refine(grid::Grid) = refine(grid, RegularRefinement(2))
+
+"""
+    refinemaxlen(mesh)
+
+Refine `mesh` to ensure that no element exceeds the
+maximum length specified by [`maxlen`](@ref).
+"""
+refinemaxlen(mesh::Mesh) = refine(mesh, MaxLengthRefinement(maxlen()))
 
 # ----------------
 # IMPLEMENTATIONS

--- a/src/tolerances.jl
+++ b/src/tolerances.jl
@@ -50,8 +50,8 @@ rtol(𝒟::Type{<:ForwardDiff.Dual}) = rtol(ForwardDiff.valtype(𝒟))
 const MAXLEN = ScopedValue(500u"km")
 
 """
-Maximum length used for discretization of non-Euclidean geometries.
-It is used in the source code in calls to the [`discretize`](@ref)
-and [`simplexify`](@ref) functions.
+    maxlen()
+
+Maximum length used for refinement of non-Euclidean geometries.
 """
 maxlen() = MAXLEN[]

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -489,7 +489,7 @@ end
   @test nvertices.(mesh) ⊆ [2]
 
   bezier = BezierCurve(latlon(0, 0), latlon(0, 10), latlon(10, 10))
-  mesh = discretize(bezier)
+  mesh = discretize(bezier) |> refinemaxlen
   @test topology(mesh) == GridTopology((50,), (false,))
   @test nvertices(mesh) == 51
   @test nelements(mesh) == 50
@@ -505,7 +505,7 @@ end
   @test nvertices.(mesh) ⊆ [2]
 
   bezier = BezierCurve(latlon(0, 0), latlon(0, 10), latlon(10, 10), latlon(0, 0))
-  mesh = discretize(bezier)
+  mesh = discretize(bezier) |> refinemaxlen
   @test topology(mesh) == GridTopology((50,), (true,))
   @test nvertices(mesh) == 50
   @test nelements(mesh) == 50
@@ -537,7 +537,7 @@ end
   @test nvertices.(mesh) ⊆ [4]
 
   box = Box(latlon(0, 0), latlon(10, 10))
-  mesh = discretize(box)
+  mesh = discretize(box) |> refinemaxlen
   @test topology(mesh) == GridTopology((4, 4), (false, false))
   @test nvertices(mesh) == 5 * 5
   @test nelements(mesh) == 4 * 4
@@ -585,7 +585,7 @@ end
   @test nvertices.(mesh) ⊆ [2]
 
   seg = Segment(latlon(0, 0), latlon(10, 10))
-  mesh = discretize(seg)
+  mesh = discretize(seg) |> refinemaxlen
   @test topology(mesh) == GridTopology((4,), (false,))
   @test nvertices(mesh) == 5
   @test nelements(mesh) == 4
@@ -601,7 +601,7 @@ end
   @test nvertices.(mesh) ⊆ [2]
 
   rope = Rope(latlon(0, 0), latlon(0, 10), latlon(10, 0))
-  mesh = discretize(rope)
+  mesh = discretize(rope) |> refinemaxlen
   @test topology(mesh) == GridTopology((8,), (false,))
   @test nvertices(mesh) == 9
   @test nelements(mesh) == 8
@@ -617,7 +617,7 @@ end
   @test nvertices.(mesh) ⊆ [2]
 
   ring = Ring(latlon(0, 0), latlon(0, 10), latlon(10, 0))
-  mesh = discretize(ring)
+  mesh = discretize(ring) |> refinemaxlen
   @test topology(mesh) == GridTopology((12,), (true,))
   @test nvertices(mesh) == 12
   @test nelements(mesh) == 12
@@ -632,7 +632,7 @@ end
   @test nvertices.(mesh) ⊆ [3]
 
   tri = Triangle(latlon(0, 0), latlon(0, 10), latlon(10, 0))
-  mesh = discretize(tri)
+  mesh = discretize(tri) |> refinemaxlen
   @test nvertices(mesh) == 19
   @test nelements(mesh) == 12
   @test eltype(mesh) <: Quadrangle
@@ -647,7 +647,7 @@ end
   @test nvertices.(mesh) ⊆ [4]
 
   quad = Quadrangle(latlon(0, 0), latlon(0, 10), latlon(10, 10), latlon(10, 0))
-  mesh = discretize(quad)
+  mesh = discretize(quad) |> refinemaxlen
   @test topology(mesh) == GridTopology((4, 4), (false, false))
   @test nvertices(mesh) == 25
   @test nelements(mesh) == 16
@@ -668,7 +668,7 @@ end
   hole1 = latlon.([(2, 2), (4, 2), (4, 4), (2, 4)])
   hole2 = latlon.([(2, 6), (4, 6), (4, 8), (2, 8)])
   poly = PolyArea([outer, hole1, hole2])
-  mesh = discretize(poly)
+  mesh = discretize(poly) |> refinemaxlen
   @test nvertices(mesh) == 191
   @test nelements(mesh) == 168
   @test eltype(mesh) <: Quadrangle
@@ -686,7 +686,7 @@ end
   tri = Triangle(latlon(0, -10), latlon(0, 0), latlon(10, -10))
   quad = Quadrangle(latlon(0, 0), latlon(0, 10), latlon(10, 10), latlon(10, 0))
   multi = Multi([tri, quad])
-  mesh = discretize(multi)
+  mesh = discretize(multi) |> refinemaxlen
   @test nvertices(mesh) == 44
   @test nelements(mesh) == 28
   @test eltype(mesh) <: Quadrangle


### PR DESCRIPTION
The refinement is explicit now to avoid over-discretization. Now that we have efficient `measure` for non-Euclidean geometries, we don't need to refine the meshes to get accurate results.