### PR TITLE
Fix Julia compiler bug related to refinemaxlen

### DIFF
--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -62,19 +62,19 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, geoms::ObservableVector{<:Geo
   triangulate = simplexify ∘ mayberefine ∘ discretize
 
   if pdim === Val(1)
-    meshes = Makie.@lift triangulate.($geoms)
+    meshes = Makie.@lift map(triangulate, $geoms)
     vizmany!(plot, meshes, colors)
     if showpoints[]
       vizfacets!(plot, geoms)
     end
   elseif pdim === Val(2)
-    meshes = Makie.@lift triangulate.($geoms)
+    meshes = Makie.@lift map(triangulate, $geoms)
     vizmany!(plot, meshes, colors)
     if showsegments[]
       vizfacets!(plot, geoms)
     end
   elseif pdim == Val(3)
-    meshes = Makie.@lift triangulate.(boundary.($geoms))
+    meshes = Makie.@lift map(triangulate, boundary.($geoms))
     vizmany!(plot, meshes, colors)
   end
 end


### PR DESCRIPTION
The following code takes forever on Julia v1.12.5 because of a bug in the compiler:

```julia
using GeoStats

A = Point(LatLon(0, 0))
B = Point(LatLon(0, 90))
C = Point(LatLon(45, 90))

segs = [Segment(A, B), Segment(B, C), Segment(A, C)]

func = refinemaxlen ∘ discretize

func.(segs)
```

Replacing the broadcast by a simple map call returns quickly as expected:

```julia
map(func, segs)
```

EDIT: tested on Julia v1.12.6 and the bug is still present.