### PR TITLE
Support vertex colors for 3D Cartesian grids

### DIFF
--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -67,17 +67,17 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     # visualize as a quadrangle mesh so that
     # colors can be specified at vertices
     verts = Makie.@lift map(asmakie, eachvertex($grid))
-    quads = Makie.@lift mapreduce(vcat, elements(topology($grid))) do elem
+    quads = Makie.@lift reduce(vcat, map(elements(topology($grid))) do elem
       i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
       [
-        GB.QuadFace(i1, i2, i3, i4),
-        GB.QuadFace(i5, i6, i7, i8),
-        GB.QuadFace(i1, i2, i6, i5),
-        GB.QuadFace(i2, i3, i7, i6),
-        GB.QuadFace(i3, i4, i8, i7),
-        GB.QuadFace(i4, i1, i5, i8)
+        GB.QuadFace(i4, i3, i2, i1),
+        GB.QuadFace(i6, i5, i1, i2),
+        GB.QuadFace(i3, i7, i6, i2),
+        GB.QuadFace(i4, i8, i7, i3),
+        GB.QuadFace(i1, i5, i8, i4),
+        GB.QuadFace(i6, i7, i8, i5)
       ]
-    end
+    end)
     mesh = Makie.@lift GB.Mesh($verts, $quads)
     Makie.mesh!(plot, mesh, color=colorant, shading=true)
   else

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -72,9 +72,8 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
       map(elements(topology($grid))) do elem
         i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
         [
-          # follow the same ordering of vertices
-          # specified in the `boundary` method for
-          # Hexahedron in Meshes.jl source code
+          # follow the same order of vertices specified
+          # in the `boundary` method for Hexahedron
           GB.QuadFace(i4, i3, i2, i1),
           GB.QuadFace(i6, i5, i1, i2),
           GB.QuadFace(i3, i7, i6, i2),

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -64,7 +64,22 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
   xyz = Makie.@lift map(x -> ustrip.(x), Meshes.xyz($grid))
 
   if nc[] == nv[]
-    error("not implemented")
+    # visualize as a quadrangle mesh so that
+    # colors can be specified at vertices
+    verts = Makie.@lift map(asmakie, eachvertex($grid))
+    quads = Makie.@lift mapreduce(vcat, elements(topology($grid))) do elem
+      i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
+      [
+        GB.QuadFace(i1, i2, i3, i4),
+        GB.QuadFace(i5, i6, i7, i8),
+        GB.QuadFace(i1, i2, i6, i5),
+        GB.QuadFace(i2, i3, i7, i6),
+        GB.QuadFace(i3, i4, i8, i7),
+        GB.QuadFace(i4, i1, i5, i8)
+      ]
+    end
+    mesh = Makie.@lift GB.Mesh($verts, $quads)
+    Makie.mesh!(plot, mesh, color=colorant, shading=true)
   else
     # visualize as built-in meshscatter
     xs = Makie.@lift $xyz[1][(begin + 1):end]

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -73,7 +73,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
         i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
         [
           # follow the same order of vertices specified
-          # in the `boundary` method for Hexahedron
+          # in the `boundary` method for `Hexahedron`
           GB.QuadFace(i4, i3, i2, i1),
           GB.QuadFace(i6, i5, i1, i2),
           GB.QuadFace(i3, i7, i6, i2),

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -67,17 +67,23 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     # visualize as a quadrangle mesh so that
     # colors can be specified at vertices
     verts = Makie.@lift map(asmakie, eachvertex($grid))
-    quads = Makie.@lift reduce(vcat, map(elements(topology($grid))) do elem
-      i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
-      [
-        GB.QuadFace(i4, i3, i2, i1),
-        GB.QuadFace(i6, i5, i1, i2),
-        GB.QuadFace(i3, i7, i6, i2),
-        GB.QuadFace(i4, i8, i7, i3),
-        GB.QuadFace(i1, i5, i8, i4),
-        GB.QuadFace(i6, i7, i8, i5)
-      ]
-    end)
+    quads = Makie.@lift reduce(
+      vcat,
+      map(elements(topology($grid))) do elem
+        i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
+        [
+          # follow the same ordering of vertices
+          # specified in the `boundary` method for
+          # Hexahedron in Meshes.jl source code
+          GB.QuadFace(i4, i3, i2, i1),
+          GB.QuadFace(i6, i5, i1, i2),
+          GB.QuadFace(i3, i7, i6, i2),
+          GB.QuadFace(i4, i8, i7, i3),
+          GB.QuadFace(i1, i5, i8, i4),
+          GB.QuadFace(i6, i7, i8, i5)
+        ]
+      end
+    )
     mesh = Makie.@lift GB.Mesh($verts, $quads)
     Makie.mesh!(plot, mesh, color=colorant, shading=true)
   else


### PR DESCRIPTION
This PR adds vertex-color support for 3D `CartesianGrid` / `RegularGrid` visualization, see https://github.com/JuliaGeometry/Meshes.jl/issues/1250

We render vertex-colored 3D grids as a Makie quad mesh built from hexahedral faces. We keep the existing `meshscatter!` path for single-color and element-color grid rendering.