### PR TITLE
Use Makie's ComputeGraph instead of @lift

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -43,15 +43,13 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - name: Retrieve downstream package
-        # Note: we retrieve the current `main` branch of the downstream package (MeshesVizTests.jl) to ensure
+        # Note: we retrieve the current `main` branch of the downstream package to ensure
         # that compatibility errors we make in Meshes.jl are detected already here
         # See also https://github.com/trixi-framework/Trixi.jl/pull/1707#discussion_r1382938895
         uses: actions/checkout@v6
         with:
           repository: JuliaGeometry/${{ matrix.package }}
           path: downstream
-        # Note: this script loads the upstream (to-be-tested) version of Meshes.jl
-        # See also https://github.com/JuliaGeometry/Meshes.jl/pull/1366#issuecomment-4605948374
       - name: Load upstream package into downstream environment
         shell: julia --color=yes --project=downstream {0}
         run: |

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -43,13 +43,15 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - name: Retrieve downstream package
-        # Note: we retrieve the current `main` branch of the downstream package to ensure
+        # Note: we retrieve the current `main` branch of the downstream package (MeshesVizTests.jl) to ensure
         # that compatibility errors we make in Meshes.jl are detected already here
         # See also https://github.com/trixi-framework/Trixi.jl/pull/1707#discussion_r1382938895
         uses: actions/checkout@v6
         with:
           repository: JuliaGeometry/${{ matrix.package }}
           path: downstream
+        # Note: this script loads the upstream (to-be-tested) version of Meshes.jl
+        # See also https://github.com/JuliaGeometry/Meshes.jl/pull/1366#issuecomment-4605948374
       - name: Load upstream package into downstream environment
         shell: julia --color=yes --project=downstream {0}
         run: |

--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -86,6 +86,7 @@ include("mesh.jl")
 include("grid.jl")
 include("geomset.jl")
 include("subdomain.jl")
+include("transfdomain.jl")
 include("fallbacks.jl")
 
 end

--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -78,9 +78,6 @@ function xyzlabels(CRS)
   end
 end
 
-# color handling
-include("colors.jl")
-
 # utilities
 include("utils.jl")
 

--- a/ext/colors.jl
+++ b/ext/colors.jl
@@ -1,8 +1,0 @@
-# ------------------------------------------------------------------
-# Licensed under the MIT License. See LICENSE in the project root.
-# ------------------------------------------------------------------
-
-# preprocess colors provided by user
-process(values::AbstractVector, colorscheme, colorrange, alphas) = colorfy(values; alphas, colorscheme, colorrange)
-
-process(value, colorscheme, colorrange, alphas) = process([value], colorscheme, colorrange, alphas) |> first

--- a/ext/fallbacks.jl
+++ b/ext/fallbacks.jl
@@ -10,10 +10,11 @@ Makie.convert_arguments(::Type{<:Viz}, geom::Geometry) = (GeometrySet([geom]),)
 Makie.plottype(::Domain) = Viz{<:Tuple{Domain}}
 Makie.convert_arguments(::Type{<:Viz}, domain::Domain) = (GeometrySet(collect(domain)),)
 
-# skip conversion and use specialized methods
+# skip fallback and use specialized methods
 Makie.convert_arguments(::Type{<:Viz}, mesh::Mesh) = (mesh,)
 Makie.convert_arguments(::Type{<:Viz}, gset::GeometrySet) = (gset,)
-Makie.convert_arguments(::Type{<:Viz}, subdom::SubDomain) = (subdom,)
+Makie.convert_arguments(::Type{<:Viz}, sdom::SubDomain) = (sdom,)
+Makie.convert_arguments(::Type{<:Viz}, tdom::TransformedDomain) = (tdom,)
 
 # vector of geometries (for convenience)
 Makie.plottype(::AbstractVector{<:Geometry}) = Viz{<:Tuple{AbstractVector{<:Geometry}}}

--- a/ext/fallbacks.jl
+++ b/ext/fallbacks.jl
@@ -14,7 +14,7 @@ Makie.convert_arguments(::Type{<:Viz}, domain::Domain) = (GeometrySet(collect(do
 Makie.convert_arguments(::Type{<:Viz}, mesh::Mesh) = (mesh,)
 Makie.convert_arguments(::Type{<:Viz}, gset::GeometrySet) = (gset,)
 Makie.convert_arguments(::Type{<:Viz}, sdom::SubDomain) = (sdom,)
-Makie.convert_arguments(::Type{<:Viz}, tdom::TransformedDomain) = (tdom,)
+Makie.convert_arguments(::Type{<:Viz}, tgrid::TransformedGrid) = (tgrid,)
 
 # vector of geometries (for convenience)
 Makie.plottype(::AbstractVector{<:Geometry}) = Viz{<:Tuple{AbstractVector{<:Geometry}}}

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -2,20 +2,16 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-Makie.plot!(plot::Viz{<:Tuple{GeometrySet}}) = vizgset!(plot)
+function Makie.plot!(plot::Viz{<:Tuple{GeometrySet}})
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  vizgset!(plot)
+end
 
 # split heterogeneous geometry sets into homogeneous vectors
 # of geometries and send these vectors to specialized recipes
-function vizgset!(plot; facets=false)
-  gset = plot.object[]
-
-  # process color spec into colorant
-  if !facets
-    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-  end
-
+function vizgset!(plot)
   # get geometries
-  geoms = parent(gset)
+  geoms = parent(plot.object[])
 
   # get geometry types
   types = unique(map(typeof, geoms))
@@ -23,29 +19,20 @@ function vizgset!(plot; facets=false)
   for (i, G) in enumerate(types)
     inds_sym = Symbol(:inds_, i)
     gvec_sym = Symbol(:gvec_, i)
+    cvec_sym = Symbol(:cvec_, i)
 
-    Makie.map!(plot, [:object], inds_sym) do g
-      findall(x -> x isa G, parent(g))
-    end
-
-    Makie.map!(plot, [:object, inds_sym], gvec_sym) do g, inds
-      collect(G, parent(g)[inds])
+    Makie.map!(plot, [:object, :colorant], [inds_sym, gvec_sym, cvec_sym]) do g, colorant
+      inds = findall(x -> x isa G, parent(g))
+      gvec = collect(G, parent(g)[inds])
+      cvec = colorant isa AbstractVector ? colorant[inds] : fill(colorant, length(inds))
+      inds, gvec, cvec
     end
 
     gvec = collect(G, geoms[findall(x -> x isa G, geoms)])
     M = manifold(first(gvec))
     pdim = paramdim(first(gvec))
     edim = embeddim(first(gvec))
-
-    if facets
-      vizgsetfacets!(plot, M, Val(pdim), Val(edim), G, gvec_sym)
-    else
-      cvec_sym = Symbol(:cvec_, i)
-      Makie.map!(plot, [:colorant, inds_sym], cvec_sym) do colorant, inds
-        colorant isa AbstractVector ? colorant[inds] : fill(colorant, length(inds))
-      end
-      vizgset!(plot, M, Val(pdim), Val(edim), G, gvec_sym, cvec_sym)
-    end
+    vizgset!(plot, M, Val(pdim), Val(edim), G, gvec_sym, cvec_sym)
   end
 end
 
@@ -269,7 +256,7 @@ end
 # FACETS
 # -------
 
-vizfacets!(plot::Viz{<:Tuple{GeometrySet}}) = vizgset!(plot, facets=false)
+vizfacets!(plot::Viz{<:Tuple{GeometrySet}}) = vizfacets!(plot)
 
 function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, G::Type, geoms::Symbol)
   gvec = plot[geoms][]

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -10,27 +10,27 @@ end
 # split heterogeneous geometry sets into homogeneous vectors
 # of geometries and send these vectors to specialized recipes
 function vizgset!(plot)
-  # get geometries
+  # retrieve geometries and their types
   geoms = parent(plot.object[])
-
-  # get geometry types
   types = unique(map(typeof, geoms))
 
   for (i, G) in enumerate(types)
-    gvec_sym = Symbol(:gvec_, i)
-    cvec_sym = Symbol(:cvec_, i)
-
-    Makie.map!(plot, [:object, :colorant], [gvec_sym, cvec_sym]) do g, colorant
-      inds = findall(x -> x isa G, parent(g))
-      gvec = collect(G, parent(g)[inds])
+    # add nodes to compute graph for this type of geometry
+    gvecid = Symbol(:geoms, i)
+    cvecid = Symbol(:colors, i)
+    Makie.map!(plot, [:object, :colorant], [gvecid, cvecid]) do gset, colorant
+      geos = parent(gset)
+      inds = findall(x -> x isa G, geos)
+      gvec = collect(G, geos[inds])
       cvec = colorant isa AbstractVector ? colorant[inds] : fill(colorant, length(inds))
       gvec, cvec
     end
-    gvec = plot[gvec_sym][]
-    M = manifold(first(gvec))
-    pdim = paramdim(first(gvec))
-    edim = embeddim(first(gvec))
-    vizgset!(plot, M, Val(pdim), Val(edim), G, gvec_sym, cvec_sym)
+
+    # dispatch specialized recipe for this type of geometry
+    M = manifold(G)
+    pdim = paramdim(G)
+    edim = embeddim(G)
+    vizgset!(plot, M, Val(pdim), Val(edim), G, gvecid, cvecid)
   end
 end
 

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -7,7 +7,7 @@ Makie.plot!(plot::Viz{<:Tuple{GeometrySet}}) = vizgset!(plot)
 # split heterogeneous geometry sets into homogeneous vectors
 # of geometries and send these vectors to specialized recipes
 function vizgset!(plot; facets=false)
-  gset = plot[:object][]
+  gset = plot.object[]
 
   # process color spec into colorant
   if !facets
@@ -55,8 +55,8 @@ end
 
 # fallback to visualization of discretized geometries
 function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::Symbol, colors::Symbol)
-  showsegments = plot[:showsegments]
-  showpoints = plot[:showpoints]
+  showsegments = plot.showsegments
+  showpoints = plot.showpoints
 
   # refine meshes over the 🌐 manifold until
   # they satisfy the maximum length criterion
@@ -115,8 +115,8 @@ function vizgset!(plot, M::Type, pdim::Val, edim::Val, G::Type{<:Multi}, geoms::
 end
 
 function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, geoms::Symbol, colors::Symbol)
-  pointmarker = plot[:pointmarker]
-  pointsize = plot[:pointsize]
+  pointmarker = plot.pointmarker
+  pointsize = plot.pointsize
 
   coords_sym = Symbol(geoms, :_coords)
 
@@ -130,8 +130,7 @@ function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, geoms::Symbol, c
 end
 
 function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol, colors::Symbol)
-  segmentsize = plot[:segmentsize]
-  showpoints = plot[:showpoints]
+  showpoints = plot.showpoints
 
   orig_sym = Symbol(geoms, :_orig)
   dirs_sym = Symbol(geoms, :_dirs)
@@ -188,7 +187,7 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
 end
 
 function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms::Symbol, colors::Symbol)
-  segmentsize = plot[:segmentsize]
+  segmentsize = plot.segmentsize
 
   inter_sym = Symbol(geoms, :_inter)
   vinds_sym = Symbol(geoms, :_vinds)
@@ -248,9 +247,9 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
 end
 
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, geoms::Symbol, colors::Symbol)
-  showsegments = plot[:showsegments]
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  showsegments = plot.showsegments
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   polys_sym = Symbol(geoms, :_polys)
 
@@ -281,9 +280,9 @@ function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, G::Type, geoms::Symbol)
 end
 
 function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, G::Type, geoms::Symbol)
-  pointmarker = plot[:pointmarker]
-  pointcolor = plot[:pointcolor]
-  pointsize = plot[:pointsize]
+  pointmarker = plot.pointmarker
+  pointcolor = plot.pointcolor
+  pointsize = plot.pointsize
 
   pset_sym = Symbol(geoms, :_pset)
 
@@ -297,8 +296,8 @@ function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, G::Type, geoms::Symbol)
 end
 
 function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, G::Type, geoms::Symbol)
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   bset_sym = Symbol(geoms, :_bset)
 

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -57,7 +57,7 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::S
     end
     vizmany!(plot, plot[meshes_sym], plot[colors])
     if plot.showpoints[]
-      vizfacets!(plot, G, geoms)
+      vizfacets!(plot, geoms)
     end
   elseif pdim === Val(2)
     Makie.map!(plot, [geoms], meshes_sym) do gvec
@@ -65,7 +65,7 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::S
     end
     vizmany!(plot, plot[meshes_sym], plot[colors])
     if plot.showsegments[]
-      vizfacets!(plot, G, geoms)
+      vizfacets!(plot, geoms)
     end
   elseif pdim === Val(3)
     Makie.map!(plot, [geoms], meshes_sym) do gvec
@@ -160,7 +160,7 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
   end
 
   if plot.showpoints[]
-    vizfacets!(plot, G, geoms)
+    vizfacets!(plot, geoms)
   end
 end
 
@@ -243,17 +243,15 @@ end
 # FACETS
 # -------
 
-vizfacets!(plot::Viz{<:Tuple{GeometrySet}}) = vizfacets!(plot)
-
-function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, G::Type, geoms::Symbol)
+function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, geoms::Symbol)
   gvec = plot[geoms][]
   M = manifold(first(gvec))
   pdim = paramdim(first(gvec))
   edim = embeddim(first(gvec))
-  vizgsetfacets!(plot, M, Val(pdim), Val(edim), G, geoms)
+  vizgsetfacets!(plot, M, Val(pdim), Val(edim), geoms)
 end
 
-function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, G::Type, geoms::Symbol)
+function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, geoms::Symbol)
   pset_sym = Symbol(geoms, :_pset)
 
   # all boundaries are points or multipoints
@@ -265,7 +263,7 @@ function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, G::Type, geoms::Symbol)
   viz!(plot, plot[pset_sym], color=plot.pointcolor, pointmarker=plot.pointmarker, pointsize=plot.pointsize)
 end
 
-function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, G::Type, geoms::Symbol)
+function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, geoms::Symbol)
   bset_sym = Symbol(geoms, :_bset)
 
   # all boundaries are 1D geometries

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -197,14 +197,11 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
   dcolor_sym = Symbol(colors, :_dcolor)
 
   # split vertical and non-vertical lines
-  Makie.map!(plot, [geoms], inter_sym) do gvec
-    [line ∩ Line((0, 0), (0, 1)) for line in gvec]
-  end
-  Makie.map!(plot, [inter_sym], vinds_sym) do inter
-    findall(g -> isnothing(g) || g isa Line, inter)
-  end
-  Makie.map!(plot, [geoms, vinds_sym], dinds_sym) do gvec, vinds
-    setdiff(1:length(gvec), vinds)
+  Makie.map!(plot, [geoms], [inter_sym, vinds_sym, dinds_sym]) do gvec
+    inter = [line ∩ Line((0, 0), (0, 1)) for line in gvec]
+    vinds = findall(g -> isnothing(g) || g isa Line, inter)
+    dinds = setdiff(1:length(gvec), vinds)
+    inter, vinds, dinds
   end
 
   # split colors accordingly

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -167,7 +167,7 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid:
   # split colors accordingly
   vcolorid = Symbol(cvecid, :_vcolor)
   dcolorid = Symbol(cvecid, :_dcolor)
-  Makie.map!(plot, [cvecid, vindsid, dindsid], vcolorid) do cvec, vinds, dinds
+  Makie.map!(plot, [cvecid, vindsid, dindsid], [vcolorid, dcolorid]) do cvec, vinds, dinds
     cvec[vinds], cvec[dinds]
   end
 
@@ -175,7 +175,7 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid:
   xcoordid = Symbol(gvecid, :_xcoord)
   ycoordid = Symbol(gvecid, :_ycoord)
   slopesid = Symbol(gvecid, :_slopes)
-  Makie.map!(plot, [interid, gvecid, vindsid, dindsid], [xcoordid, ycoordid, slopesid]) do inter, gvec, vinds, dinds
+  Makie.map!(plot, [gvecid, interid, vindsid, dindsid], [xcoordid, ycoordid, slopesid]) do gvec, inter, vinds, dinds
     # x coordinates of vertical lines
     xcoords = map(gvec[vinds]) do vline
       c = coords(vline(0))

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -53,7 +53,7 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, ::Type{<:Geometry}, gvecid::S
   # the resulting quadrangles into triangles
   triangulate = simplexify ∘ mayberefine ∘ discretize ∘ maybeboundary
 
-  # visualize geometries as single mesh of triangles
+  # visualize geometries as single mesh of simplices
   meshid = Symbol(gvecid, :_mesh)
   colorid = Symbol(cvecid, :_color)
   Makie.map!(plot, [gvecid, cvecid], [meshid, colorid]) do gvec, cvec
@@ -62,7 +62,8 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, ::Type{<:Geometry}, gvecid::S
     color = [cvec[i] for (i, m) in enumerate(meshes) for _ in 1:nelements(m)]
     mesh, color
   end
-  viz!(plot, plot[meshid], color=plot[colorid])
+  # forward segment size in case of 1D simplices
+  viz!(plot, plot[meshid], color=plot[colorid], segmentsize=plot.segmentsize)
 
   # visualize facets if requested
   pdim === Val(1) && plot.showpoints[] && vizfacets!(plot, gvecid)

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -69,34 +69,33 @@ end
 
 # collect and visualize parents of multi-geometries
 function vizgset!(plot, M::Type, pdim::Val, edim::Val, ::Type{<:Multi}, gvecid::Symbol, cvecid::Symbol)
-  parents_sym = Symbol(gvecid, :_parents)
-  pcolors_sym = Symbol(cvecid, :_pcolors)
+  parentsid = Symbol(gvecid, :_parents)
+  pcolorsid = Symbol(cvecid, :_pcolors)
 
   # repeat colors for parents
-  Makie.map!(plot, [cvecid, gvecid], [pcolors_sym, parents_sym]) do cvec, gvec
+  Makie.map!(plot, [gvecid, cvecid], [parentsid, pcolorsid]) do gvec, cvec
+    parents = mapreduce(parent, vcat, gvec)
     pcolors = [cvec[i] for (i, g) in enumerate(gvec) for _ in 1:length(parent(g))]
-    pgeoms = mapreduce(parent, vcat, gvec)
-    pcolors, pgeoms
+    parents, pcolors
   end
 
-  P = typeof(first(parent(first(plot[gvecid][]))))
-
   # call recipe for parents
-  vizgset!(plot, M, pdim, edim, P, parents_sym, pcolors_sym)
+  P = typeof(first(plot[parentsid][]))
+  vizgset!(plot, M, pdim, edim, P, parentsid, pcolorsid)
 end
 
-function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, gvecid::Symbol, cvecid::Symbol)
-  coords_sym = Symbol(gvecid, :_coords)
+function vizgset!(plot, ::Type, ::Val, ::Val, ::Type{<:Point}, gvecid::Symbol, cvecid::Symbol)
+  coordsid = Symbol(gvecid, :_coords)
 
   # get raw Cartesian coordinates of points
-  Makie.map!(plot, [gvecid], coords_sym) do gvec
+  Makie.map!(plot, gvecid, coordsid) do gvec
     map(p -> ustrip.(to(p)), gvec)
   end
 
   # visualize points with given marker and size
   Makie.scatter!(
     plot,
-    plot[coords_sym],
+    plot[coordsid],
     color=plot[cvecid],
     marker=plot.pointmarker,
     markersize=plot.pointsize,
@@ -104,48 +103,48 @@ function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, gvecid::Symbol, 
   )
 end
 
-function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, gvecid::Symbol, cvecid::Symbol)
-  orig_sym = Symbol(gvecid, :_orig)
-  dirs_sym = Symbol(gvecid, :_dirs)
+function vizgset!(plot, ::Type, ::Val, edim::Val, ::Type{<:Ray}, gvecid::Symbol, cvecid::Symbol)
+  origid = Symbol(gvecid, :_orig)
+  dirsid = Symbol(gvecid, :_dirs)
 
   # visualize as built-in arrows
-  Makie.map!(plot, [gvecid], [orig_sym, dirs_sym]) do gvec
-    oris = [asmakie(ray(0)) for ray in gvec]
+  Makie.map!(plot, gvecid, [origid, dirsid]) do gvec
+    orig = [asmakie(ray(0)) for ray in gvec]
     dirs = [asmakie(ray(1) - ray(0)) for ray in gvec]
-    oris, dirs
+    orig, dirs
   end
 
   if edim === Val(2)
-    tipwidth_sym = Symbol(gvecid, :_tipwidth)
-    shaftwidth_sym = Symbol(gvecid, :_shaftwidth)
-    Makie.map!(plot, [:segmentsize], [tipwidth_sym, shaftwidth_sym]) do sz
+    tipwidthid = Symbol(gvecid, :_tipwidth)
+    shaftwidthid = Symbol(gvecid, :_shaftwidth)
+    Makie.map!(plot, :segmentsize, [tipwidthid, shaftwidthid]) do sz
       tw = 5 * sz
       sw = 0.2 * tw
       tw, sw
     end
     Makie.arrows2d!(
       plot,
-      plot[orig_sym],
-      plot[dirs_sym],
+      plot[origid],
+      plot[dirsid],
       color=plot[cvecid],
-      tipwidth=plot[tipwidth_sym],
-      shaftwidth=plot[shaftwidth_sym]
+      tipwidth=plot[tipwidthid],
+      shaftwidth=plot[shaftwidthid]
     )
   elseif edim === Val(3)
-    tipradius_sym = Symbol(gvecid, :_tipradius)
-    shaftradius_sym = Symbol(gvecid, :_shaftradius)
-    Makie.map!(plot, [:segmentsize], [tipradius_sym, shaftradius_sym]) do sz
+    tipradiusid = Symbol(gvecid, :_tipradius)
+    shaftradiusid = Symbol(gvecid, :_shaftradius)
+    Makie.map!(plot, :segmentsize, [tipradiusid, shaftradiusid]) do sz
       tr = 0.05 * sz
       sr = 0.5 * tr
       tr, sr
     end
     Makie.arrows3d!(
       plot,
-      plot[orig_sym],
-      plot[dirs_sym],
+      plot[origid],
+      plot[dirsid],
       color=plot[cvecid],
-      tipradius=plot[tipradius_sym],
-      shaftradius=plot[shaftradius_sym]
+      tipradius=plot[tipradiusid],
+      shaftradius=plot[shaftradiusid]
     )
   else
     error("not implemented")

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -26,8 +26,7 @@ function vizgset!(plot)
       cvec = colorant isa AbstractVector ? colorant[inds] : fill(colorant, length(inds))
       gvec, cvec
     end
-
-    gvec = collect(G, geoms[findall(x -> x isa G, geoms)])
+    gvec = plot[gvec_sym][]
     M = manifold(first(gvec))
     pdim = paramdim(first(gvec))
     edim = embeddim(first(gvec))

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -174,41 +174,45 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid:
     cvec[vinds], cvec[dinds]
   end
 
-  # compute coordinates and slopes of lines
-  xcoordid = Symbol(gvecid, :_xcoord)
-  ycoordid = Symbol(gvecid, :_ycoord)
-  slopesid = Symbol(gvecid, :_slopes)
-  Makie.map!(plot, [gvecid, interid, vindsid, dindsid], [xcoordid, ycoordid, slopesid]) do gvec, inter, vinds, dinds
-    # x coordinates of vertical lines
-    xcoords = map(gvec[vinds]) do vline
-      c = coords(vline(0))
-      x = convert(Cartesian, c).x
-      ustrip(x)
-    end
-
-    # y coordinates of non-vertical lines
-    ycoords = map(inter[dinds]) do I
-      y = if I isa Line # horizontal line through origin
-        zero(Meshes.lentype(I))
-      else # intersection point with vertical axis
-        convert(Cartesian, coords(I)).y
+  # visualize vertical lines
+  if !isempty(plot[vindsid][])
+    xcoordid = Symbol(gvecid, :_xcoord)
+    Makie.map!(plot, [gvecid, vindsid], xcoordid) do gvec, vinds
+      # x coordinates of vertical lines
+      map(gvec[vinds]) do vline
+        c = coords(vline(0))
+        x = convert(Cartesian, c).x
+        ustrip(x)
       end
-      ustrip(y)
     end
-
-    # slopes of non-vertical lines
-    slopes = map(gvec[dinds]) do dline
-      c1 = convert(Cartesian, coords(dline(0)))
-      c2 = convert(Cartesian, coords(dline(1)))
-      (c2.y - c1.y) / (c2.x - c1.x)
-    end
-
-    xcoords, ycoords, slopes
+    Makie.vlines!(plot, plot[xcoordid], color=plot[vcolorid], linewidth=plot.segmentsize)
   end
 
-  # visualize vertical and non-vertical lines
-  Makie.vlines!(plot, plot[xcoordid], color=plot[vcolorid], linewidth=plot.segmentsize)
-  Makie.ablines!(plot, plot[ycoordid], plot[slopesid], color=plot[dcolorid], linewidth=plot.segmentsize)
+  # visualize non-vertical lines
+  if !isempty(plot[dindsid][])
+    ycoordid = Symbol(gvecid, :_ycoord)
+    Makie.map!(plot, [interid, dindsid], ycoordid) do inter, dinds
+      # y coordinates of non-vertical lines
+      map(inter[dinds]) do I
+        y = if I isa Line # horizontal line through origin
+          zero(Meshes.lentype(I))
+        else # intersection point with vertical axis
+          convert(Cartesian, coords(I)).y
+        end
+        ustrip(y)
+      end
+    end
+    slopesid = Symbol(gvecid, :_slopes)
+    Makie.map!(plot, [gvecid, dindsid], slopesid) do gvec, dinds
+      # slopes of non-vertical lines
+      map(gvec[dinds]) do dline
+        c1 = convert(Cartesian, coords(dline(0)))
+        c2 = convert(Cartesian, coords(dline(1)))
+        (c2.y - c1.y) / (c2.x - c1.x)
+      end
+    end
+    Makie.ablines!(plot, plot[ycoordid], plot[slopesid], color=plot[dcolorid], linewidth=plot.segmentsize)
+  end
 end
 
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, ::Type{<:Polygon}, gvecid::Symbol, cvecid::Symbol)

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -153,7 +153,14 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
     Makie.map!(plot, [tipwidth_sym], shaftwidth_sym) do tw
       0.2 * tw
     end
-    Makie.arrows2d!(plot, plot[orig_sym], plot[dirs_sym], color=plot[colors], tipwidth=plot[tipwidth_sym], shaftwidth=plot[shaftwidth_sym])
+    Makie.arrows2d!(
+      plot,
+      plot[orig_sym],
+      plot[dirs_sym],
+      color=plot[colors],
+      tipwidth=plot[tipwidth_sym],
+      shaftwidth=plot[shaftwidth_sym]
+    )
   elseif edim === Val(3)
     tipradius_sym = Symbol(geoms, :_tipradius)
     shaftradius_sym = Symbol(geoms, :_shaftradius)
@@ -163,7 +170,14 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
     Makie.map!(plot, [tipradius_sym], shaftradius_sym) do tr
       0.5 * tr
     end
-    Makie.arrows3d!(plot, plot[orig_sym], plot[dirs_sym], color=plot[colors], tipradius=plot[tipradius_sym], shaftradius=plot[shaftradius_sym])
+    Makie.arrows3d!(
+      plot,
+      plot[orig_sym],
+      plot[dirs_sym],
+      color=plot[colors],
+      tipradius=plot[tipradius_sym],
+      shaftradius=plot[shaftradius_sym]
+    )
   else
     error("not implemented")
   end

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -69,25 +69,23 @@ end
 
 # collect and visualize parents of multi-geometries
 function vizgset!(plot, M::Type, pdim::Val, edim::Val, ::Type{<:Multi}, gvecid::Symbol, cvecid::Symbol)
+  # repeat colors for parents
   parentsid = Symbol(gvecid, :_parents)
   pcolorsid = Symbol(cvecid, :_pcolors)
-
-  # repeat colors for parents
   Makie.map!(plot, [gvecid, cvecid], [parentsid, pcolorsid]) do gvec, cvec
     parents = mapreduce(parent, vcat, gvec)
     pcolors = [cvec[i] for (i, g) in enumerate(gvec) for _ in 1:length(parent(g))]
     parents, pcolors
   end
 
-  # call recipe for parents
+  # visualize as set of parents
   P = typeof(first(plot[parentsid][]))
   vizgset!(plot, M, pdim, edim, P, parentsid, pcolorsid)
 end
 
 function vizgset!(plot, ::Type, ::Val, ::Val, ::Type{<:Point}, gvecid::Symbol, cvecid::Symbol)
-  coordsid = Symbol(gvecid, :_coords)
-
   # get raw Cartesian coordinates of points
+  coordsid = Symbol(gvecid, :_coords)
   Makie.map!(plot, gvecid, coordsid) do gvec
     map(p -> ustrip.(to(p)), gvec)
   end

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -27,9 +27,10 @@ function vizgset!(plot)
     end
 
     # dispatch specialized recipe for this type of geometry
-    M = manifold(G)
-    pdim = paramdim(G)
-    edim = embeddim(G)
+    g = first(plot[gvecid][])
+    M = manifold(g)
+    pdim = paramdim(g)
+    edim = embeddim(g)
     vizgset!(plot, M, Val(pdim), Val(edim), G, gvecid, cvecid)
   end
 end
@@ -39,7 +40,10 @@ end
 # ---------------
 
 # fallback to visualization of discretized geometries
-function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::Symbol, colors::Symbol)
+function vizgset!(plot, M::Type, pdim::Val, ::Val, ::Type{<:Geometry}, gvecid::Symbol, cvecid::Symbol)
+  # visualize 3D geometries as boundary meshes
+  maybeboundary = pdim === Val(3) ? boundary : identity
+
   # refine meshes over the 🌐 manifold until
   # they satisfy the maximum length criterion
   mayberefine = M === 🌐 ? refinemaxlen : identity
@@ -47,57 +51,45 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::S
   # make sure that the geometries are refined with
   # efficient "grid-like" methods before splitting
   # the resulting quadrangles into triangles
-  triangulate = simplexify ∘ mayberefine ∘ discretize
+  triangulate = simplexify ∘ mayberefine ∘ discretize ∘ maybeboundary
 
-  meshes_sym = Symbol(geoms, :_meshes)
-
-  if pdim === Val(1)
-    Makie.map!(plot, [geoms], meshes_sym) do gvec
-      map(triangulate, gvec)
-    end
-    vizmany!(plot, plot[meshes_sym], plot[colors])
-    if plot.showpoints[]
-      vizfacets!(plot, geoms)
-    end
-  elseif pdim === Val(2)
-    Makie.map!(plot, [geoms], meshes_sym) do gvec
-      map(triangulate, gvec)
-    end
-    vizmany!(plot, plot[meshes_sym], plot[colors])
-    if plot.showsegments[]
-      vizfacets!(plot, geoms)
-    end
-  elseif pdim === Val(3)
-    Makie.map!(plot, [geoms], meshes_sym) do gvec
-      map(triangulate ∘ boundary, gvec)
-    end
-    vizmany!(plot, plot[meshes_sym], plot[colors])
+  # add node to compute graph for triangle meshes
+  meshesid = Symbol(gvecid, :_meshes)
+  Makie.map!(plot, gvecid, meshesid) do gvec
+    map(triangulate, gvec)
   end
+
+  # visualize geometries
+  vizmany!(plot, plot[meshesid], plot[cvecid])
+
+  # visualize facets if requested
+  pdim === Val(1) && plot.showpoints[] && vizfacets!(plot, gvecid)
+  pdim === Val(2) && plot.showsegments[] && vizfacets!(plot, gvecid)
 end
 
 # collect and visualize parents of multi-geometries
-function vizgset!(plot, M::Type, pdim::Val, edim::Val, G::Type{<:Multi}, geoms::Symbol, colors::Symbol)
-  parents_sym = Symbol(geoms, :_parents)
-  pcolors_sym = Symbol(colors, :_pcolors)
+function vizgset!(plot, M::Type, pdim::Val, edim::Val, ::Type{<:Multi}, gvecid::Symbol, cvecid::Symbol)
+  parents_sym = Symbol(gvecid, :_parents)
+  pcolors_sym = Symbol(cvecid, :_pcolors)
 
   # repeat colors for parents
-  Makie.map!(plot, [colors, geoms], [pcolors_sym, parents_sym]) do cvec, gvec
+  Makie.map!(plot, [cvecid, gvecid], [pcolors_sym, parents_sym]) do cvec, gvec
     pcolors = [cvec[i] for (i, g) in enumerate(gvec) for _ in 1:length(parent(g))]
     pgeoms = mapreduce(parent, vcat, gvec)
     pcolors, pgeoms
   end
 
-  P = typeof(first(parent(first(plot[geoms][]))))
+  P = typeof(first(parent(first(plot[gvecid][]))))
 
   # call recipe for parents
   vizgset!(plot, M, pdim, edim, P, parents_sym, pcolors_sym)
 end
 
-function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, geoms::Symbol, colors::Symbol)
-  coords_sym = Symbol(geoms, :_coords)
+function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, gvecid::Symbol, cvecid::Symbol)
+  coords_sym = Symbol(gvecid, :_coords)
 
   # get raw Cartesian coordinates of points
-  Makie.map!(plot, [geoms], coords_sym) do gvec
+  Makie.map!(plot, [gvecid], coords_sym) do gvec
     map(p -> ustrip.(to(p)), gvec)
   end
 
@@ -105,27 +97,27 @@ function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, geoms::Symbol, c
   Makie.scatter!(
     plot,
     plot[coords_sym],
-    color=plot[colors],
+    color=plot[cvecid],
     marker=plot.pointmarker,
     markersize=plot.pointsize,
     overdraw=true
   )
 end
 
-function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol, colors::Symbol)
-  orig_sym = Symbol(geoms, :_orig)
-  dirs_sym = Symbol(geoms, :_dirs)
+function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, gvecid::Symbol, cvecid::Symbol)
+  orig_sym = Symbol(gvecid, :_orig)
+  dirs_sym = Symbol(gvecid, :_dirs)
 
   # visualize as built-in arrows
-  Makie.map!(plot, [geoms], [orig_sym, dirs_sym]) do gvec
+  Makie.map!(plot, [gvecid], [orig_sym, dirs_sym]) do gvec
     oris = [asmakie(ray(0)) for ray in gvec]
     dirs = [asmakie(ray(1) - ray(0)) for ray in gvec]
     oris, dirs
   end
 
   if edim === Val(2)
-    tipwidth_sym = Symbol(geoms, :_tipwidth)
-    shaftwidth_sym = Symbol(geoms, :_shaftwidth)
+    tipwidth_sym = Symbol(gvecid, :_tipwidth)
+    shaftwidth_sym = Symbol(gvecid, :_shaftwidth)
     Makie.map!(plot, [:segmentsize], [tipwidth_sym, shaftwidth_sym]) do sz
       tw = 5 * sz
       sw = 0.2 * tw
@@ -135,13 +127,13 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
       plot,
       plot[orig_sym],
       plot[dirs_sym],
-      color=plot[colors],
+      color=plot[cvecid],
       tipwidth=plot[tipwidth_sym],
       shaftwidth=plot[shaftwidth_sym]
     )
   elseif edim === Val(3)
-    tipradius_sym = Symbol(geoms, :_tipradius)
-    shaftradius_sym = Symbol(geoms, :_shaftradius)
+    tipradius_sym = Symbol(gvecid, :_tipradius)
+    shaftradius_sym = Symbol(gvecid, :_shaftradius)
     Makie.map!(plot, [:segmentsize], [tipradius_sym, shaftradius_sym]) do sz
       tr = 0.05 * sz
       sr = 0.5 * tr
@@ -151,7 +143,7 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
       plot,
       plot[orig_sym],
       plot[dirs_sym],
-      color=plot[colors],
+      color=plot[cvecid],
       tipradius=plot[tipradius_sym],
       shaftradius=plot[shaftradius_sym]
     )
@@ -160,21 +152,21 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
   end
 
   if plot.showpoints[]
-    vizfacets!(plot, geoms)
+    vizfacets!(plot, gvecid)
   end
 end
 
-function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms::Symbol, colors::Symbol)
+function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, gvecid::Symbol, cvecid::Symbol)
   segmentsize = plot.segmentsize
 
-  inter_sym = Symbol(geoms, :_inter)
-  vinds_sym = Symbol(geoms, :_vinds)
-  dinds_sym = Symbol(geoms, :_dinds)
-  vcolor_sym = Symbol(colors, :_vcolor)
-  dcolor_sym = Symbol(colors, :_dcolor)
+  inter_sym = Symbol(gvecid, :_inter)
+  vinds_sym = Symbol(gvecid, :_vinds)
+  dinds_sym = Symbol(gvecid, :_dinds)
+  vcolor_sym = Symbol(cvecid, :_vcolor)
+  dcolor_sym = Symbol(cvecid, :_dcolor)
 
   # split vertical and non-vertical lines
-  Makie.map!(plot, [geoms], [inter_sym, vinds_sym, dinds_sym]) do gvec
+  Makie.map!(plot, [gvecid], [inter_sym, vinds_sym, dinds_sym]) do gvec
     inter = [line ∩ Line((0, 0), (0, 1)) for line in gvec]
     vinds = findall(g -> isnothing(g) || g isa Line, inter)
     dinds = setdiff(1:length(gvec), vinds)
@@ -182,15 +174,15 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
   end
 
   # split colors accordingly
-  Makie.map!(plot, [colors, vinds_sym], vcolor_sym) do cvec, vinds
+  Makie.map!(plot, [cvecid, vinds_sym], vcolor_sym) do cvec, vinds
     cvec[vinds]
   end
-  Makie.map!(plot, [colors, dinds_sym], dcolor_sym) do cvec, dinds
+  Makie.map!(plot, [cvecid, dinds_sym], dcolor_sym) do cvec, dinds
     cvec[dinds]
   end
 
-  xcoord_sym = Symbol(geoms, :_xcoord)
-  Makie.map!(plot, [geoms, vinds_sym], xcoord_sym) do gvec, vinds
+  xcoord_sym = Symbol(gvecid, :_xcoord)
+  Makie.map!(plot, [gvecid, vinds_sym], xcoord_sym) do gvec, vinds
     vlines = gvec[vinds]
     map(vlines) do vline
       c = coords(vline(0))
@@ -200,8 +192,8 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
   end
   Makie.vlines!(plot, plot[xcoord_sym], color=plot[vcolor_sym], linewidth=segmentsize)
 
-  ycoord_sym = Symbol(geoms, :_ycoord)
-  slopes_sym = Symbol(geoms, :_slopes)
+  ycoord_sym = Symbol(gvecid, :_ycoord)
+  slopes_sym = Symbol(gvecid, :_slopes)
   Makie.map!(plot, [inter_sym, dinds_sym], ycoord_sym) do inter, dinds
     dinter = inter[dinds]
     map(dinter) do I
@@ -213,7 +205,7 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
       ustrip(y)
     end
   end
-  Makie.map!(plot, [geoms, dinds_sym], slopes_sym) do gvec, dinds
+  Makie.map!(plot, [gvecid, dinds_sym], slopes_sym) do gvec, dinds
     dlines = gvec[dinds]
     map(dlines) do dline
       c1 = convert(Cartesian, coords(dline(0)))
@@ -224,18 +216,18 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
   Makie.ablines!(plot, plot[ycoord_sym], plot[slopes_sym], color=plot[dcolor_sym], linewidth=segmentsize)
 end
 
-function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, geoms::Symbol, colors::Symbol)
-  polys_sym = Symbol(geoms, :_polys)
+function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, gvecid::Symbol, cvecid::Symbol)
+  polys_sym = Symbol(gvecid, :_polys)
 
   # visualize as built-in polygons
-  Makie.map!(plot, [geoms], polys_sym) do gvec
+  Makie.map!(plot, [gvecid], polys_sym) do gvec
     map(asmakie, gvec)
   end
 
   if plot.showsegments[]
-    Makie.poly!(plot, plot[polys_sym], color=plot[colors], strokecolor=plot.segmentcolor, strokewidth=plot.segmentsize)
+    Makie.poly!(plot, plot[polys_sym], color=plot[cvecid], strokecolor=plot.segmentcolor, strokewidth=plot.segmentsize)
   else
-    Makie.poly!(plot, plot[polys_sym], color=plot[colors])
+    Makie.poly!(plot, plot[polys_sym], color=plot[cvecid])
   end
 end
 
@@ -243,19 +235,19 @@ end
 # FACETS
 # -------
 
-function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, geoms::Symbol)
-  gvec = plot[geoms][]
+function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, gvecid::Symbol)
+  gvec = plot[gvecid][]
   M = manifold(first(gvec))
   pdim = paramdim(first(gvec))
   edim = embeddim(first(gvec))
-  vizgsetfacets!(plot, M, Val(pdim), Val(edim), geoms)
+  vizgsetfacets!(plot, M, Val(pdim), Val(edim), gvecid)
 end
 
-function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, geoms::Symbol)
-  pset_sym = Symbol(geoms, :_pset)
+function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, gvecid::Symbol)
+  pset_sym = Symbol(gvecid, :_pset)
 
   # all boundaries are points or multipoints
-  Makie.map!(plot, [geoms], pset_sym) do gvec
+  Makie.map!(plot, [gvecid], pset_sym) do gvec
     points = filter(!isnothing, map(boundary, gvec))
     GeometrySet(points)
   end
@@ -263,11 +255,11 @@ function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, geoms::Symbol)
   viz!(plot, plot[pset_sym], color=plot.pointcolor, pointmarker=plot.pointmarker, pointsize=plot.pointsize)
 end
 
-function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, geoms::Symbol)
-  bset_sym = Symbol(geoms, :_bset)
+function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, gvecid::Symbol)
+  bset_sym = Symbol(gvecid, :_bset)
 
   # all boundaries are 1D geometries
-  Makie.map!(plot, [geoms], bset_sym) do gvec
+  Makie.map!(plot, [gvecid], bset_sym) do gvec
     bounds = filter(!isnothing, map(boundary, gvec))
     GeometrySet(bounds)
   end

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -104,10 +104,9 @@ function vizgset!(plot, ::Type, ::Val, ::Val, ::Type{<:Point}, gvecid::Symbol, c
 end
 
 function vizgset!(plot, ::Type, ::Val, edim::Val, ::Type{<:Ray}, gvecid::Symbol, cvecid::Symbol)
+  # visualize as built-in arrows
   origid = Symbol(gvecid, :_orig)
   dirsid = Symbol(gvecid, :_dirs)
-
-  # visualize as built-in arrows
   Makie.map!(plot, gvecid, [origid, dirsid]) do gvec
     orig = [asmakie(ray(0)) for ray in gvec]
     dirs = [asmakie(ray(1) - ray(0)) for ray in gvec]
@@ -156,10 +155,10 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, ::Type{<:Ray}, gvecid::Symbol,
 end
 
 function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid::Symbol, cvecid::Symbol)
+  # split vertical and non-vertical lines
   interid = Symbol(gvecid, :_inter)
   vindsid = Symbol(gvecid, :_vinds)
   dindsid = Symbol(gvecid, :_dinds)
-  # split vertical and non-vertical lines
   Makie.map!(plot, gvecid, [interid, vindsid, dindsid]) do gvec
     inter = [line ∩ Line((0, 0), (0, 1)) for line in gvec]
     vinds = findall(g -> isnothing(g) || g isa Line, inter)
@@ -174,6 +173,7 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid:
     cvec[vinds], cvec[dinds]
   end
 
+  # compute coordinates and slopes of lines
   xcoordid = Symbol(gvecid, :_xcoord)
   ycoordid = Symbol(gvecid, :_ycoord)
   slopesid = Symbol(gvecid, :_slopes)
@@ -211,13 +211,11 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid:
 end
 
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, ::Type{<:Polygon}, gvecid::Symbol, cvecid::Symbol)
-  polysid = Symbol(gvecid, :_polys)
-
   # visualize as built-in polygons
+  polysid = Symbol(gvecid, :_polys)
   Makie.map!(plot, gvecid, polysid) do gvec
     map(asmakie, gvec)
   end
-
   if plot.showsegments[]
     Makie.poly!(plot, plot[polysid], color=plot[cvecid], strokecolor=plot.segmentcolor, strokewidth=plot.segmentsize)
   else
@@ -230,33 +228,29 @@ end
 # -------
 
 function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, gvecid::Symbol)
-  gvec = plot[gvecid][]
-  M = manifold(first(gvec))
-  pdim = paramdim(first(gvec))
-  edim = embeddim(first(gvec))
+  g = first(plot[gvecid][])
+  M = manifold(g)
+  pdim = paramdim(g)
+  edim = embeddim(g)
   vizgsetfacets!(plot, M, Val(pdim), Val(edim), gvecid)
 end
 
 function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, gvecid::Symbol)
-  pset_sym = Symbol(gvecid, :_pset)
-
   # all boundaries are points or multipoints
-  Makie.map!(plot, [gvecid], pset_sym) do gvec
+  psetid = Symbol(gvecid, :_pset)
+  Makie.map!(plot, [gvecid], psetid) do gvec
     points = filter(!isnothing, map(boundary, gvec))
     GeometrySet(points)
   end
-
-  viz!(plot, plot[pset_sym], color=plot.pointcolor, pointmarker=plot.pointmarker, pointsize=plot.pointsize)
+  viz!(plot, plot[psetid], color=plot.pointcolor, pointmarker=plot.pointmarker, pointsize=plot.pointsize)
 end
 
 function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, gvecid::Symbol)
-  bset_sym = Symbol(gvecid, :_bset)
-
   # all boundaries are 1D geometries
-  Makie.map!(plot, [gvecid], bset_sym) do gvec
+  bsetid = Symbol(gvecid, :_bset)
+  Makie.map!(plot, [gvecid], bsetid) do gvec
     bounds = filter(!isnothing, map(boundary, gvec))
     GeometrySet(bounds)
   end
-
-  viz!(plot, plot[bset_sym], color=plot.segmentcolor, segmentsize=plot.segmentsize)
+  viz!(plot, plot[bsetid], color=plot.segmentcolor, segmentsize=plot.segmentsize)
 end

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -53,14 +53,16 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, ::Type{<:Geometry}, gvecid::S
   # the resulting quadrangles into triangles
   triangulate = simplexify ∘ mayberefine ∘ discretize ∘ maybeboundary
 
-  # add node to compute graph for triangle meshes
-  meshesid = Symbol(gvecid, :_meshes)
-  Makie.map!(plot, gvecid, meshesid) do gvec
-    map(triangulate, gvec)
+  # visualize geometries as single mesh of triangles
+  meshid = Symbol(gvecid, :_mesh)
+  colorid = Symbol(cvecid, :_color)
+  Makie.map!(plot, [gvecid, cvecid], [meshid, colorid]) do gvec, cvec
+    meshes = map(triangulate, gvec)
+    mesh = reduce(merge, meshes)
+    color = [cvec[i] for (i, m) in enumerate(meshes) for _ in 1:nelements(m)]
+    mesh, color
   end
-
-  # visualize geometries
-  vizmany!(plot, plot[meshesid], plot[cvecid])
+  viz!(plot, plot[meshid], color=plot[colorid])
 
   # visualize facets if requested
   pdim === Val(1) && plot.showpoints[] && vizfacets!(plot, gvecid)

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -210,18 +210,18 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid:
   Makie.ablines!(plot, plot[ycoordid], plot[slopesid], color=plot[dcolorid], linewidth=plot.segmentsize)
 end
 
-function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, gvecid::Symbol, cvecid::Symbol)
-  polys_sym = Symbol(gvecid, :_polys)
+function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, ::Type{<:Polygon}, gvecid::Symbol, cvecid::Symbol)
+  polysid = Symbol(gvecid, :_polys)
 
   # visualize as built-in polygons
-  Makie.map!(plot, [gvecid], polys_sym) do gvec
+  Makie.map!(plot, gvecid, polysid) do gvec
     map(asmakie, gvec)
   end
 
   if plot.showsegments[]
-    Makie.poly!(plot, plot[polys_sym], color=plot[cvecid], strokecolor=plot.segmentcolor, strokewidth=plot.segmentsize)
+    Makie.poly!(plot, plot[polysid], color=plot[cvecid], strokecolor=plot.segmentcolor, strokewidth=plot.segmentsize)
   else
-    Makie.poly!(plot, plot[polys_sym], color=plot[cvecid])
+    Makie.poly!(plot, plot[polysid], color=plot[cvecid])
   end
 end
 

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -2,43 +2,49 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-const ObservableVector{T} = Makie.Observable{<:AbstractVector{T}}
-
 Makie.plot!(plot::Viz{<:Tuple{GeometrySet}}) = vizgset!(plot)
 
 # split heterogeneous geometry sets into homogeneous vectors
 # of geometries and send these vectors to specialized recipes
 function vizgset!(plot; facets=false)
-  gset = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
+  gset = plot[:object][]
 
   # process color spec into colorant
-  colorant = facets ? nothing : Makie.@lift(process($color, $colormap, $colorrange, $alpha))
+  if !facets
+    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  end
 
   # get geometries
-  geoms = Makie.@lift parent($gset)
+  geoms = parent(gset)
 
   # get geometry types
-  types = Makie.@lift unique(map(typeof, $geoms))
+  types = unique(map(typeof, geoms))
 
-  for G in types[]
-    inds = Makie.@lift findall(g -> g isa G, $geoms)
-    gvec = Makie.@lift collect(G, $geoms[$inds])
-    M = Makie.@lift manifold(first($gvec))
-    pdim = Makie.@lift paramdim(first($gvec))
-    edim = Makie.@lift embeddim(first($gvec))
+  for (i, G) in enumerate(types)
+    inds_sym = Symbol(:inds_, i)
+    gvec_sym = Symbol(:gvec_, i)
+
+    Makie.map!(plot, [:object], inds_sym) do g
+      findall(x -> x isa G, parent(g))
+    end
+
+    Makie.map!(plot, [:object, inds_sym], gvec_sym) do g, inds
+      collect(G, parent(g)[inds])
+    end
+
+    gvec = collect(G, geoms[findall(x -> x isa G, geoms)])
+    M = manifold(first(gvec))
+    pdim = paramdim(first(gvec))
+    edim = embeddim(first(gvec))
+
     if facets
-      vizgsetfacets!(plot, M[], Val(pdim[]), Val(edim[]), gvec)
+      vizgsetfacets!(plot, M, Val(pdim), Val(edim), G, gvec_sym)
     else
-      cvec = Makie.@lift if $colorant isa AbstractVector
-        $colorant[$inds]
-      else
-        fill($colorant, length($inds))
+      cvec_sym = Symbol(:cvec_, i)
+      Makie.map!(plot, [:colorant, inds_sym], cvec_sym) do colorant, inds
+        colorant isa AbstractVector ? colorant[inds] : fill(colorant, length(inds))
       end
-      vizgset!(plot, M[], Val(pdim[]), Val(edim[]), gvec, cvec)
+      vizgset!(plot, M, Val(pdim), Val(edim), G, gvec_sym, cvec_sym)
     end
   end
 end
@@ -48,7 +54,7 @@ end
 # ---------------
 
 # fallback to visualization of discretized geometries
-function vizgset!(plot, M::Type, pdim::Val, ::Val, geoms::ObservableVector{<:Geometry}, colors)
+function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::Symbol, colors::Symbol)
   showsegments = plot[:showsegments]
   showpoints = plot[:showpoints]
 
@@ -61,99 +67,156 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, geoms::ObservableVector{<:Geo
   # the resulting quadrangles into triangles
   triangulate = simplexify ∘ mayberefine ∘ discretize
 
+  meshes_sym = Symbol(geoms, :_meshes)
+
   if pdim === Val(1)
-    meshes = Makie.@lift map(triangulate, $geoms)
-    vizmany!(plot, meshes, colors)
+    Makie.map!(plot, [geoms], meshes_sym) do gvec
+      map(triangulate, gvec)
+    end
+    vizmany!(plot, plot[meshes_sym], plot[colors])
     if showpoints[]
-      vizfacets!(plot, geoms)
+      vizfacets!(plot, G, geoms)
     end
   elseif pdim === Val(2)
-    meshes = Makie.@lift map(triangulate, $geoms)
-    vizmany!(plot, meshes, colors)
+    Makie.map!(plot, [geoms], meshes_sym) do gvec
+      map(triangulate, gvec)
+    end
+    vizmany!(plot, plot[meshes_sym], plot[colors])
     if showsegments[]
-      vizfacets!(plot, geoms)
+      vizfacets!(plot, G, geoms)
     end
   elseif pdim === Val(3)
-    meshes = Makie.@lift map(triangulate ∘ boundary, $geoms)
-    vizmany!(plot, meshes, colors)
+    Makie.map!(plot, [geoms], meshes_sym) do gvec
+      map(triangulate ∘ boundary, gvec)
+    end
+    vizmany!(plot, plot[meshes_sym], plot[colors])
   end
 end
 
 # collect and visualize parents of multi-geometries
-function vizgset!(plot, M::Type, pdim::Val, edim::Val, geoms::ObservableVector{<:Multi}, colors)
+function vizgset!(plot, M::Type, pdim::Val, edim::Val, G::Type{<:Multi}, geoms::Symbol, colors::Symbol)
+  parents_sym = Symbol(geoms, :_parents)
+  pcolors_sym = Symbol(colors, :_pcolors)
+
   # retrieve parent geometries
-  parents = Makie.@lift mapreduce(parent, vcat, $geoms)
+  Makie.map!(plot, [geoms], parents_sym) do gvec
+    mapreduce(parent, vcat, gvec)
+  end
 
   # repeat colors for parents
-  pcolors = Makie.@lift [$colors[i] for (i, g) in enumerate($geoms) for _ in 1:length(parent(g))]
+  Makie.map!(plot, [colors, geoms], pcolors_sym) do cvec, gvec
+    [cvec[i] for (i, g) in enumerate(gvec) for _ in 1:length(parent(g))]
+  end
+
+  P = typeof(first(parent(first(plot[geoms][]))))
 
   # call recipe for parents
-  vizgset!(plot, M, pdim, edim, parents, pcolors)
+  vizgset!(plot, M, pdim, edim, P, parents_sym, pcolors_sym)
 end
 
-function vizgset!(plot, ::Type, ::Val, ::Val, geoms::ObservableVector{<:Point}, colors)
+function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, geoms::Symbol, colors::Symbol)
   pointmarker = plot[:pointmarker]
   pointsize = plot[:pointsize]
 
+  coords_sym = Symbol(geoms, :_coords)
+
   # get raw Cartesian coordinates of points
-  coords = Makie.@lift map(p -> ustrip.(to(p)), $geoms)
+  Makie.map!(plot, [geoms], coords_sym) do gvec
+    map(p -> ustrip.(to(p)), gvec)
+  end
 
   # visualize points with given marker and size
-  Makie.scatter!(plot, coords, color=colors, marker=pointmarker, markersize=pointsize, overdraw=true)
+  Makie.scatter!(plot, plot[coords_sym], color=plot[colors], marker=pointmarker, markersize=pointsize, overdraw=true)
 end
 
-function vizgset!(plot, ::Type, ::Val, edim::Val, geoms::ObservableVector{<:Ray}, colors)
+function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol, colors::Symbol)
   segmentsize = plot[:segmentsize]
   showpoints = plot[:showpoints]
 
+  orig_sym = Symbol(geoms, :_orig)
+  dirs_sym = Symbol(geoms, :_dirs)
+
   # visualize as built-in arrows
-  orig = Makie.@lift [asmakie(ray(0)) for ray in $geoms]
-  dirs = Makie.@lift [asmakie(ray(1) - ray(0)) for ray in $geoms]
+  Makie.map!(plot, [geoms], orig_sym) do gvec
+    [asmakie(ray(0)) for ray in gvec]
+  end
+  Makie.map!(plot, [geoms], dirs_sym) do gvec
+    [asmakie(ray(1) - ray(0)) for ray in gvec]
+  end
+
   if edim === Val(2)
-    tipwidth = Makie.@lift 5 * $segmentsize
-    shaftwidth = Makie.@lift 0.2 * $tipwidth
-    Makie.arrows2d!(plot, orig, dirs, color=colors, tipwidth=tipwidth, shaftwidth=shaftwidth)
+    tipwidth_sym = Symbol(geoms, :_tipwidth)
+    shaftwidth_sym = Symbol(geoms, :_shaftwidth)
+    Makie.map!(plot, [:segmentsize], tipwidth_sym) do sz
+      5 * sz
+    end
+    Makie.map!(plot, [tipwidth_sym], shaftwidth_sym) do tw
+      0.2 * tw
+    end
+    Makie.arrows2d!(plot, plot[orig_sym], plot[dirs_sym], color=plot[colors], tipwidth=plot[tipwidth_sym], shaftwidth=plot[shaftwidth_sym])
   elseif edim === Val(3)
-    tipradius = Makie.@lift 0.05 * $segmentsize
-    shaftradius = Makie.@lift 0.5 * $tipradius
-    Makie.arrows3d!(plot, orig, dirs, color=colors, tipradius=tipradius, shaftradius=shaftradius)
+    tipradius_sym = Symbol(geoms, :_tipradius)
+    shaftradius_sym = Symbol(geoms, :_shaftradius)
+    Makie.map!(plot, [:segmentsize], tipradius_sym) do sz
+      0.05 * sz
+    end
+    Makie.map!(plot, [tipradius_sym], shaftradius_sym) do tr
+      0.5 * tr
+    end
+    Makie.arrows3d!(plot, plot[orig_sym], plot[dirs_sym], color=plot[colors], tipradius=plot[tipradius_sym], shaftradius=plot[shaftradius_sym])
   else
     error("not implemented")
   end
 
   if showpoints[]
-    vizfacets!(plot, geoms)
+    vizfacets!(plot, G, geoms)
   end
 end
 
-function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, geoms::ObservableVector{<:Line}, colors)
+function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms::Symbol, colors::Symbol)
   segmentsize = plot[:segmentsize]
 
+  inter_sym = Symbol(geoms, :_inter)
+  vinds_sym = Symbol(geoms, :_vinds)
+  dinds_sym = Symbol(geoms, :_dinds)
+  vcolor_sym = Symbol(colors, :_vcolor)
+  dcolor_sym = Symbol(colors, :_dcolor)
+
   # split vertical and non-vertical lines
-  inter = Makie.@lift [line ∩ Line((0, 0), (0, 1)) for line in $geoms]
-  vinds = Makie.@lift findall(g -> isnothing(g) || g isa Line, $inter)
-  dinds = Makie.@lift setdiff(1:length($geoms), $vinds)
+  Makie.map!(plot, [geoms], inter_sym) do gvec
+    [line ∩ Line((0, 0), (0, 1)) for line in gvec]
+  end
+  Makie.map!(plot, [inter_sym], vinds_sym) do inter
+    findall(g -> isnothing(g) || g isa Line, inter)
+  end
+  Makie.map!(plot, [geoms, vinds_sym], dinds_sym) do gvec, vinds
+    setdiff(1:length(gvec), vinds)
+  end
 
   # split colors accordingly
-  vcolor = Makie.@lift $colors[$vinds]
-  dcolor = Makie.@lift $colors[$dinds]
+  Makie.map!(plot, [colors, vinds_sym], vcolor_sym) do cvec, vinds
+    cvec[vinds]
+  end
+  Makie.map!(plot, [colors, dinds_sym], dcolor_sym) do cvec, dinds
+    cvec[dinds]
+  end
 
-  # visualize vertical lines
-  if !isempty(vinds[])
-    vlines = Makie.@lift $geoms[$vinds]
-    xcoord = Makie.@lift map($vlines) do vline
+  xcoord_sym = Symbol(geoms, :_xcoord)
+  Makie.map!(plot, [geoms, vinds_sym], xcoord_sym) do gvec, vinds
+    vlines = gvec[vinds]
+    map(vlines) do vline
       c = coords(vline(0))
       x = convert(Cartesian, c).x
       ustrip(x)
     end
-    Makie.vlines!(plot, xcoord, color=vcolor, linewidth=segmentsize)
   end
+  Makie.vlines!(plot, plot[xcoord_sym], color=plot[vcolor_sym], linewidth=segmentsize)
 
-  # visualize non-vertical lines
-  if !isempty(dinds[])
-    dlines = Makie.@lift $geoms[$dinds]
-    dinter = Makie.@lift $inter[$dinds]
-    ycoord = Makie.@lift map($dinter) do I
+  ycoord_sym = Symbol(geoms, :_ycoord)
+  slopes_sym = Symbol(geoms, :_slopes)
+  Makie.map!(plot, [inter_sym, dinds_sym], ycoord_sym) do inter, dinds
+    dinter = inter[dinds]
+    map(dinter) do I
       y = if I isa Line # horizontal line through origin
         zero(Meshes.lentype(I))
       else # intersection point with vertical axis
@@ -161,26 +224,34 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, geoms::ObservableVector
       end
       ustrip(y)
     end
-    slopes = Makie.@lift map($dlines) do dline
+  end
+  Makie.map!(plot, [geoms, dinds_sym], slopes_sym) do gvec, dinds
+    dlines = gvec[dinds]
+    map(dlines) do dline
       c1 = convert(Cartesian, coords(dline(0)))
       c2 = convert(Cartesian, coords(dline(1)))
       (c2.y - c1.y) / (c2.x - c1.x)
     end
-    Makie.ablines!(plot, ycoord, slopes, color=dcolor, linewidth=segmentsize)
   end
+  Makie.ablines!(plot, plot[ycoord_sym], plot[slopes_sym], color=plot[dcolor_sym], linewidth=segmentsize)
 end
 
-function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, geoms::ObservableVector{<:Polygon}, colors)
+function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, geoms::Symbol, colors::Symbol)
   showsegments = plot[:showsegments]
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
+  polys_sym = Symbol(geoms, :_polys)
+
   # visualize as built-in polygons
-  polys = Makie.@lift map(asmakie, $geoms)
+  Makie.map!(plot, [geoms], polys_sym) do gvec
+    map(asmakie, gvec)
+  end
+
   if showsegments[]
-    Makie.poly!(plot, polys, color=colors, strokecolor=segmentcolor, strokewidth=segmentsize)
+    Makie.poly!(plot, plot[polys_sym], color=plot[colors], strokecolor=segmentcolor, strokewidth=segmentsize)
   else
-    Makie.poly!(plot, polys, color=colors)
+    Makie.poly!(plot, plot[polys_sym], color=plot[colors])
   end
 end
 
@@ -190,30 +261,41 @@ end
 
 vizfacets!(plot::Viz{<:Tuple{GeometrySet}}) = vizgset!(plot, facets=false)
 
-function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, geoms)
-  M = Makie.@lift manifold(first($geoms))
-  pdim = Makie.@lift paramdim(first($geoms))
-  edim = Makie.@lift embeddim(first($geoms))
-  vizgsetfacets!(plot, M[], Val(pdim[]), Val(edim[]), geoms)
+function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, G::Type, geoms::Symbol)
+  gvec = plot[geoms][]
+  M = manifold(first(gvec))
+  pdim = paramdim(first(gvec))
+  edim = embeddim(first(gvec))
+  vizgsetfacets!(plot, M, Val(pdim), Val(edim), G, geoms)
 end
 
-function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, geoms)
+function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, G::Type, geoms::Symbol)
   pointmarker = plot[:pointmarker]
   pointcolor = plot[:pointcolor]
   pointsize = plot[:pointsize]
 
+  pset_sym = Symbol(geoms, :_pset)
+
   # all boundaries are points or multipoints
-  points = Makie.@lift filter(!isnothing, map(boundary, $geoms))
-  pset = Makie.@lift GeometrySet($points)
-  viz!(plot, pset, color=pointcolor, pointmarker=pointmarker, pointsize=pointsize)
+  Makie.map!(plot, [geoms], pset_sym) do gvec
+    points = filter(!isnothing, map(boundary, gvec))
+    GeometrySet(points)
+  end
+
+  viz!(plot, plot[pset_sym], color=pointcolor, pointmarker=pointmarker, pointsize=pointsize)
 end
 
-function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, geoms)
+function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, G::Type, geoms::Symbol)
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
+  bset_sym = Symbol(geoms, :_bset)
+
   # all boundaries are 1D geometries
-  bounds = Makie.@lift filter(!isnothing, map(boundary, $geoms))
-  bset = Makie.@lift GeometrySet($bounds)
-  viz!(plot, bset, color=segmentcolor, segmentsize=segmentsize)
+  Makie.map!(plot, [geoms], bset_sym) do gvec
+    bounds = filter(!isnothing, map(boundary, gvec))
+    GeometrySet(bounds)
+  end
+
+  viz!(plot, plot[bset_sym], color=segmentcolor, segmentsize=segmentsize)
 end

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -42,9 +42,6 @@ end
 
 # fallback to visualization of discretized geometries
 function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::Symbol, colors::Symbol)
-  showsegments = plot.showsegments
-  showpoints = plot.showpoints
-
   # refine meshes over the 🌐 manifold until
   # they satisfy the maximum length criterion
   mayberefine = M === 🌐 ? refinemaxlen : identity
@@ -61,7 +58,7 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::S
       map(triangulate, gvec)
     end
     vizmany!(plot, plot[meshes_sym], plot[colors])
-    if showpoints[]
+    if plot.showpoints[]
       vizfacets!(plot, G, geoms)
     end
   elseif pdim === Val(2)
@@ -69,7 +66,7 @@ function vizgset!(plot, M::Type, pdim::Val, ::Val, G::Type{<:Geometry}, geoms::S
       map(triangulate, gvec)
     end
     vizmany!(plot, plot[meshes_sym], plot[colors])
-    if showsegments[]
+    if plot.showsegments[]
       vizfacets!(plot, G, geoms)
     end
   elseif pdim === Val(3)
@@ -85,14 +82,11 @@ function vizgset!(plot, M::Type, pdim::Val, edim::Val, G::Type{<:Multi}, geoms::
   parents_sym = Symbol(geoms, :_parents)
   pcolors_sym = Symbol(colors, :_pcolors)
 
-  # retrieve parent geometries
-  Makie.map!(plot, [geoms], parents_sym) do gvec
-    mapreduce(parent, vcat, gvec)
-  end
-
   # repeat colors for parents
-  Makie.map!(plot, [colors, geoms], pcolors_sym) do cvec, gvec
-    [cvec[i] for (i, g) in enumerate(gvec) for _ in 1:length(parent(g))]
+  Makie.map!(plot, [colors, geoms], [pcolors_sym, parents_sym]) do cvec, gvec
+    pcolors = [cvec[i] for (i, g) in enumerate(gvec) for _ in 1:length(parent(g))]
+    pgeoms = mapreduce(parent, vcat, gvec)
+    pcolors, pgeoms
   end
 
   P = typeof(first(parent(first(plot[geoms][]))))
@@ -102,9 +96,6 @@ function vizgset!(plot, M::Type, pdim::Val, edim::Val, G::Type{<:Multi}, geoms::
 end
 
 function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, geoms::Symbol, colors::Symbol)
-  pointmarker = plot.pointmarker
-  pointsize = plot.pointsize
-
   coords_sym = Symbol(geoms, :_coords)
 
   # get raw Cartesian coordinates of points
@@ -113,31 +104,34 @@ function vizgset!(plot, ::Type, ::Val, ::Val, G::Type{<:Point}, geoms::Symbol, c
   end
 
   # visualize points with given marker and size
-  Makie.scatter!(plot, plot[coords_sym], color=plot[colors], marker=pointmarker, markersize=pointsize, overdraw=true)
+  Makie.scatter!(
+    plot,
+    plot[coords_sym],
+    color=plot[colors],
+    marker=plot.pointmarker,
+    markersize=plot.pointsize,
+    overdraw=true
+  )
 end
 
 function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol, colors::Symbol)
-  showpoints = plot.showpoints
-
   orig_sym = Symbol(geoms, :_orig)
   dirs_sym = Symbol(geoms, :_dirs)
 
   # visualize as built-in arrows
-  Makie.map!(plot, [geoms], orig_sym) do gvec
-    [asmakie(ray(0)) for ray in gvec]
-  end
-  Makie.map!(plot, [geoms], dirs_sym) do gvec
-    [asmakie(ray(1) - ray(0)) for ray in gvec]
+  Makie.map!(plot, [geoms], [orig_sym, dirs_sym]) do gvec
+    oris = [asmakie(ray(0)) for ray in gvec]
+    dirs = [asmakie(ray(1) - ray(0)) for ray in gvec]
+    oris, dirs
   end
 
   if edim === Val(2)
     tipwidth_sym = Symbol(geoms, :_tipwidth)
     shaftwidth_sym = Symbol(geoms, :_shaftwidth)
-    Makie.map!(plot, [:segmentsize], tipwidth_sym) do sz
-      5 * sz
-    end
-    Makie.map!(plot, [tipwidth_sym], shaftwidth_sym) do tw
-      0.2 * tw
+    Makie.map!(plot, [:segmentsize], [tipwidth_sym, shaftwidth_sym]) do sz
+      tw = 5 * sz
+      sw = 0.2 * tw
+      tw, sw
     end
     Makie.arrows2d!(
       plot,
@@ -150,11 +144,10 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
   elseif edim === Val(3)
     tipradius_sym = Symbol(geoms, :_tipradius)
     shaftradius_sym = Symbol(geoms, :_shaftradius)
-    Makie.map!(plot, [:segmentsize], tipradius_sym) do sz
-      0.05 * sz
-    end
-    Makie.map!(plot, [tipradius_sym], shaftradius_sym) do tr
-      0.5 * tr
+    Makie.map!(plot, [:segmentsize], [tipradius_sym, shaftradius_sym]) do sz
+      tr = 0.05 * sz
+      sr = 0.5 * tr
+      tr, sr
     end
     Makie.arrows3d!(
       plot,
@@ -168,7 +161,7 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, G::Type{<:Ray}, geoms::Symbol,
     error("not implemented")
   end
 
-  if showpoints[]
+  if plot.showpoints[]
     vizfacets!(plot, G, geoms)
   end
 end
@@ -234,10 +227,6 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
 end
 
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, geoms::Symbol, colors::Symbol)
-  showsegments = plot.showsegments
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
   polys_sym = Symbol(geoms, :_polys)
 
   # visualize as built-in polygons
@@ -245,8 +234,8 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, 
     map(asmakie, gvec)
   end
 
-  if showsegments[]
-    Makie.poly!(plot, plot[polys_sym], color=plot[colors], strokecolor=segmentcolor, strokewidth=segmentsize)
+  if plot.showsegments[]
+    Makie.poly!(plot, plot[polys_sym], color=plot[colors], strokecolor=plot.segmentcolor, strokewidth=plot.segmentsize)
   else
     Makie.poly!(plot, plot[polys_sym], color=plot[colors])
   end
@@ -267,10 +256,6 @@ function vizfacets!(plot::Viz{<:Tuple{GeometrySet}}, G::Type, geoms::Symbol)
 end
 
 function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, G::Type, geoms::Symbol)
-  pointmarker = plot.pointmarker
-  pointcolor = plot.pointcolor
-  pointsize = plot.pointsize
-
   pset_sym = Symbol(geoms, :_pset)
 
   # all boundaries are points or multipoints
@@ -279,13 +264,10 @@ function vizgsetfacets!(plot, ::Type, ::Val{1}, ::Val, G::Type, geoms::Symbol)
     GeometrySet(points)
   end
 
-  viz!(plot, plot[pset_sym], color=pointcolor, pointmarker=pointmarker, pointsize=pointsize)
+  viz!(plot, plot[pset_sym], color=plot.pointcolor, pointmarker=plot.pointmarker, pointsize=plot.pointsize)
 end
 
 function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, G::Type, geoms::Symbol)
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
   bset_sym = Symbol(geoms, :_bset)
 
   # all boundaries are 1D geometries
@@ -294,5 +276,5 @@ function vizgsetfacets!(plot, ::Type, ::Val{2}, ::Val, G::Type, geoms::Symbol)
     GeometrySet(bounds)
   end
 
-  viz!(plot, plot[bset_sym], color=segmentcolor, segmentsize=segmentsize)
+  viz!(plot, plot[bset_sym], color=plot.segmentcolor, segmentsize=plot.segmentsize)
 end

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{GeometrySet}})
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  colorant!(plot)
   vizgset!(plot)
 end
 

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -17,15 +17,14 @@ function vizgset!(plot)
   types = unique(map(typeof, geoms))
 
   for (i, G) in enumerate(types)
-    inds_sym = Symbol(:inds_, i)
     gvec_sym = Symbol(:gvec_, i)
     cvec_sym = Symbol(:cvec_, i)
 
-    Makie.map!(plot, [:object, :colorant], [inds_sym, gvec_sym, cvec_sym]) do g, colorant
+    Makie.map!(plot, [:object, :colorant], [gvec_sym, cvec_sym]) do g, colorant
       inds = findall(x -> x isa G, parent(g))
       gvec = collect(G, parent(g)[inds])
       cvec = colorant isa AbstractVector ? colorant[inds] : fill(colorant, length(inds))
-      inds, gvec, cvec
+      gvec, cvec
     end
 
     gvec = collect(G, geoms[findall(x -> x isa G, geoms)])

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -155,47 +155,38 @@ function vizgset!(plot, ::Type, ::Val, edim::Val, ::Type{<:Ray}, gvecid::Symbol,
   end
 end
 
-function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, gvecid::Symbol, cvecid::Symbol)
-  segmentsize = plot.segmentsize
-
-  inter_sym = Symbol(gvecid, :_inter)
-  vinds_sym = Symbol(gvecid, :_vinds)
-  dinds_sym = Symbol(gvecid, :_dinds)
-  vcolor_sym = Symbol(cvecid, :_vcolor)
-  dcolor_sym = Symbol(cvecid, :_dcolor)
-
+function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, ::Type{<:Line}, gvecid::Symbol, cvecid::Symbol)
+  interid = Symbol(gvecid, :_inter)
+  vindsid = Symbol(gvecid, :_vinds)
+  dindsid = Symbol(gvecid, :_dinds)
   # split vertical and non-vertical lines
-  Makie.map!(plot, [gvecid], [inter_sym, vinds_sym, dinds_sym]) do gvec
+  Makie.map!(plot, gvecid, [interid, vindsid, dindsid]) do gvec
     inter = [line ∩ Line((0, 0), (0, 1)) for line in gvec]
     vinds = findall(g -> isnothing(g) || g isa Line, inter)
     dinds = setdiff(1:length(gvec), vinds)
-    (inter, vinds, dinds)
+    inter, vinds, dinds
   end
 
   # split colors accordingly
-  Makie.map!(plot, [cvecid, vinds_sym], vcolor_sym) do cvec, vinds
-    cvec[vinds]
-  end
-  Makie.map!(plot, [cvecid, dinds_sym], dcolor_sym) do cvec, dinds
-    cvec[dinds]
+  vcolorid = Symbol(cvecid, :_vcolor)
+  dcolorid = Symbol(cvecid, :_dcolor)
+  Makie.map!(plot, [cvecid, vindsid, dindsid], vcolorid) do cvec, vinds, dinds
+    cvec[vinds], cvec[dinds]
   end
 
-  xcoord_sym = Symbol(gvecid, :_xcoord)
-  Makie.map!(plot, [gvecid, vinds_sym], xcoord_sym) do gvec, vinds
-    vlines = gvec[vinds]
-    map(vlines) do vline
+  xcoordid = Symbol(gvecid, :_xcoord)
+  ycoordid = Symbol(gvecid, :_ycoord)
+  slopesid = Symbol(gvecid, :_slopes)
+  Makie.map!(plot, [interid, gvecid, vindsid, dindsid], [xcoordid, ycoordid, slopesid]) do inter, gvec, vinds, dinds
+    # x coordinates of vertical lines
+    xcoords = map(gvec[vinds]) do vline
       c = coords(vline(0))
       x = convert(Cartesian, c).x
       ustrip(x)
     end
-  end
-  Makie.vlines!(plot, plot[xcoord_sym], color=plot[vcolor_sym], linewidth=segmentsize)
 
-  ycoord_sym = Symbol(gvecid, :_ycoord)
-  slopes_sym = Symbol(gvecid, :_slopes)
-  Makie.map!(plot, [inter_sym, dinds_sym], ycoord_sym) do inter, dinds
-    dinter = inter[dinds]
-    map(dinter) do I
+    # y coordinates of non-vertical lines
+    ycoords = map(inter[dinds]) do I
       y = if I isa Line # horizontal line through origin
         zero(Meshes.lentype(I))
       else # intersection point with vertical axis
@@ -203,16 +194,20 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, gvecid
       end
       ustrip(y)
     end
-  end
-  Makie.map!(plot, [gvecid, dinds_sym], slopes_sym) do gvec, dinds
-    dlines = gvec[dinds]
-    map(dlines) do dline
+
+    # slopes of non-vertical lines
+    slopes = map(gvec[dinds]) do dline
       c1 = convert(Cartesian, coords(dline(0)))
       c2 = convert(Cartesian, coords(dline(1)))
       (c2.y - c1.y) / (c2.x - c1.x)
     end
+
+    xcoords, ycoords, slopes
   end
-  Makie.ablines!(plot, plot[ycoord_sym], plot[slopes_sym], color=plot[dcolor_sym], linewidth=segmentsize)
+
+  # visualize vertical and non-vertical lines
+  Makie.vlines!(plot, plot[xcoordid], color=plot[vcolorid], linewidth=plot.segmentsize)
+  Makie.ablines!(plot, plot[ycoordid], plot[slopesid], color=plot[dcolorid], linewidth=plot.segmentsize)
 end
 
 function vizgset!(plot, ::Type{<:𝔼}, ::Val{2}, ::Val{2}, G::Type{<:Polygon}, gvecid::Symbol, cvecid::Symbol)

--- a/ext/geomset.jl
+++ b/ext/geomset.jl
@@ -201,7 +201,7 @@ function vizgset!(plot, ::Type{<:𝔼}, ::Val, ::Val{2}, G::Type{<:Line}, geoms:
     inter = [line ∩ Line((0, 0), (0, 1)) for line in gvec]
     vinds = findall(g -> isnothing(g) || g isa Line, inter)
     dinds = setdiff(1:length(gvec), vinds)
-    inter, vinds, dinds
+    (inter, vinds, dinds)
   end
 
   # split colors accordingly

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -5,11 +5,11 @@
 Makie.plot!(plot::Viz{<:Tuple{Grid}}) = vizgrid!(plot)
 
 function vizgrid!(plot)
-  grid = plot[:object]
-  M = Makie.@lift manifold($grid)
-  pdim = Makie.@lift paramdim($grid)
-  edim = Makie.@lift embeddim($grid)
-  vizgrid!(plot, M[], Val(pdim[]), Val(edim[]))
+  grid = plot[:object][]
+  M = manifold(grid)
+  pdim = paramdim(grid)
+  edim = embeddim(grid)
+  vizgrid!(plot, M, Val(pdim), Val(edim))
 end
 
 # ---------------
@@ -19,52 +19,62 @@ end
 vizgrid!(plot, M::Type, pdim::Val, edim::Val) = vizgridfallback!(plot, M, pdim, edim)
 
 function vizgridfallback!(plot, M, pdim, edim)
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
   showsegments = plot[:showsegments]
 
   # process color spec into colorant
-  colorant = Makie.@lift process($color, $colormap, $colorrange, $alpha)
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
   # number of vertices, elements and colors
-  nverts = Makie.@lift nvertices($grid)
-  nelems = Makie.@lift nelements($grid)
-  ncolor = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+  Makie.map!(nvertices, plot, [:object], :nverts)
+  Makie.map!(nelements, plot, [:object], :nelems)
+  Makie.map!(plot, [:colorant], :ncolor) do colorant
+    colorant isa AbstractVector ? length(colorant) : 1
+  end
 
   # visualize quadrangle mesh with texture using uv coords
   # plots with uv coords are always interpolated,
   # so it is only used in the case ncolor == nverts
   # or when there is a large number of elements
-  if pdim === Val(2) && (ncolor[] == 1 || ncolor[] == nverts[] || nelems[] ≥ 1000)
+  if pdim === Val(2) && (plot[:ncolor][] == 1 || plot[:ncolor][] == plot[:nverts][] || plot[:nelems][] ≥ 1000)
     # decide whether or not to reverse connectivity list
-    rfunc = Makie.@lift crs($grid) <: LatLon && orientation(first($grid)) == CW ? reverse : identity
-
-    verts = Makie.@lift map(asmakie, eachvertex($grid))
-    quads = Makie.@lift [GB.QuadFace($rfunc(indices(e))) for e in elements(topology($grid))]
-
-    dims = Makie.@lift size($grid)
-    vdims = Makie.@lift Meshes.vsize($grid)
-    texture = if ncolor[] == 1
-      Makie.@lift fill($colorant, $dims)
-    elseif ncolor[] == nelems[]
-      Makie.@lift reshape($colorant, $dims)
-    elseif ncolor[] == nverts[]
-      Makie.@lift reshape($colorant, $vdims)
-    else
-      throw(ArgumentError("invalid number of colors"))
+    Makie.map!(plot, [:object], :rfunc) do grid
+      crs(grid) <: LatLon && orientation(first(grid)) == CW ? reverse : identity
     end
 
-    uv = Makie.@lift [Makie.Vec2f(v, 1 - u) for v in range(0, 1, $vdims[2]) for u in range(0, 1, $vdims[1])]
+    Makie.map!(plot, [:object], :verts) do grid
+      map(asmakie, eachvertex(grid))
+    end
+    Makie.map!(plot, [:object, :rfunc], :quads) do grid, rfunc
+      [GB.QuadFace(rfunc(indices(e))) for e in elements(topology(grid))]
+    end
 
-    mesh = Makie.@lift GB.Mesh($verts, $quads, uv=$uv)
+    Makie.map!(size, plot, [:object], :dims)
+    Makie.map!(Meshes.vsize, plot, [:object], :vdims)
+
+    Makie.map!(plot, [:colorant, :ncolor, :nelems, :nverts, :dims, :vdims], :texture) do colorant, ncolor, nelems, nverts, dims, vdims
+      if ncolor == 1
+        fill(colorant, dims)
+      elseif ncolor == nelems
+        reshape(colorant, dims)
+      elseif ncolor == nverts
+        reshape(colorant, vdims)
+      else
+        throw(ArgumentError("invalid number of colors"))
+      end
+    end
+
+    Makie.map!(plot, [:vdims], :uv) do vdims
+      [Makie.Vec2f(v, 1 - u) for v in range(0, 1, vdims[2]) for u in range(0, 1, vdims[1])]
+    end
+
+    Makie.map!(plot, [:verts, :quads, :uv], :mesh) do verts, quads, uv
+      GB.Mesh(verts, quads, uv=uv)
+    end
 
     # enable shading in 3D
     shading = edim === Val(3)
 
-    Makie.mesh!(plot, mesh, color=texture, shading=shading)
+    Makie.mesh!(plot, plot[:mesh], color=plot[:texture], shading=shading)
 
     if showsegments[]
       vizfacets!(plot)
@@ -79,11 +89,11 @@ end
 # -------
 
 function vizfacets!(plot::Viz{<:Tuple{Grid}})
-  grid = plot[:object]
-  M = Makie.@lift manifold($grid)
-  pdim = Makie.@lift paramdim($grid)
-  edim = Makie.@lift embeddim($grid)
-  vizgridfacets!(plot, M[], Val(pdim[]), Val(edim[]))
+  grid = plot[:object][]
+  M = manifold(grid)
+  pdim = paramdim(grid)
+  edim = embeddim(grid)
+  vizgridfacets!(plot, M, Val(pdim), Val(edim))
 end
 
 vizgridfacets!(plot, M::Type, pdim::Val, edim::Val) = vizmeshfacets!(plot, M, pdim, edim)

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -2,7 +2,10 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-Makie.plot!(plot::Viz{<:Tuple{Grid}}) = vizgrid!(plot)
+function Makie.plot!(plot::Viz{<:Tuple{Grid}})
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  vizgrid!(plot)
+end
 
 function vizgrid!(plot)
   grid = plot.object[]
@@ -19,9 +22,6 @@ end
 vizgrid!(plot, M::Type, pdim::Val, edim::Val) = vizgridfallback!(plot, M, pdim, edim)
 
 function vizgridfallback!(plot, M, pdim, edim)
-  # process color spec into colorant
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-
   # number of vertices, elements and colors
   Makie.map!(plot, [:object, :colorant], [:nv, :ne, :nc]) do grid, colorant
     nv = nvertices(grid)

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -74,7 +74,7 @@ function vizgridfallback!(plot, M, pdim, edim)
       vizfacets!(plot)
     end
   else
-    # fallback to triangle mesh visualization
+    # visualize as simple mesh
     vizmesh!(plot)
   end
 end

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{Grid}})
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  colorant!(plot)
   vizgrid!(plot)
 end
 

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -5,7 +5,7 @@
 Makie.plot!(plot::Viz{<:Tuple{Grid}}) = vizgrid!(plot)
 
 function vizgrid!(plot)
-  grid = plot[:object][]
+  grid = plot.object[]
   M = manifold(grid)
   pdim = paramdim(grid)
   edim = embeddim(grid)
@@ -19,7 +19,7 @@ end
 vizgrid!(plot, M::Type, pdim::Val, edim::Val) = vizgridfallback!(plot, M, pdim, edim)
 
 function vizgridfallback!(plot, M, pdim, edim)
-  showsegments = plot[:showsegments]
+  showsegments = plot.showsegments
 
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
@@ -35,7 +35,7 @@ function vizgridfallback!(plot, M, pdim, edim)
   # plots with uv coords are always interpolated,
   # so it is only used in the case ncolor == nverts
   # or when there is a large number of elements
-  if pdim === Val(2) && (plot[:ncolor][] == 1 || plot[:ncolor][] == plot[:nverts][] || plot[:nelems][] ≥ 1000)
+  if pdim === Val(2) && (plot.ncolor[] == 1 || plot.ncolor[] == plot.nverts[] || plot.nelems[] ≥ 1000)
     # decide whether or not to reverse connectivity list
     Makie.map!(plot, [:object], :rfunc) do grid
       crs(grid) <: LatLon && orientation(first(grid)) == CW ? reverse : identity
@@ -78,7 +78,7 @@ function vizgridfallback!(plot, M, pdim, edim)
     # enable shading in 3D
     shading = edim === Val(3)
 
-    Makie.mesh!(plot, plot[:mesh], color=plot[:texture], shading=shading)
+    Makie.mesh!(plot, plot.mesh, color=plot.texture, shading=shading)
 
     if showsegments[]
       vizfacets!(plot)
@@ -93,7 +93,7 @@ end
 # -------
 
 function vizfacets!(plot::Viz{<:Tuple{Grid}})
-  grid = plot[:object][]
+  grid = plot.object[]
   M = manifold(grid)
   pdim = paramdim(grid)
   edim = embeddim(grid)

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -100,7 +100,6 @@ vizgridfacets!(plot, M::Type, pdim::Val, edim::Val) = vizmeshfacets!(plot, M, pd
 include("grid/cartesian.jl")
 include("grid/rectilinear.jl")
 include("grid/structured.jl")
-include("grid/transformed.jl")
 
 # -----------------
 # HELPER FUNCTIONS

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -51,7 +51,11 @@ function vizgridfallback!(plot, M, pdim, edim)
     Makie.map!(size, plot, [:object], :dims)
     Makie.map!(Meshes.vsize, plot, [:object], :vdims)
 
-    Makie.map!(plot, [:colorant, :ncolor, :nelems, :nverts, :dims, :vdims], :texture) do colorant, ncolor, nelems, nverts, dims, vdims
+    Makie.map!(
+      plot,
+      [:colorant, :ncolor, :nelems, :nverts, :dims, :vdims],
+      :texture
+    ) do colorant, ncolor, nelems, nverts, dims, vdims
       if ncolor == 1
         fill(colorant, dims)
       elseif ncolor == nelems

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -34,7 +34,7 @@ function vizgridfallback!(plot, M, pdim, edim)
   # only used in the case nc == nv or when the grid is large
   if pdim === Val(2) && (plot.nc[] == 1 || plot.nc[] == plot.nv[] || plot.ne[] ≥ 1000)
     # visualize quadrangle mesh with texture using uv coords
-    Makie.map!(plot, [:object, :colorant], [:mesh, :texture]) do grid, colorant
+    Makie.map!(plot, [:object, :colorant, :nv, :ne, :nc], [:mesh, :texture]) do grid, colorant, nv, ne, nc
       # retrieve relevant sizes
       sz = size(grid)
       vz = Meshes.vsize(grid)
@@ -52,11 +52,11 @@ function vizgridfallback!(plot, M, pdim, edim)
       mesh = GB.Mesh(verts, quads; uv)
 
       # texture map
-      texture = if plot.nc[] == 1
+      texture = if nc == 1
         fill(colorant, sz)
-      elseif plot.nc[] == plot.nv[]
+      elseif nc == nv
         reshape(colorant, vz)
-      elseif plot.nc[] == plot.ne[]
+      elseif nc == ne
         reshape(colorant, sz)
       else
         throw(ArgumentError("invalid number of colors"))

--- a/ext/grid.jl
+++ b/ext/grid.jl
@@ -19,60 +19,50 @@ end
 vizgrid!(plot, M::Type, pdim::Val, edim::Val) = vizgridfallback!(plot, M, pdim, edim)
 
 function vizgridfallback!(plot, M, pdim, edim)
-  showsegments = plot.showsegments
-
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
   # number of vertices, elements and colors
-  Makie.map!(nvertices, plot, [:object], :nverts)
-  Makie.map!(nelements, plot, [:object], :nelems)
-  Makie.map!(plot, [:colorant], :ncolor) do colorant
-    colorant isa AbstractVector ? length(colorant) : 1
+  Makie.map!(plot, [:object, :colorant], [:nv, :ne, :nc]) do grid, colorant
+    nv = nvertices(grid)
+    ne = nelements(grid)
+    nc = colorant isa AbstractVector ? length(colorant) : 1
+    nv, ne, nc
   end
 
-  # visualize quadrangle mesh with texture using uv coords
-  # plots with uv coords are always interpolated,
-  # so it is only used in the case ncolor == nverts
-  # or when there is a large number of elements
-  if pdim === Val(2) && (plot.ncolor[] == 1 || plot.ncolor[] == plot.nverts[] || plot.nelems[] ≥ 1000)
-    # decide whether or not to reverse connectivity list
-    Makie.map!(plot, [:object], :rfunc) do grid
-      crs(grid) <: LatLon && orientation(first(grid)) == CW ? reverse : identity
-    end
+  # plots with uv coords are always interpolated, so it is
+  # only used in the case nc == nv or when the grid is large
+  if pdim === Val(2) && (plot.nc[] == 1 || plot.nc[] == plot.nv[] || plot.ne[] ≥ 1000)
+    # visualize quadrangle mesh with texture using uv coords
+    Makie.map!(plot, [:object, :colorant], [:mesh, :texture]) do grid, colorant
+      # retrieve relevant sizes
+      sz = size(grid)
+      vz = Meshes.vsize(grid)
 
-    Makie.map!(plot, [:object], :verts) do grid
-      map(asmakie, eachvertex(grid))
-    end
-    Makie.map!(plot, [:object, :rfunc], :quads) do grid, rfunc
-      [GB.QuadFace(rfunc(indices(e))) for e in elements(topology(grid))]
-    end
+      # decide whether or not to reverse connectivity list
+      rev = crs(grid) <: LatLon && orientation(first(grid)) == CW ? reverse : identity
 
-    Makie.map!(size, plot, [:object], :dims)
-    Makie.map!(Meshes.vsize, plot, [:object], :vdims)
+      # vertices and quadrangles
+      verts = map(asmakie, eachvertex(grid))
+      quads = [GB.QuadFace(rev(indices(e))) for e in elements(topology(grid))]
 
-    Makie.map!(
-      plot,
-      [:colorant, :ncolor, :nelems, :nverts, :dims, :vdims],
-      :texture
-    ) do colorant, ncolor, nelems, nverts, dims, vdims
-      if ncolor == 1
-        fill(colorant, dims)
-      elseif ncolor == nelems
-        reshape(colorant, dims)
-      elseif ncolor == nverts
-        reshape(colorant, vdims)
+      # uv coordinates for texture mapping
+      uv = [Makie.Vec2f(v, 1 - u) for v in range(0, 1, vz[2]) for u in range(0, 1, vz[1])]
+
+      mesh = GB.Mesh(verts, quads; uv)
+
+      # texture map
+      texture = if plot.nc[] == 1
+        fill(colorant, sz)
+      elseif plot.nc[] == plot.nv[]
+        reshape(colorant, vz)
+      elseif plot.nc[] == plot.ne[]
+        reshape(colorant, sz)
       else
         throw(ArgumentError("invalid number of colors"))
       end
-    end
 
-    Makie.map!(plot, [:vdims], :uv) do vdims
-      [Makie.Vec2f(v, 1 - u) for v in range(0, 1, vdims[2]) for u in range(0, 1, vdims[1])]
-    end
-
-    Makie.map!(plot, [:verts, :quads, :uv], :mesh) do verts, quads, uv
-      GB.Mesh(verts, quads, uv=uv)
+      mesh, texture
     end
 
     # enable shading in 3D
@@ -80,10 +70,11 @@ function vizgridfallback!(plot, M, pdim, edim)
 
     Makie.mesh!(plot, plot.mesh, color=plot.texture, shading=shading)
 
-    if showsegments[]
+    if plot.showsegments[]
       vizfacets!(plot)
     end
-  else # fallback to triangle mesh visualization
+  else
+    # fallback to triangle mesh visualization
     vizmesh!(plot)
   end
 end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -105,22 +105,22 @@ function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val
   segmentcolor = plot.segmentcolor
   segmentsize = plot.segmentsize
 
-  Makie.map!(plot, [:object], [:facets_x, :facets_y]) do grid
+  Makie.map!(plot, [:object], [:xfacets, :yfacets]) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
 
-  Makie.lines!(plot, plot.facets_x, plot.facets_y, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=segmentcolor, linewidth=segmentsize)
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
   segmentcolor = plot.segmentcolor
   segmentsize = plot.segmentsize
 
-  Makie.map!(plot, [:object], [:facets_x, :facets_y, :facets_z]) do grid
+  Makie.map!(plot, [:object], [:xfacets, :yfacets, :zfacets]) do grid
     x, y, z = Meshes.xyz(grid)
     xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
   end
 
-  Makie.lines!(plot, plot.facets_x, plot.facets_y, plot.facets_z, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, plot.zfacets, color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -6,34 +6,29 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
-  # number of vertices and colors
-  Makie.map!(nvertices, plot, [:object], :nv)
-  Makie.map!(plot, [:colorant], :nc) do colorant
-    colorant isa AbstractVector ? length(colorant) : 1
-  end
+  # compute coordinates and color matrix
+  Makie.map!(plot, [:object, :colorant], [:x, :y, :C, :interpolate]) do grid, colorant
+    sz = size(grid)
+    nv = nvertices(grid)
+    nc = colorant isa AbstractVector ? length(colorant) : 1
 
-  # size and extrema coordinates
-  Makie.map!(size, plot, [:object], :sz)
-  Makie.map!(plot, [:object], [:x, :y]) do grid
-    x, y = Meshes.xyz(grid)
-    xₛ, xₑ = extrema(ustrip.(x))
-    yₛ, yₑ = extrema(ustrip.(y))
-    ((xₛ, xₑ), (yₛ, yₑ))
-  end
+    xs, ys = Meshes.xyz(grid)
+    x = extrema(ustrip.(xs))
+    y = extrema(ustrip.(ys))
 
-  if plot.nc[] == plot.nv[]
-    # visualize as built-in image with interpolation
-    Makie.map!(plot, [:colorant, :sz], :C) do colorant, sz
+    C = if nc == 1
+      fill(colorant, sz)
+    elseif nc == nv
       reshape(colorant, sz .+ 1)
+    else
+      reshape(colorant, sz)
     end
-    Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=true)
-  else
-    # visualize as built-in image without interpolation
-    Makie.map!(plot, [:colorant, :sz, :nc], :C) do colorant, sz, nc
-      nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
-    end
-    Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=false)
+
+    x, y, C, (nc == nv)
   end
+
+  # visualize as built-in image with or without interpolation
+  Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=plot.interpolate)
 
   if plot.showsegments[]
     vizfacets!(plot)

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -72,15 +72,14 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     # visualize as built-in meshscatter
     Makie.map!(plot, :object, [:xyz, :rect]) do grid
       sp = ustrip.(spacing(grid))
-      cs = map(x -> ustrip.(x), Meshes.xyz(grid))
-      xs = cs[1][(begin + 1):end]
-      ys = cs[2][(begin + 1):end]
-      zs = cs[3][(begin + 1):end]
+      xs, ys, zs = map(Meshes.xyz(grid)) do c
+        ustrip.(c[(begin + 1):end])
+      end
       xyz = [(x, y, z) for z in zs for y in ys for x in xs]
-      rect = Makie.Rect3(-1 .* sp, sp)
-      xyz, rect
+      rec = Makie.Rect3(-1 .* sp, sp)
+      xyz, rec
     end
-    Makie.meshscatter!(plot, plot.xyz, marker=plot.rect, markersize=1, color=plot.colorant)
+    Makie.meshscatter!(plot, plot.xyz, marker=plot.rec, markersize=1, color=plot.colorant)
   end
 
   if plot.showsegments[]

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -3,39 +3,44 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
   showsegments = plot[:showsegments]
 
   # process color spec into colorant
-  colorant = Makie.@lift process($color, $colormap, $colorrange, $alpha)
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
   # number of vertices and colors
-  nv = Makie.@lift nvertices($grid)
-  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+  Makie.map!(nvertices, plot, [:object], :nv)
+  Makie.map!(plot, [:colorant], :nc) do colorant
+    colorant isa AbstractVector ? length(colorant) : 1
+  end
 
   # size and extrema coordinates
-  sz = Makie.@lift size($grid)
-  xy = Makie.@lift let
-    x, y = Meshes.xyz($grid)
+  Makie.map!(size, plot, [:object], :sz)
+  Makie.map!(plot, [:object], :xy) do grid
+    x, y = Meshes.xyz(grid)
     xₛ, xₑ = extrema(ustrip.(x))
     yₛ, yₑ = extrema(ustrip.(y))
     (xₛ, xₑ), (yₛ, yₑ)
   end
-  x = Makie.@lift $xy[1]
-  y = Makie.@lift $xy[2]
+  Makie.map!(plot, [:xy], :x) do xy
+    xy[1]
+  end
+  Makie.map!(plot, [:xy], :y) do xy
+    xy[2]
+  end
 
-  if nc[] == nv[]
+  if plot[:nc][] == plot[:nv][]
     # visualize as built-in image with interpolation
-    C = Makie.@lift reshape($colorant, $sz .+ 1)
-    Makie.image!(plot, x, y, C, interpolate=true)
+    Makie.map!(plot, [:colorant, :sz], :C) do colorant, sz
+      reshape(colorant, sz .+ 1)
+    end
+    Makie.image!(plot, plot[:x], plot[:y], plot[:C], interpolate=true)
   else
     # visualize as built-in image without interpolation
-    C = Makie.@lift $nc == 1 ? fill($colorant, $sz) : reshape($colorant, $sz)
-    Makie.image!(plot, x, y, C, interpolate=false)
+    Makie.map!(plot, [:nc, :colorant, :sz], :C) do nc, colorant, sz
+      nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
+    end
+    Makie.image!(plot, plot[:x], plot[:y], plot[:C], interpolate=false)
   end
 
   if showsegments[]
@@ -45,54 +50,69 @@ end
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
   # retrieve parameters
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
   showsegments = plot[:showsegments]
 
   # process color spec into colorant
-  colorant = Makie.@lift process($color, $colormap, $colorrange, $alpha)
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
   # number of vertices and colors
-  nv = Makie.@lift nvertices($grid)
-  nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+  Makie.map!(nvertices, plot, [:object], :nv)
+  Makie.map!(plot, [:colorant], :nc) do colorant
+    colorant isa AbstractVector ? length(colorant) : 1
+  end
 
   # spacing and coordinates
-  sp = Makie.@lift ustrip.(spacing($grid))
-  xyz = Makie.@lift map(x -> ustrip.(x), Meshes.xyz($grid))
+  Makie.map!(plot, [:object], :sp) do grid
+    ustrip.(spacing(grid))
+  end
+  Makie.map!(plot, [:object], :xyz) do grid
+    map(x -> ustrip.(x), Meshes.xyz(grid))
+  end
 
-  if nc[] == nv[]
+  if plot[:nc][] == plot[:nv][]
     # visualize as a quadrangle mesh so that
     # colors can be specified at vertices
-    verts = Makie.@lift map(asmakie, eachvertex($grid))
-    quads = Makie.@lift reduce(
-      vcat,
-      map(elements(topology($grid))) do elem
-        i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
-        [
-          # follow the same order of vertices specified
-          # in the `boundary` method for `Hexahedron`
-          GB.QuadFace(i4, i3, i2, i1),
-          GB.QuadFace(i6, i5, i1, i2),
-          GB.QuadFace(i3, i7, i6, i2),
-          GB.QuadFace(i4, i8, i7, i3),
-          GB.QuadFace(i1, i5, i8, i4),
-          GB.QuadFace(i6, i7, i8, i5)
-        ]
-      end
-    )
-    mesh = Makie.@lift GB.Mesh($verts, $quads)
-    Makie.mesh!(plot, mesh, color=colorant, shading=true)
+    Makie.map!(plot, [:object], :verts) do grid
+      map(asmakie, eachvertex(grid))
+    end
+    Makie.map!(plot, [:object], :quads) do grid
+      reduce(
+        vcat,
+        map(elements(topology(grid))) do elem
+          i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
+          [
+            # follow the same order of vertices specified
+            # in the `boundary` method for `Hexahedron`
+            GB.QuadFace(i4, i3, i2, i1),
+            GB.QuadFace(i6, i5, i1, i2),
+            GB.QuadFace(i3, i7, i6, i2),
+            GB.QuadFace(i4, i8, i7, i3),
+            GB.QuadFace(i1, i5, i8, i4),
+            GB.QuadFace(i6, i7, i8, i5)
+          ]
+        end
+      )
+    end
+    Makie.map!(GB.Mesh, plot, [:verts, :quads], :mesh)
+    Makie.mesh!(plot, plot[:mesh], color=plot[:colorant], shading=true)
   else
     # visualize as built-in meshscatter
-    xs = Makie.@lift $xyz[1][(begin + 1):end]
-    ys = Makie.@lift $xyz[2][(begin + 1):end]
-    zs = Makie.@lift $xyz[3][(begin + 1):end]
-    rect = Makie.@lift Makie.Rect3(-1 .* $sp, $sp)
-    coords = Makie.@lift [(x, y, z) for z in $zs for y in $ys for x in $xs]
-    Makie.meshscatter!(plot, coords, marker=rect, markersize=1, color=colorant)
+    Makie.map!(plot, [:xyz], :xs) do xyz
+      xyz[1][(begin + 1):end]
+    end
+    Makie.map!(plot, [:xyz], :ys) do xyz
+      xyz[2][(begin + 1):end]
+    end
+    Makie.map!(plot, [:xyz], :zs) do xyz
+      xyz[3][(begin + 1):end]
+    end
+    Makie.map!(plot, [:sp], :rect) do sp
+      Makie.Rect3(-1 .* sp, sp)
+    end
+    Makie.map!(plot, [:xs, :ys, :zs], :coords) do xs, ys, zs
+      [(x, y, z) for z in zs for y in ys for x in xs]
+    end
+    Makie.meshscatter!(plot, plot[:coords], marker=plot[:rect], markersize=1, color=plot[:colorant])
   end
 
   if showsegments[]
@@ -101,32 +121,40 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  grid = plot[:object]
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  xy = Makie.@lift let
-    x, y = Meshes.xyz($grid)
+  Makie.map!(plot, [:object], :xy) do grid
+    x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
-  x = Makie.@lift $xy[1]
-  y = Makie.@lift $xy[2]
+  Makie.map!(plot, [:xy], :x) do xy
+    xy[1]
+  end
+  Makie.map!(plot, [:xy], :y) do xy
+    xy[2]
+  end
 
-  Makie.lines!(plot, x, y, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:x], plot[:y], color=segmentcolor, linewidth=segmentsize)
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
-  grid = plot[:object]
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  xyz = Makie.@lift let
-    x, y, z = Meshes.xyz($grid)
+  Makie.map!(plot, [:object], :xyz) do grid
+    x, y, z = Meshes.xyz(grid)
     xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
   end
-  x = Makie.@lift $xyz[1]
-  y = Makie.@lift $xyz[2]
-  z = Makie.@lift $xyz[3]
+  Makie.map!(plot, [:xyz], :x) do xyz
+    xyz[1]
+  end
+  Makie.map!(plot, [:xyz], :y) do xyz
+    xyz[2]
+  end
+  Makie.map!(plot, [:xyz], :z) do xyz
+    xyz[3]
+  end
 
-  Makie.lines!(plot, x, y, z, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:x], plot[:y], plot[:z], color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -31,7 +31,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
     Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=true)
   else
     # visualize as built-in image without interpolation
-    Makie.map!(plot, [:nc, :colorant, :sz], :C) do nc, colorant, sz
+    Makie.map!(plot, [:colorant, :sz, :nc], :C) do colorant, sz, nc
       nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
     end
     Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=false)

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -16,17 +16,11 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
 
   # size and extrema coordinates
   Makie.map!(size, plot, [:object], :sz)
-  Makie.map!(plot, [:object], :xy) do grid
+  Makie.map!(plot, [:object], [:x, :y]) do grid
     x, y = Meshes.xyz(grid)
     xₛ, xₑ = extrema(ustrip.(x))
     yₛ, yₑ = extrema(ustrip.(y))
-    (xₛ, xₑ), (yₛ, yₑ)
-  end
-  Makie.map!(plot, [:xy], :x) do xy
-    xy[1]
-  end
-  Makie.map!(plot, [:xy], :y) do xy
-    xy[2]
+    [(xₛ, xₑ), (yₛ, yₑ)]
   end
 
   if plot[:nc][] == plot[:nv][]
@@ -97,20 +91,14 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     Makie.mesh!(plot, plot[:mesh], color=plot[:colorant], shading=true)
   else
     # visualize as built-in meshscatter
-    Makie.map!(plot, [:xyz], :xs) do xyz
-      xyz[1][(begin + 1):end]
-    end
-    Makie.map!(plot, [:xyz], :ys) do xyz
-      xyz[2][(begin + 1):end]
-    end
-    Makie.map!(plot, [:xyz], :zs) do xyz
-      xyz[3][(begin + 1):end]
+    Makie.map!(plot, [:xyz], :coords) do xyz
+      xs = xyz[1][(begin + 1):end]
+      ys = xyz[2][(begin + 1):end]
+      zs = xyz[3][(begin + 1):end]
+      [(x, y, z) for z in zs for y in ys for x in xs]
     end
     Makie.map!(plot, [:sp], :rect) do sp
       Makie.Rect3(-1 .* sp, sp)
-    end
-    Makie.map!(plot, [:xs, :ys, :zs], :coords) do xs, ys, zs
-      [(x, y, z) for z in zs for y in ys for x in xs]
     end
     Makie.meshscatter!(plot, plot[:coords], marker=plot[:rect], markersize=1, color=plot[:colorant])
   end
@@ -124,15 +112,9 @@ function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  Makie.map!(plot, [:object], :facets_xy) do grid
+  Makie.map!(plot, [:object], [:facets_x, :facets_y]) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
-  end
-  Makie.map!(plot, [:facets_xy], :facets_x) do xy
-    xy[1]
-  end
-  Makie.map!(plot, [:facets_xy], :facets_y) do xy
-    xy[2]
   end
 
   Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
@@ -142,18 +124,9 @@ function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  Makie.map!(plot, [:object], :facets_xyz) do grid
+  Makie.map!(plot, [:object], [:facets_x, :facets_y, :facets_z]) do grid
     x, y, z = Meshes.xyz(grid)
     xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
-  end
-  Makie.map!(plot, [:facets_xyz], :facets_x) do xyz
-    xyz[1]
-  end
-  Makie.map!(plot, [:facets_xyz], :facets_y) do xyz
-    xyz[2]
-  end
-  Makie.map!(plot, [:facets_xyz], :facets_z) do xyz
-    xyz[3]
   end
 
   Makie.lines!(plot, plot[:facets_x], plot[:facets_y], plot[:facets_z], color=segmentcolor, linewidth=segmentsize)

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -124,37 +124,37 @@ function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  Makie.map!(plot, [:object], :xy) do grid
+  Makie.map!(plot, [:object], :facets_xy) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
-  Makie.map!(plot, [:xy], :x) do xy
+  Makie.map!(plot, [:facets_xy], :facets_x) do xy
     xy[1]
   end
-  Makie.map!(plot, [:xy], :y) do xy
+  Makie.map!(plot, [:facets_xy], :facets_y) do xy
     xy[2]
   end
 
-  Makie.lines!(plot, plot[:x], plot[:y], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  Makie.map!(plot, [:object], :xyz) do grid
+  Makie.map!(plot, [:object], :facets_xyz) do grid
     x, y, z = Meshes.xyz(grid)
     xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
   end
-  Makie.map!(plot, [:xyz], :x) do xyz
+  Makie.map!(plot, [:facets_xyz], :facets_x) do xyz
     xyz[1]
   end
-  Makie.map!(plot, [:xyz], :y) do xyz
+  Makie.map!(plot, [:facets_xyz], :facets_y) do xyz
     xyz[2]
   end
-  Makie.map!(plot, [:xyz], :z) do xyz
+  Makie.map!(plot, [:facets_xyz], :facets_z) do xyz
     xyz[3]
   end
 
-  Makie.lines!(plot, plot[:x], plot[:y], plot[:z], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], plot[:facets_z], color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -12,9 +12,9 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
     nv = nvertices(grid)
     nc = colorant isa AbstractVector ? length(colorant) : 1
 
-    xs, ys = Meshes.xyz(grid)
-    x = extrema(ustrip.(xs))
-    y = extrema(ustrip.(ys))
+    x, y = map(Meshes.xyz(grid)) do c
+      extrema(ustrip.(c))
+    end
 
     C = if nc == 1
       fill(colorant, sz)
@@ -89,16 +89,16 @@ end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
   Makie.map!(plot, :object, [:xfacets, :yfacets]) do grid
-    x, y = Meshes.xyz(grid)
-    xysegments(ustrip.(x), ustrip.(y))
+    x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
+    xysegments(x, y)
   end
   Makie.lines!(plot, plot.xfacets, plot.yfacets, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
   Makie.map!(plot, :object, [:xfacets, :yfacets, :zfacets]) do grid
-    x, y, z = Meshes.xyz(grid)
-    xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
+    x, y, z = map(c -> ustrip.(c), Meshes.xyz(grid))
+    xyzsegments(x, y, z)
   end
   Makie.lines!(plot, plot.xfacets, plot.yfacets, plot.zfacets, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -73,17 +73,17 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     Makie.mesh!(plot, plot.mesh, color=plot.colorant, shading=true)
   else
     # visualize as built-in meshscatter
-    Makie.map!(plot, [:object], [:coords, :rect]) do grid
-      xyz = map(x -> ustrip.(x), Meshes.xyz(grid))
-      xs = xyz[1][(begin + 1):end]
-      ys = xyz[2][(begin + 1):end]
-      zs = xyz[3][(begin + 1):end]
-      coords = [(x, y, z) for z in zs for y in ys for x in xs]
+    Makie.map!(plot, [:object], [:xyz, :rect]) do grid
       sp = ustrip.(spacing(grid))
+      cs = map(x -> ustrip.(x), Meshes.xyz(grid))
+      xs = cs[1][(begin + 1):end]
+      ys = cs[2][(begin + 1):end]
+      zs = cs[3][(begin + 1):end]
+      xyz = [(x, y, z) for z in zs for y in ys for x in xs]
       rect = Makie.Rect3(-1 .* sp, sp)
-      (coords, rect)
+      xyz, rect
     end
-    Makie.meshscatter!(plot, plot.coords, marker=plot.rect, markersize=1, color=plot.colorant)
+    Makie.meshscatter!(plot, plot.xyz, marker=plot.rect, markersize=1, color=plot.colorant)
   end
 
   if plot.showsegments[]

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -3,8 +3,6 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  showsegments = plot.showsegments
-
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
@@ -37,15 +35,12 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
     Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=false)
   end
 
-  if showsegments[]
+  if plot.showsegments[]
     vizfacets!(plot)
   end
 end
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
-  # retrieve parameters
-  showsegments = plot.showsegments
-
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
@@ -96,31 +91,23 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     Makie.meshscatter!(plot, plot.coords, marker=plot.rect, markersize=1, color=plot.colorant)
   end
 
-  if showsegments[]
+  if plot.showsegments[]
     vizfacets!(plot)
   end
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
   Makie.map!(plot, [:object], [:xfacets, :yfacets]) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
-
-  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
   Makie.map!(plot, [:object], [:xfacets, :yfacets, :zfacets]) do grid
     x, y, z = Meshes.xyz(grid)
     xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
   end
-
-  Makie.lines!(plot, plot.xfacets, plot.yfacets, plot.zfacets, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, plot.zfacets, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  showsegments = plot[:showsegments]
+  showsegments = plot.showsegments
 
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
@@ -23,18 +23,18 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
     ((xₛ, xₑ), (yₛ, yₑ))
   end
 
-  if plot[:nc][] == plot[:nv][]
+  if plot.nc[] == plot.nv[]
     # visualize as built-in image with interpolation
     Makie.map!(plot, [:colorant, :sz], :C) do colorant, sz
       reshape(colorant, sz .+ 1)
     end
-    Makie.image!(plot, plot[:x], plot[:y], plot[:C], interpolate=true)
+    Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=true)
   else
     # visualize as built-in image without interpolation
     Makie.map!(plot, [:nc, :colorant, :sz], :C) do nc, colorant, sz
       nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
     end
-    Makie.image!(plot, plot[:x], plot[:y], plot[:C], interpolate=false)
+    Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=false)
   end
 
   if showsegments[]
@@ -44,7 +44,7 @@ end
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
   # retrieve parameters
-  showsegments = plot[:showsegments]
+  showsegments = plot.showsegments
 
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
@@ -63,7 +63,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     map(x -> ustrip.(x), Meshes.xyz(grid))
   end
 
-  if plot[:nc][] == plot[:nv][]
+  if plot.nc[] == plot.nv[]
     # visualize as a quadrangle mesh so that
     # colors can be specified at vertices
     Makie.map!(plot, [:object], :verts) do grid
@@ -88,7 +88,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
       )
     end
     Makie.map!(GB.Mesh, plot, [:verts, :quads], :mesh)
-    Makie.mesh!(plot, plot[:mesh], color=plot[:colorant], shading=true)
+    Makie.mesh!(plot, plot.mesh, color=plot.colorant, shading=true)
   else
     # visualize as built-in meshscatter
     Makie.map!(plot, [:xyz], :coords) do xyz
@@ -100,7 +100,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     Makie.map!(plot, [:sp], :rect) do sp
       Makie.Rect3(-1 .* sp, sp)
     end
-    Makie.meshscatter!(plot, plot[:coords], marker=plot[:rect], markersize=1, color=plot[:colorant])
+    Makie.meshscatter!(plot, plot.coords, marker=plot.rect, markersize=1, color=plot.colorant)
   end
 
   if showsegments[]
@@ -109,25 +109,25 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   Makie.map!(plot, [:object], [:facets_x, :facets_y]) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
 
-  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.facets_x, plot.facets_y, color=segmentcolor, linewidth=segmentsize)
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   Makie.map!(plot, [:object], [:facets_x, :facets_y, :facets_z]) do grid
     x, y, z = Meshes.xyz(grid)
     xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
   end
 
-  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], plot[:facets_z], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.facets_x, plot.facets_y, plot.facets_z, color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -55,14 +55,6 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     colorant isa AbstractVector ? length(colorant) : 1
   end
 
-  # spacing and coordinates
-  Makie.map!(plot, [:object], :sp) do grid
-    ustrip.(spacing(grid))
-  end
-  Makie.map!(plot, [:object], :xyz) do grid
-    map(x -> ustrip.(x), Meshes.xyz(grid))
-  end
-
   if plot.nc[] == plot.nv[]
     # visualize as a quadrangle mesh so that
     # colors can be specified at vertices
@@ -91,14 +83,15 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     Makie.mesh!(plot, plot.mesh, color=plot.colorant, shading=true)
   else
     # visualize as built-in meshscatter
-    Makie.map!(plot, [:xyz], :coords) do xyz
+    Makie.map!(plot, [:object], [:coords, :rect]) do grid
+      xyz = map(x -> ustrip.(x), Meshes.xyz(grid))
       xs = xyz[1][(begin + 1):end]
       ys = xyz[2][(begin + 1):end]
       zs = xyz[3][(begin + 1):end]
-      [(x, y, z) for z in zs for y in ys for x in xs]
-    end
-    Makie.map!(plot, [:sp], :rect) do sp
-      Makie.Rect3(-1 .* sp, sp)
+      coords = [(x, y, z) for z in zs for y in ys for x in xs]
+      sp = ustrip.(spacing(grid))
+      rect = Makie.Rect3(-1 .* sp, sp)
+      (coords, rect)
     end
     Makie.meshscatter!(plot, plot.coords, marker=plot.rect, markersize=1, color=plot.colorant)
   end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -40,19 +40,18 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
   # number of vertices and colors
-  Makie.map!(nvertices, plot, [:object], :nv)
-  Makie.map!(plot, [:colorant], :nc) do colorant
-    colorant isa AbstractVector ? length(colorant) : 1
+  Makie.map!(plot, [:object, :colorant], [:nv, :nc]) do grid, colorant
+    nv = nvertices(grid)
+    nc = colorant isa AbstractVector ? length(colorant) : 1
+    nv, nc
   end
 
   if plot.nc[] == plot.nv[]
     # visualize as a quadrangle mesh so that
     # colors can be specified at vertices
-    Makie.map!(plot, [:object], :verts) do grid
-      map(asmakie, eachvertex(grid))
-    end
-    Makie.map!(plot, [:object], :quads) do grid
-      reduce(
+    Makie.map!(plot, :object, :mesh) do grid
+      verts = map(asmakie, eachvertex(grid))
+      quads = reduce(
         vcat,
         map(elements(topology(grid))) do elem
           i1, i2, i3, i4, i5, i6, i7, i8 = indices(elem)
@@ -68,8 +67,8 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
           ]
         end
       )
+      GB.Mesh(verts, quads)
     end
-    Makie.map!(GB.Mesh, plot, [:verts, :quads], :mesh)
     Makie.mesh!(plot, plot.mesh, color=plot.colorant, shading=true)
   else
     # visualize as built-in meshscatter

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -70,7 +70,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     Makie.mesh!(plot, plot.mesh, color=plot.colorant, shading=true)
   else
     # visualize as built-in meshscatter
-    Makie.map!(plot, :object, [:xyz, :rect]) do grid
+    Makie.map!(plot, :object, [:xyz, :rec]) do grid
       sp = ustrip.(spacing(grid))
       xs, ys, zs = map(Meshes.xyz(grid)) do c
         ustrip.(c[(begin + 1):end])

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -6,7 +6,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
-  # compute coordinates and color matrix
+  # visualize as built-in image with or without interpolation
   Makie.map!(plot, [:object, :colorant], [:x, :y, :C, :interpolate]) do grid, colorant
     sz = size(grid)
     nv = nvertices(grid)
@@ -26,8 +26,6 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
 
     x, y, C, (nc == nv)
   end
-
-  # visualize as built-in image with or without interpolation
   Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=plot.interpolate)
 
   if plot.showsegments[]

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -20,7 +20,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
     x, y = Meshes.xyz(grid)
     xₛ, xₑ = extrema(ustrip.(x))
     yₛ, yₑ = extrema(ustrip.(y))
-    [(xₛ, xₑ), (yₛ, yₑ)]
+    ((xₛ, xₑ), (yₛ, yₑ))
   end
 
   if plot[:nc][] == plot[:nv][]

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -70,7 +70,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
     Makie.mesh!(plot, plot.mesh, color=plot.colorant, shading=true)
   else
     # visualize as built-in meshscatter
-    Makie.map!(plot, [:object], [:xyz, :rect]) do grid
+    Makie.map!(plot, :object, [:xyz, :rect]) do grid
       sp = ustrip.(spacing(grid))
       cs = map(x -> ustrip.(x), Meshes.xyz(grid))
       xs = cs[1][(begin + 1):end]
@@ -89,7 +89,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, :
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  Makie.map!(plot, [:object], [:xfacets, :yfacets]) do grid
+  Makie.map!(plot, :object, [:xfacets, :yfacets]) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
@@ -97,7 +97,7 @@ function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
-  Makie.map!(plot, [:object], [:xfacets, :yfacets, :zfacets]) do grid
+  Makie.map!(plot, :object, [:xfacets, :yfacets, :zfacets]) do grid
     x, y, z = Meshes.xyz(grid)
     xyzsegments(ustrip.(x), ustrip.(y), ustrip.(z))
   end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -3,9 +3,6 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  # process color spec into colorant
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-
   # visualize as built-in image with or without interpolation
   Makie.map!(plot, [:object, :colorant], [:x, :y, :C, :interpolate]) do grid, colorant
     sz = size(grid)
@@ -34,9 +31,6 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
 end
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{3}, ::Val{3})
-  # process color spec into colorant
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-
   # number of vertices and colors
   Makie.map!(plot, [:object, :colorant], [:nv, :nc]) do grid, colorant
     nv = nvertices(grid)

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -16,14 +16,9 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
     end
 
     # grid coordinates
-    Makie.map!(plot, [:object], :xyz) do grid
-      map(x -> ustrip.(x), Meshes.xyz(grid))
-    end
-    Makie.map!(plot, [:xyz], :xs) do xyz
-      xyz[1]
-    end
-    Makie.map!(plot, [:xyz], :ys) do xyz
-      xyz[2]
+    Makie.map!(plot, [:object], [:xs, :ys]) do grid
+      xs, ys, _ = map(x -> ustrip.(x), Meshes.xyz(grid))
+      [xs, ys]
     end
 
     if plot[:nc][] == plot[:nv][]
@@ -51,15 +46,9 @@ function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::V
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  Makie.map!(plot, [:object], :facets_xy) do grid
-    x, y = Meshes.xyz(grid)
+  Makie.map!(plot, [:object], [:facets_x, :facets_y]) do grid
+    x, y, _ = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
-  end
-  Makie.map!(plot, [:facets_xy], :facets_x) do xy
-    xy[1]
-  end
-  Makie.map!(plot, [:facets_xy], :facets_y) do xy
-    xy[2]
   end
 
   Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -17,8 +17,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
 
     # grid coordinates
     Makie.map!(plot, [:object], [:xs, :ys]) do grid
-      xs, ys, _ = map(x -> ustrip.(x), Meshes.xyz(grid))
-      [xs, ys]
+      map(x -> ustrip.(x), Meshes.xyz(grid))
     end
 
     if plot[:nc][] == plot[:nv][]
@@ -47,7 +46,7 @@ function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::V
   segmentsize = plot[:segmentsize]
 
   Makie.map!(plot, [:object], [:facets_x, :facets_y]) do grid
-    x, y, _ = Meshes.xyz(grid)
+    x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
 

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -42,7 +42,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  Makie.map!(plot, [:object], [:xfacets, :yfacets]) do grid
+  Makie.map!(plot, :object, [:xfacets, :yfacets]) do grid
     x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
     xysegments(x, y)
   end

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -20,10 +20,10 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
       vizmesh!(plot)
     else
       # visualize as built-in heatmap
-      Makie.map!(plot, [:object, :colorant, :nc], [:x, :y, :C]) do grid, colorant, nc
+      Makie.map!(plot, [:object, :colorant], [:x, :y, :C]) do grid, colorant
         sz = size(grid)
         x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
-        C = if nc == 1
+        C = if plot.nc[] == 1
           fill(colorant, sz)
         else
           reshape(colorant, sz)

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -3,36 +3,37 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
-  showsegments = plot.showsegments
-
   if crs(plot.object[]) <: Cartesian
     # process color spec into colorant
     Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
     # number of vertices and colors
-    Makie.map!(nvertices, plot, [:object], :nv)
-    Makie.map!(plot, [:colorant], :nc) do colorant
-      colorant isa AbstractVector ? length(colorant) : 1
+    Makie.map!(plot, [:object, :colorant], [:nv, :nc]) do grid, colorant
+      nv = nvertices(grid)
+      nc = colorant isa AbstractVector ? length(colorant) : 1
+      nv, nc
     end
 
-    # grid coordinates
-    Makie.map!(plot, [:object], [:x, :y]) do grid
-      map(x -> ustrip.(x), Meshes.xyz(grid))
-    end
     if plot.nc[] == plot.nv[]
       # visualize as a simple mesh so that
       # colors can be specified at vertices
       vizmesh!(plot)
     else
       # visualize as built-in heatmap
-      Makie.map!(size, plot, [:object], :sz)
-      Makie.map!(plot, [:nc, :colorant, :sz], :C) do nc, colorant, sz
-        nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
+      Makie.map!(plot, [:object, :colorant, :nc], [:x, :y, :C]) do grid, colorant, nc
+        sz = size(grid)
+        x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
+        C = if nc == 1
+          fill(colorant, sz)
+        else
+          reshape(colorant, sz)
+        end
+        x, y, C
       end
       Makie.heatmap!(plot, plot.x, plot.y, plot.C)
     end
 
-    if showsegments[]
+    if plot.showsegments[]
       vizfacets!(plot)
     end
   else
@@ -41,13 +42,9 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
   Makie.map!(plot, [:object], [:xfacets, :yfacets]) do grid
-    x, y = Meshes.xyz(grid)
-    xysegments(ustrip.(x), ustrip.(y))
+    x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
+    xysegments(x, y)
   end
-
-  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -16,7 +16,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
     end
 
     # grid coordinates
-    Makie.map!(plot, [:object], [:xs, :ys]) do grid
+    Makie.map!(plot, [:object], [:x, :y]) do grid
       map(x -> ustrip.(x), Meshes.xyz(grid))
     end
     if plot.nc[] == plot.nv[]
@@ -29,7 +29,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
       Makie.map!(plot, [:nc, :colorant, :sz], :C) do nc, colorant, sz
         nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
       end
-      Makie.heatmap!(plot, plot.xs, plot.ys, plot.C)
+      Makie.heatmap!(plot, plot.x, plot.y, plot.C)
     end
 
     if showsegments[]
@@ -44,10 +44,10 @@ function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::V
   segmentcolor = plot.segmentcolor
   segmentsize = plot.segmentsize
 
-  Makie.map!(plot, [:object], [:facets_x, :facets_y]) do grid
+  Makie.map!(plot, [:object], [:xfacets, :yfacets]) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
 
-  Makie.lines!(plot, plot.facets_x, plot.facets_y, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -51,16 +51,16 @@ function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::V
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  Makie.map!(plot, [:object], :xy) do grid
+  Makie.map!(plot, [:object], :facets_xy) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
-  Makie.map!(plot, [:xy], :x) do xy
+  Makie.map!(plot, [:facets_xy], :facets_x) do xy
     xy[1]
   end
-  Makie.map!(plot, [:xy], :y) do xy
+  Makie.map!(plot, [:facets_xy], :facets_y) do xy
     xy[2]
   end
 
-  Makie.lines!(plot, plot[:x], plot[:y], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -4,9 +4,6 @@
 
 function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
   if crs(plot.object[]) <: Cartesian
-    # process color spec into colorant
-    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-
     # number of vertices and colors
     Makie.map!(plot, [:object, :colorant], [:nv, :nc]) do grid, colorant
       nv = nvertices(grid)

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -16,14 +16,10 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
       vizmesh!(plot)
     else
       # visualize as built-in heatmap
-      Makie.map!(plot, [:object, :colorant, :nc], [:x, :y, :C]) do grid, colorant, nc
+      Makie.map!(plot, [:object, :colorant], [:x, :y, :C]) do grid, colorant
         sz = size(grid)
         x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
-        C = if nc == 1
-          fill(colorant, sz)
-        else
-          reshape(colorant, sz)
-        end
+        C = colorant isa AbstractVector ? reshape(colorant, sz) : fill(colorant, sz)
         x, y, C
       end
       Makie.heatmap!(plot, plot.x, plot.y, plot.C)

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -3,35 +3,40 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
   showsegments = plot[:showsegments]
 
-  if crs(grid[]) <: Cartesian
+  if crs(plot[:object][]) <: Cartesian
     # process color spec into colorant
-    colorant = Makie.@lift process($color, $colormap, $colorrange, $alpha)
+    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
     # number of vertices and colors
-    nv = Makie.@lift nvertices($grid)
-    nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+    Makie.map!(nvertices, plot, [:object], :nv)
+    Makie.map!(plot, [:colorant], :nc) do colorant
+      colorant isa AbstractVector ? length(colorant) : 1
+    end
 
     # grid coordinates
-    xyz = Makie.@lift map(x -> ustrip.(x), Meshes.xyz($grid))
-    xs = Makie.@lift $xyz[1]
-    ys = Makie.@lift $xyz[2]
+    Makie.map!(plot, [:object], :xyz) do grid
+      map(x -> ustrip.(x), Meshes.xyz(grid))
+    end
+    Makie.map!(plot, [:xyz], :xs) do xyz
+      xyz[1]
+    end
+    Makie.map!(plot, [:xyz], :ys) do xyz
+      xyz[2]
+    end
 
-    if nc[] == nv[]
+    if plot[:nc][] == plot[:nv][]
       # visualize as a simple mesh so that
       # colors can be specified at vertices
       vizmesh!(plot)
     else
       # visualize as built-in heatmap
-      sz = Makie.@lift size($grid)
-      C = Makie.@lift $nc == 1 ? fill($colorant, $sz) : reshape($colorant, $sz)
-      Makie.heatmap!(plot, xs, ys, C)
+      Makie.map!(size, plot, [:object], :sz)
+      Makie.map!(plot, [:nc, :colorant, :sz], :C) do nc, colorant, sz
+        nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
+      end
+      Makie.heatmap!(plot, plot[:xs], plot[:ys], plot[:C])
     end
 
     if showsegments[]
@@ -43,16 +48,19 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  grid = plot[:object]
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  xy = Makie.@lift let
-    x, y = Meshes.xyz($grid)
+  Makie.map!(plot, [:object], :xy) do grid
+    x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
-  x = Makie.@lift $xy[1]
-  y = Makie.@lift $xy[2]
+  Makie.map!(plot, [:xy], :x) do xy
+    xy[1]
+  end
+  Makie.map!(plot, [:xy], :y) do xy
+    xy[2]
+  end
 
-  Makie.lines!(plot, x, y, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:x], plot[:y], color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -16,10 +16,10 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
       vizmesh!(plot)
     else
       # visualize as built-in heatmap
-      Makie.map!(plot, [:object, :colorant], [:x, :y, :C]) do grid, colorant
+      Makie.map!(plot, [:object, :colorant, :nc], [:x, :y, :C]) do grid, colorant, nc
         sz = size(grid)
         x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
-        C = if plot.nc[] == 1
+        C = if nc == 1
           fill(colorant, sz)
         else
           reshape(colorant, sz)

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -12,8 +12,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
     end
 
     if plot.nc[] == plot.nv[]
-      # visualize as a simple mesh so that
-      # colors can be specified at vertices
+      # visualize as simple mesh
       vizmesh!(plot)
     else
       # visualize as built-in heatmap

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -3,9 +3,9 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
-  showsegments = plot[:showsegments]
+  showsegments = plot.showsegments
 
-  if crs(plot[:object][]) <: Cartesian
+  if crs(plot.object[]) <: Cartesian
     # process color spec into colorant
     Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
@@ -19,8 +19,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
     Makie.map!(plot, [:object], [:xs, :ys]) do grid
       map(x -> ustrip.(x), Meshes.xyz(grid))
     end
-
-    if plot[:nc][] == plot[:nv][]
+    if plot.nc[] == plot.nv[]
       # visualize as a simple mesh so that
       # colors can be specified at vertices
       vizmesh!(plot)
@@ -30,7 +29,7 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
       Makie.map!(plot, [:nc, :colorant, :sz], :C) do nc, colorant, sz
         nc == 1 ? fill(colorant, sz) : reshape(colorant, sz)
       end
-      Makie.heatmap!(plot, plot[:xs], plot[:ys], plot[:C])
+      Makie.heatmap!(plot, plot.xs, plot.ys, plot.C)
     end
 
     if showsegments[]
@@ -42,13 +41,13 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{RectilinearGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   Makie.map!(plot, [:object], [:facets_x, :facets_y]) do grid
     x, y = Meshes.xyz(grid)
     xysegments(ustrip.(x), ustrip.(y))
   end
 
-  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.facets_x, plot.facets_y, color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -51,14 +51,14 @@ function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Va
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  Makie.map!(structuredsegments, plot, [:object], :tup)
-  Makie.map!(plot, [:tup], :x) do tup
+  Makie.map!(structuredsegments, plot, [:object], :facets_tup)
+  Makie.map!(plot, [:facets_tup], :facets_x) do tup
     tup[1]
   end
-  Makie.map!(plot, [:tup], :y) do tup
+  Makie.map!(plot, [:facets_tup], :facets_y) do tup
     tup[2]
   end
-  Makie.lines!(plot, plot[:x], plot[:y], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
 end
 
 function structuredsegments(grid)

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -3,34 +3,27 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
-  showsegments = plot.showsegments
-
   if crs(plot.object[]) <: Cartesian
     # process color spec into colorant
     Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
     # number of vertices and colors
-    Makie.map!(nvertices, plot, [:object], :nv)
-    Makie.map!(plot, [:colorant], :nc) do colorant
-      colorant isa AbstractVector ? length(colorant) : 1
+    Makie.map!(plot, [:object, :colorant], [:nv, :nc]) do grid, colorant
+      nv = nvertices(grid)
+      nc = colorant isa AbstractVector ? length(colorant) : 1
+      nv, nc
     end
 
     if plot.nc[] == plot.nv[]
-      # size and coordinates
-      Makie.map!(plot, [:object], :sz) do grid
-        size(grid) .+ 1
-      end
-      Makie.map!(plot, [:object], [:X, :Y]) do grid
-        map(X -> ustrip.(X), Meshes.XYZ(grid))
-      end
-
       # visualize as built-in surface
-      Makie.map!(plot, [:colorant, :sz], :C) do colorant, sz
-        reshape(colorant, sz)
+      Makie.map!(plot, [:object, :colorant], [:X, :Y, :C]) do grid, colorant
+        X, Y = map(c -> ustrip.(c), Meshes.XYZ(grid))
+        C = reshape(colorant, Meshes.vsize(grid))
+        X, Y, C
       end
       Makie.surface!(plot, plot.X, plot.Y, color=plot.C)
 
-      if showsegments[]
+      if plot.showsegments[]
         vizfacets!(plot)
       end
     else
@@ -42,11 +35,8 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
   Makie.map!(structuredsegments, plot, [:object], [:xfacets, :yfacets])
-  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end
 
 function structuredsegments(grid)

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -21,8 +21,7 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
         size(grid) .+ 1
       end
       Makie.map!(plot, [:object], [:X, :Y]) do grid
-        x, y, _ = map(X -> ustrip.(X), Meshes.XYZ(grid))
-        [x, y]
+        map(X -> ustrip.(X), Meshes.XYZ(grid))
       end
 
       # visualize as built-in surface
@@ -48,7 +47,7 @@ function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Va
 
   Makie.map!(structuredsegments, plot, [:object], :facets_tup)
   Makie.map!(plot, [:facets_tup], [:facets_x, :facets_y]) do tup
-    [tup[1], tup[2]]
+    (tup[1], tup[2])
   end
   Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -4,9 +4,6 @@
 
 function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
   if crs(plot.object[]) <: Cartesian
-    # process color spec into colorant
-    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-
     # number of vertices and colors
     Makie.map!(plot, [:object, :colorant], [:nv, :nc]) do grid, colorant
       nv = nvertices(grid)

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -3,31 +3,38 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
-  grid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
   showsegments = plot[:showsegments]
 
-  if crs(grid[]) <: Cartesian
+  if crs(plot[:object][]) <: Cartesian
     # process color spec into colorant
-    colorant = Makie.@lift process($color, $colormap, $colorrange, $alpha)
+    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
     # number of vertices and colors
-    nv = Makie.@lift nvertices($grid)
-    nc = Makie.@lift $colorant isa AbstractVector ? length($colorant) : 1
+    Makie.map!(nvertices, plot, [:object], :nv)
+    Makie.map!(plot, [:colorant], :nc) do colorant
+      colorant isa AbstractVector ? length(colorant) : 1
+    end
 
-    if nc[] == nv[]
+    if plot[:nc][] == plot[:nv][]
       # size and coordinates
-      sz = Makie.@lift size($grid) .+ 1
-      XYZ = Makie.@lift map(X -> ustrip.(X), Meshes.XYZ($grid))
-      X = Makie.@lift $XYZ[1]
-      Y = Makie.@lift $XYZ[2]
+      Makie.map!(plot, [:object], :sz) do grid
+        size(grid) .+ 1
+      end
+      Makie.map!(plot, [:object], :XYZ) do grid
+        map(X -> ustrip.(X), Meshes.XYZ(grid))
+      end
+      Makie.map!(plot, [:XYZ], :X) do XYZ
+        XYZ[1]
+      end
+      Makie.map!(plot, [:XYZ], :Y) do XYZ
+        XYZ[2]
+      end
 
       # visualize as built-in surface
-      C = Makie.@lift reshape($colorant, $sz)
-      Makie.surface!(plot, X, Y, color=C)
+      Makie.map!(plot, [:colorant, :sz], :C) do colorant, sz
+        reshape(colorant, sz)
+      end
+      Makie.surface!(plot, plot[:X], plot[:Y], color=plot[:C])
 
       if showsegments[]
         vizfacets!(plot)
@@ -41,13 +48,17 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  grid = plot[:object]
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
-  tup = Makie.@lift structuredsegments($grid)
-  x, y = Makie.@lift($tup[1]), Makie.@lift($tup[2])
-  Makie.lines!(plot, x, y, color=segmentcolor, linewidth=segmentsize)
+  Makie.map!(structuredsegments, plot, [:object], :tup)
+  Makie.map!(plot, [:tup], :x) do tup
+    tup[1]
+  end
+  Makie.map!(plot, [:tup], :y) do tup
+    tup[2]
+  end
+  Makie.lines!(plot, plot[:x], plot[:y], color=segmentcolor, linewidth=segmentsize)
 end
 
 function structuredsegments(grid)

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -3,9 +3,9 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val{2}, edim::Val{2})
-  showsegments = plot[:showsegments]
+  showsegments = plot.showsegments
 
-  if crs(plot[:object][]) <: Cartesian
+  if crs(plot.object[]) <: Cartesian
     # process color spec into colorant
     Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
@@ -15,7 +15,7 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
       colorant isa AbstractVector ? length(colorant) : 1
     end
 
-    if plot[:nc][] == plot[:nv][]
+    if plot.nc[] == plot.nv[]
       # size and coordinates
       Makie.map!(plot, [:object], :sz) do grid
         size(grid) .+ 1
@@ -28,7 +28,7 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
       Makie.map!(plot, [:colorant, :sz], :C) do colorant, sz
         reshape(colorant, sz)
       end
-      Makie.surface!(plot, plot[:X], plot[:Y], color=plot[:C])
+      Makie.surface!(plot, plot.X, plot.Y, color=plot.C)
 
       if showsegments[]
         vizfacets!(plot)
@@ -42,14 +42,14 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   Makie.map!(structuredsegments, plot, [:object], :facets_tup)
   Makie.map!(plot, [:facets_tup], [:facets_x, :facets_y]) do tup
     (tup[1], tup[2])
   end
-  Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.facets_x, plot.facets_y, color=segmentcolor, linewidth=segmentsize)
 end
 
 function structuredsegments(grid)

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -45,11 +45,8 @@ function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Va
   segmentcolor = plot.segmentcolor
   segmentsize = plot.segmentsize
 
-  Makie.map!(structuredsegments, plot, [:object], :facets_tup)
-  Makie.map!(plot, [:facets_tup], [:facets_x, :facets_y]) do tup
-    (tup[1], tup[2])
-  end
-  Makie.lines!(plot, plot.facets_x, plot.facets_y, color=segmentcolor, linewidth=segmentsize)
+  Makie.map!(structuredsegments, plot, [:object], [:xfacets, :yfacets])
+  Makie.lines!(plot, plot.xfacets, plot.yfacets, color=segmentcolor, linewidth=segmentsize)
 end
 
 function structuredsegments(grid)

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -24,6 +24,7 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
         vizfacets!(plot)
       end
     else
+      # visualize as simple mesh
       vizmesh!(plot)
     end
   else

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -35,7 +35,7 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
 end
 
 function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
-  Makie.map!(structuredsegments, plot, [:object], [:xfacets, :yfacets])
+  Makie.map!(structuredsegments, plot, :object, [:xfacets, :yfacets])
   Makie.lines!(plot, plot.xfacets, plot.yfacets, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end
 

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -20,14 +20,9 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
       Makie.map!(plot, [:object], :sz) do grid
         size(grid) .+ 1
       end
-      Makie.map!(plot, [:object], :XYZ) do grid
-        map(X -> ustrip.(X), Meshes.XYZ(grid))
-      end
-      Makie.map!(plot, [:XYZ], :X) do XYZ
-        XYZ[1]
-      end
-      Makie.map!(plot, [:XYZ], :Y) do XYZ
-        XYZ[2]
+      Makie.map!(plot, [:object], [:X, :Y]) do grid
+        x, y, _ = map(X -> ustrip.(X), Meshes.XYZ(grid))
+        [x, y]
       end
 
       # visualize as built-in surface
@@ -52,11 +47,8 @@ function vizgridfacets!(plot::Viz{<:Tuple{StructuredGrid}}, ::Type{<:𝔼}, ::Va
   segmentsize = plot[:segmentsize]
 
   Makie.map!(structuredsegments, plot, [:object], :facets_tup)
-  Makie.map!(plot, [:facets_tup], :facets_x) do tup
-    tup[1]
-  end
-  Makie.map!(plot, [:facets_tup], :facets_y) do tup
-    tup[2]
+  Makie.map!(plot, [:facets_tup], [:facets_x, :facets_y]) do tup
+    [tup[1], tup[2]]
   end
   Makie.lines!(plot, plot[:facets_x], plot[:facets_y], color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -9,7 +9,7 @@ function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Va
   if isoptimized(plot.trans[])
     # visualize parent grid and transform visualization
     pgrid = parent(plot.object[])
-    Makie.update!(plot, object = pgrid)
+    Makie.update!(plot, object=pgrid)
     vizgrid!(plot)
     makietransform!(plot)
   else

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -3,22 +3,18 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Val, edim::Val)
-  color = plot.color
-  alpha = plot.alpha
-  colormap = plot.colormap
-  colorrange = plot.colorrange
-  showsegments = plot.showsegments
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
-  # retrieve transformation
-  Makie.map!(Meshes.transform, plot, :object, :trans)
+  # parent grid and transformation
+  Makie.map!(plot, :object, [:pgrid, :trans]) do grid
+    pgrid = parent(grid)
+    trans = transformation(grid)
+    pgrid, trans
+  end
 
   if isoptimized(plot.trans[])
     # visualize parent grid and transform visualization
-    Makie.map!(parent, plot, :object, :grid)
-    viz!(plot, plot.grid; color, alpha, colormap, colorrange, showsegments, segmentcolor, segmentsize)
-    makietransform!(plot, plot.trans[])
+    plot.object = plot.pgrid
+    vizgrid!(plot)
+    makietransform!(plot)
   else
     # fallback to full grid visualization
     vizgridfallback!(plot, M, pdim, edim)
@@ -39,6 +35,8 @@ function isoptimized(t::Affine{2})
 end
 isoptimized(::TB.Identity) = true
 isoptimized(t::TB.SequentialTransform) = all(isoptimized, t)
+
+makietransform!(plot) = makietransform!(plot, plot.trans[])
 
 function makietransform!(plot, trans::Rotate{<:Angle2d})
   rot = first(TB.parameters(trans))

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -3,16 +3,13 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Val, edim::Val)
-  # parent grid and transformation
-  Makie.map!(plot, :object, [:pgrid, :trans]) do grid
-    pgrid = parent(grid)
-    trans = transformation(grid)
-    pgrid, trans
-  end
+  # retrieve transformation
+  Makie.map!(transformation, plot, :object, :trans)
 
   if isoptimized(plot.trans[])
     # visualize parent grid and transform visualization
-    plot.object = plot.pgrid
+    pgrid = parent(plot.object[])
+    Makie.update!(plot, object = pgrid)
     vizgrid!(plot)
     makietransform!(plot)
   else

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -3,21 +3,21 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Val, edim::Val)
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
-  showsegments = plot[:showsegments]
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  color = plot.color
+  alpha = plot.alpha
+  colormap = plot.colormap
+  colorrange = plot.colorrange
+  showsegments = plot.showsegments
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   # retrieve transformation
   Makie.map!(Meshes.transform, plot, [:object], :trans)
 
-  if isoptimized(plot[:trans][]) # visualize parent grid and transform visualization
+  if isoptimized(plot.trans[]) # visualize parent grid and transform visualization
     Makie.map!(parent, plot, [:object], :grid)
-    viz!(plot, plot[:grid]; color, alpha, colormap, colorrange, showsegments, segmentcolor, segmentsize)
-    makietransform!(plot, plot[:trans][])
+    viz!(plot, plot.grid; color, alpha, colormap, colorrange, showsegments, segmentcolor, segmentsize)
+    makietransform!(plot, plot.trans[])
   else # fallback to full grid visualization
     vizgridfallback!(plot, M, pdim, edim)
   end

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -3,14 +3,26 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Val, edim::Val)
-  # retrieve transformation
-  Makie.map!(transformation, plot, :object, :trans)
+  # retrieve parent grid and transformation
+  Makie.map!(plot, :object, [:pgrid, :trans]) do tgrid
+    pgrid = parent(tgrid)
+    trans = transformation(tgrid)
+    pgrid, trans
+  end
 
   if isoptimized(plot.trans[])
     # visualize parent grid and transform visualization
-    pgrid = parent(plot.object[])
-    Makie.update!(plot, object=pgrid)
-    vizgrid!(plot)
+    viz!(
+      plot,
+      plot.pgrid,
+      color=plot.color,
+      alpha=plot.alpha,
+      colormap=plot.colormap,
+      colorrange=plot.colorrange,
+      showsegments=plot.showsegments,
+      segmentcolor=plot.segmentcolor,
+      segmentsize=plot.segmentsize
+    )
     makietransform!(plot)
   else
     # fallback to full grid visualization

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -12,13 +12,15 @@ function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Va
   segmentsize = plot.segmentsize
 
   # retrieve transformation
-  Makie.map!(Meshes.transform, plot, [:object], :trans)
+  Makie.map!(Meshes.transform, plot, :object, :trans)
 
-  if isoptimized(plot.trans[]) # visualize parent grid and transform visualization
-    Makie.map!(parent, plot, [:object], :grid)
+  if isoptimized(plot.trans[])
+    # visualize parent grid and transform visualization
+    Makie.map!(parent, plot, :object, :grid)
     viz!(plot, plot.grid; color, alpha, colormap, colorrange, showsegments, segmentcolor, segmentsize)
     makietransform!(plot, plot.trans[])
-  else # fallback to full grid visualization
+  else
+    # fallback to full grid visualization
     vizgridfallback!(plot, M, pdim, edim)
   end
 end

--- a/ext/grid/transformed.jl
+++ b/ext/grid/transformed.jl
@@ -3,7 +3,6 @@
 # ------------------------------------------------------------------
 
 function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Val, edim::Val)
-  tgrid = plot[:object]
   color = plot[:color]
   alpha = plot[:alpha]
   colormap = plot[:colormap]
@@ -13,12 +12,12 @@ function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Va
   segmentsize = plot[:segmentsize]
 
   # retrieve transformation
-  trans = Makie.@lift Meshes.transform($tgrid)
+  Makie.map!(Meshes.transform, plot, [:object], :trans)
 
-  if isoptimized(trans[]) # visualize parent grid and transform visualization
-    grid = Makie.@lift parent($tgrid)
-    viz!(plot, grid; color, alpha, colormap, colorrange, showsegments, segmentcolor, segmentsize)
-    makietransform!(plot, trans)
+  if isoptimized(plot[:trans][]) # visualize parent grid and transform visualization
+    Makie.map!(parent, plot, [:object], :grid)
+    viz!(plot, plot[:grid]; color, alpha, colormap, colorrange, showsegments, segmentcolor, segmentsize)
+    makietransform!(plot, plot[:trans][])
   else # fallback to full grid visualization
     vizgridfallback!(plot, M, pdim, edim)
   end
@@ -39,24 +38,24 @@ end
 isoptimized(::TB.Identity) = true
 isoptimized(t::TB.SequentialTransform) = all(isoptimized, t)
 
-function makietransform!(plot, trans::Makie.Observable{<:Rotate{<:Angle2d}})
-  rot = first(TB.parameters(trans[]))
+function makietransform!(plot, trans::Rotate{<:Angle2d})
+  rot = first(TB.parameters(trans))
   θ = first(Rotations.params(rot))
   Makie.rotate!(plot, θ)
 end
 
-function makietransform!(plot, trans::Makie.Observable{<:Translate})
-  offsets = first(TB.parameters(trans[]))
+function makietransform!(plot, trans::Translate)
+  offsets = first(TB.parameters(trans))
   Makie.translate!(plot, ustrip.(offsets)...)
 end
 
-function makietransform!(plot, trans::Makie.Observable{<:Scale})
-  factors = first(TB.parameters(trans[]))
+function makietransform!(plot, trans::Scale)
+  factors = first(TB.parameters(trans))
   Makie.scale!(plot, factors...)
 end
 
-function makietransform!(plot, trans::Makie.Observable{<:Affine{2}})
-  A, b = TB.parameters(trans[])
+function makietransform!(plot, trans::Affine{2})
+  A, b = TB.parameters(trans)
   if isdiag(A)
     s₁, s₂ = A[1, 1], A[2, 2]
     Makie.scale!(plot, s₁, s₂)
@@ -68,7 +67,6 @@ function makietransform!(plot, trans::Makie.Observable{<:Affine{2}})
   Makie.translate!(plot, ustrip.(b)...)
 end
 
-makietransform!(plot, trans::Makie.Observable{<:TB.Identity}) = nothing
+makietransform!(plot, trans::TB.Identity) = nothing
 
-makietransform!(plot, trans::Makie.Observable{<:TB.SequentialTransform}) =
-  foreach(t -> makietransform!(plot, Makie.Observable(t)), trans[])
+makietransform!(plot, trans::TB.SequentialTransform) = foreach(t -> makietransform!(plot, t), trans)

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -2,17 +2,16 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-Makie.plot!(plot::Viz{<:Tuple{Mesh}}) = vizmesh!(plot)
+function Makie.plot!(plot::Viz{<:Tuple{Mesh}})
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  vizmesh!(plot)
+end
 
 function vizmesh!(plot)
   mesh = plot.object[]
   M = manifold(mesh)
   pdim = paramdim(mesh)
   edim = embeddim(mesh)
-
-  # process color spec into colorant
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-
   vizmesh!(plot, M, Val(pdim), Val(edim))
 end
 

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -5,71 +5,82 @@
 Makie.plot!(plot::Viz{<:Tuple{Mesh}}) = vizmesh!(plot)
 
 function vizmesh!(plot)
-  # retrieve mesh and plot attributes
-  mesh = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
+  mesh = plot[:object][]
 
   # retrieve manifold and dimensions
-  M = Makie.@lift manifold($mesh)
-  pdim = Makie.@lift paramdim($mesh)
-  edim = Makie.@lift embeddim($mesh)
+  M = manifold(mesh)
+  pdim = paramdim(mesh)
+  edim = embeddim(mesh)
 
   # process color spec into colorant
-  colorant = Makie.@lift process($color, $colormap, $colorrange, $alpha)
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
-  vizmesh!(plot, M[], Val(pdim[]), Val(edim[]), mesh, colorant)
+  vizmesh!(plot, M, Val(pdim), Val(edim))
 end
 
 # ---------------
 # IMPLEMENTATION
 # ---------------
 
-function vizmesh!(plot, ::Type, ::Val{1}, ::Val, mesh, colorant)
+function vizmesh!(plot, ::Type, ::Val{1}, ::Val)
   segmentsize = plot[:segmentsize]
 
-  colors = Makie.@lift $colorant isa AbstractVector ? $colorant : fill($colorant, nelements($mesh))
+  Makie.map!(plot, [:colorant, :object], :colors) do colorant, mesh
+    colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
+  end
 
   # retrieve coordinates of vertices
-  xyzs = Makie.@lift map(p -> ustrip.(to(p)), vertices($mesh))
+  Makie.map!(plot, [:object], :xyzs) do mesh
+    map(p -> ustrip.(to(p)), vertices(mesh))
+  end
 
   # retrieve connectivities of segments
-  inds = Makie.@lift map(collect ∘ indices, elements(topology($mesh)))
+  Makie.map!(plot, [:object], :inds) do mesh
+    map(collect ∘ indices, elements(topology(mesh)))
+  end
 
   # extract coordinates and colors of segments
-  scoords = Makie.@lift [$xyzs[indsₑ] for indsₑ in $inds]
-  scolors = Makie.@lift [fill($colors[e], length(indsₑ)) for (e, indsₑ) in enumerate($inds)]
+  Makie.map!(plot, [:xyzs, :inds], :scoords) do xyzs, inds
+    [xyzs[indsₑ] for indsₑ in inds]
+  end
+
+  Makie.map!(plot, [:colors, :inds], :scolors) do colors, inds
+    [fill(colors[e], length(indsₑ)) for (e, indsₑ) in enumerate(inds)]
+  end
 
   # sentinel coordinates
-  nan = Makie.@lift let
-    v = first($xyzs)
+  Makie.map!(plot, [:xyzs], :nan) do xyzs
+    v = first(xyzs)
     typeof(v)(ntuple(i -> NaN, length(v)))
   end
 
   # splice sentinel coordinates to get discrete colors
-  lcoords = Makie.@lift reduce((xyz₁, xyz₂) -> [xyz₁; [$nan]; xyz₂], $scoords)
-  lcolors = Makie.@lift reduce((col₁, col₂) -> [col₁; [first(col₁)]; col₂], $scolors)
+  Makie.map!(plot, [:scoords, :nan], :lcoords) do scoords, nan
+    reduce((xyz₁, xyz₂) -> [xyz₁; [nan]; xyz₂], scoords)
+  end
+
+  Makie.map!(plot, [:scolors], :lcolors) do scolors
+    reduce((col₁, col₂) -> [col₁; [first(col₁)]; col₂], scolors)
+  end
 
   # visualize segments
-  Makie.lines!(plot, lcoords, color=lcolors, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:lcoords], color=plot[:lcolors], linewidth=segmentsize)
 end
 
-function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
+function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
   showsegments = plot[:showsegments]
 
   # retrieve triangle mesh parameters
-  tparams = Makie.@lift let
+  Makie.map!(plot, [:object, :colorant], :tparams) do mesh, colorant
     # relevant settings
-    edim = embeddim($mesh)
-    nvert = nvertices($mesh)
-    nelem = nelements($mesh)
-    verts = map(asmakie, eachvertex($mesh))
-    elems = elements(topology($mesh))
+    edim = embeddim(mesh)
+    nvert = nvertices(mesh)
+    nelem = nelements(mesh)
+    verts = map(asmakie, eachvertex(mesh))
+    elems = elements(topology(mesh))
 
     # decide whether or not to reverse connectivity list
-    rfunc = crs($mesh) <: LatLon && orientation(first($mesh)) == CW ? reverse : identity
+    rfunc = crs(mesh) <: LatLon && orientation(first(mesh)) == CW ? reverse : identity
 
     # fan triangulation (assume convexity)
     ntri = sum(e -> nvertices(pltype(e)) - 2, elems)
@@ -84,8 +95,8 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
     end
 
     # element vs. vertex coloring
-    if $colorant isa AbstractVector
-      ncolor = length($colorant)
+    if colorant isa AbstractVector
+      ncolor = length(colorant)
       if ncolor == nelem # element coloring
         # duplicate vertices and adjust
         # connectivities to avoid linear
@@ -105,7 +116,7 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
         tcolors = map(1:nv) do i
           t = ceil(Int, i / 3)
           e = elem4tri[t]
-          $colorant[e]
+          colorant[e]
         end
       elseif ncolor == nvert # vertex coloring
         # nothing needs to be done because
@@ -115,7 +126,7 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
         # the original polygonal mesh
         tverts = verts
         telems = tris
-        tcolors = $colorant
+        tcolors = colorant
       else
         throw(ArgumentError("Provided $ncolor colors but the mesh has
                             $nvert vertices and $nelem elements."))
@@ -124,7 +135,7 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
       # nothing needs to be done
       tverts = verts
       telems = tris
-      tcolors = $colorant
+      tcolors = colorant
     end
 
     # enable shading in 3D
@@ -134,26 +145,30 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
   end
 
   # unpack observable of parameters
-  tverts = Makie.@lift $tparams[1]
-  telems = Makie.@lift $tparams[2]
-  tcolors = Makie.@lift $tparams[3]
-  tshading = Makie.@lift $tparams[4]
+  Makie.map!(plot, [:tparams], :tverts) do tparams; tparams[1] end
+  Makie.map!(plot, [:tparams], :telems) do tparams; tparams[2] end
+  Makie.map!(plot, [:tparams], :tcolors) do tparams; tparams[3] end
+  Makie.map!(plot, [:tparams], :tshading) do tparams; tparams[4] end
 
   # Makie's triangle mesh
-  mkemesh = Makie.@lift GB.Mesh($tverts, $telems)
+  Makie.map!(GB.Mesh, plot, [:tverts, :telems], :mkemesh)
 
   # main visualization
-  Makie.mesh!(plot, mkemesh, color=tcolors, shading=tshading)
+  Makie.mesh!(plot, plot[:mkemesh], color=plot[:tcolors], shading=plot[:tshading])
 
   if showsegments[]
     vizfacets!(plot)
   end
 end
 
-function vizmesh!(plot, ::Type, ::Val{3}, ::Val, mesh, colorant)
-  meshes = Makie.@lift map(discretize ∘ boundary, $mesh)
-  colors = Makie.@lift $colorant isa AbstractVector ? $colorant : fill($colorant, nelements($mesh))
-  vizmany!(plot, meshes, colors)
+function vizmesh!(plot, ::Type, ::Val{3}, ::Val)
+  Makie.map!(plot, [:object], :meshes) do mesh
+    map(discretize ∘ boundary, mesh)
+  end
+  Makie.map!(plot, [:colorant, :object], :colors) do colorant, mesh
+    colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
+  end
+  vizmany!(plot, plot[:meshes], plot[:colors])
 end
 
 # -------
@@ -161,27 +176,26 @@ end
 # -------
 
 function vizfacets!(plot::Viz{<:Tuple{Mesh}})
-  mesh = plot[:object]
-  M = Makie.@lift manifold($mesh)
-  pdim = Makie.@lift paramdim($mesh)
-  edim = Makie.@lift embeddim($mesh)
-  vizmeshfacets!(plot, M[], Val(pdim[]), Val(edim[]))
+  mesh = plot[:object][]
+  M = manifold(mesh)
+  pdim = paramdim(mesh)
+  edim = embeddim(mesh)
+  vizmeshfacets!(plot, M, Val(pdim), Val(edim))
 end
 
 function vizmeshfacets!(plot, ::Type, ::Val{2}, ::Val)
-  mesh = plot[:object]
   segmentcolor = plot[:segmentcolor]
   segmentsize = plot[:segmentsize]
 
   # retrieve raw coordinates
-  coords = Makie.@lift let
+  Makie.map!(plot, [:object], :coords) do mesh
     # relevant settings
-    ℒ = Meshes.lentype($mesh)
+    ℒ = Meshes.lentype(mesh)
     T = Unitful.numtype(ℒ)
-    edim = embeddim($mesh)
-    topo = topology($mesh)
-    nvert = nvertices($mesh)
-    verts = vertices($mesh)
+    edim = embeddim(mesh)
+    topo = topology(mesh)
+    nvert = nvertices(mesh)
+    verts = vertices(mesh)
 
     # extract coordinates and insert sentinel
     # vertex with NaN coordinates at the end
@@ -216,5 +230,5 @@ function vizmeshfacets!(plot, ::Type, ::Val{2}, ::Val)
     xyz[inds]
   end
 
-  Makie.lines!(plot, coords, color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot[:coords], color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -136,12 +136,18 @@ function vizmesh!(plot, ::Type, ::Val{2}, edim::Val)
 end
 
 function vizmesh!(plot, ::Type, ::Val{3}, ::Val)
-  Makie.map!(plot, [:object, :colorant], [:meshes, :colors]) do mesh, colorant
+  Makie.map!(plot, [:object, :colorant], [:bmesh, :bcolor]) do mesh, colorant
+    # discretize boundaries of elements
     meshes = map(discretize ∘ boundary, mesh)
     colors = colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
-    meshes, colors
+
+    # merge into single boundary mesh
+    bmesh =  reduce(merge, meshes)
+    bcolor = [colors[i] for (i, m) in enumerate(meshes) for _ in 1:nelements(m)]
+
+    bmesh, bcolor
   end
-  vizmany!(plot, plot.meshes, plot.colors)
+  viz!(plot, plot.bmesh, color=plot.bcolor)
 end
 
 # -------

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -146,7 +146,7 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
 
   # unpack observable of parameters
   Makie.map!(plot, [:tparams], [:tverts, :telems, :tcolors, :tshading]) do tparams
-    tparams[1], tparams[2], tparams[3], tparams[4]
+    (tparams[1], tparams[2], tparams[3], tparams[4])
   end
 
   # Makie's triangle mesh

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{Mesh}})
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  colorant!(plot)
   vizmesh!(plot)
 end
 

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -6,8 +6,6 @@ Makie.plot!(plot::Viz{<:Tuple{Mesh}}) = vizmesh!(plot)
 
 function vizmesh!(plot)
   mesh = plot.object[]
-
-  # retrieve manifold and dimensions
   M = manifold(mesh)
   pdim = paramdim(mesh)
   edim = embeddim(mesh)
@@ -23,53 +21,37 @@ end
 # ---------------
 
 function vizmesh!(plot, ::Type, ::Val{1}, ::Val)
-  segmentsize = plot.segmentsize
+  # compute line segment coordinates and colors
+  Makie.map!(plot, [:object, :colorant], [:lcoords, :lcolors]) do mesh, colorant
+    # retrieve colors of segments
+    colors = colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
 
-  Makie.map!(plot, [:colorant, :object], :colors) do colorant, mesh
-    colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
+    # retrieve coordinates of vertices
+    xyzs = map(p -> ustrip.(to(p)), vertices(mesh))
+
+    # retrieve connectivities of segments
+    inds = map(collect ∘ indices, elements(topology(mesh)))
+
+    # sentinel coordinates
+    xyz = first(xyzs)
+    nan = typeof(xyz)(ntuple(i -> NaN, length(xyz)))
+
+    # extract coordinates and colors of segments
+    scoords = [xyzs[indsₑ] for indsₑ in inds]
+    scolors = [fill(colors[e], length(indsₑ)) for (e, indsₑ) in enumerate(inds)]
+
+    # splice sentinel coordinates to get discrete colors
+    lcoords = reduce((xyz₁, xyz₂) -> [xyz₁; [nan]; xyz₂], scoords)
+    lcolors = reduce((col₁, col₂) -> [col₁; [first(col₁)]; col₂], scolors)
+
+    lcoords, lcolors
   end
 
-  # retrieve coordinates of vertices
-  Makie.map!(plot, [:object], :xyzs) do mesh
-    map(p -> ustrip.(to(p)), vertices(mesh))
-  end
-
-  # retrieve connectivities of segments
-  Makie.map!(plot, [:object], :inds) do mesh
-    map(collect ∘ indices, elements(topology(mesh)))
-  end
-
-  # extract coordinates and colors of segments
-  Makie.map!(plot, [:xyzs, :inds], :scoords) do xyzs, inds
-    [xyzs[indsₑ] for indsₑ in inds]
-  end
-
-  Makie.map!(plot, [:colors, :inds], :scolors) do colors, inds
-    [fill(colors[e], length(indsₑ)) for (e, indsₑ) in enumerate(inds)]
-  end
-
-  # sentinel coordinates
-  Makie.map!(plot, [:xyzs], :nan) do xyzs
-    v = first(xyzs)
-    typeof(v)(ntuple(i -> NaN, length(v)))
-  end
-
-  # splice sentinel coordinates to get discrete colors
-  Makie.map!(plot, [:scoords, :nan], :lcoords) do scoords, nan
-    reduce((xyz₁, xyz₂) -> [xyz₁; [nan]; xyz₂], scoords)
-  end
-
-  Makie.map!(plot, [:scolors], :lcolors) do scolors
-    reduce((col₁, col₂) -> [col₁; [first(col₁)]; col₂], scolors)
-  end
-
-  # visualize segments
-  Makie.lines!(plot, plot.lcoords, color=plot.lcolors, linewidth=segmentsize)
+  # visualize as built-in lines
+  Makie.lines!(plot, plot.lcoords, color=plot.lcolors, linewidth=plot.segmentsize)
 end
 
 function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
-  showsegments = plot.showsegments
-
   # retrieve triangle mesh parameters
   Makie.map!(plot, [:object, :colorant], :tparams) do mesh, colorant
     # relevant settings
@@ -80,14 +62,14 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
     elems = elements(topology(mesh))
 
     # decide whether or not to reverse connectivity list
-    rfunc = crs(mesh) <: LatLon && orientation(first(mesh)) == CW ? reverse : identity
+    rev = crs(mesh) <: LatLon && orientation(first(mesh)) == CW ? reverse : identity
 
     # fan triangulation (assume convexity)
     ntri = sum(e -> nvertices(pltype(e)) - 2, elems)
     tris = Vector{GB.TriangleFace{Int}}(undef, ntri)
     tind = 0
     for elem in elems
-      I = rfunc(indices(elem))
+      I = rev(indices(elem))
       for i in 2:(length(I) - 1)
         tind += 1
         tris[tind] = GB.TriangleFace(I[1], I[i], I[i + 1])
@@ -155,7 +137,7 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
   # main visualization
   Makie.mesh!(plot, plot.mkemesh, color=plot.tcolors, shading=plot.tshading)
 
-  if showsegments[]
+  if plot.showsegments[]
     vizfacets!(plot)
   end
 end

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -5,7 +5,7 @@
 Makie.plot!(plot::Viz{<:Tuple{Mesh}}) = vizmesh!(plot)
 
 function vizmesh!(plot)
-  mesh = plot[:object][]
+  mesh = plot.object[]
 
   # retrieve manifold and dimensions
   M = manifold(mesh)
@@ -23,7 +23,7 @@ end
 # ---------------
 
 function vizmesh!(plot, ::Type, ::Val{1}, ::Val)
-  segmentsize = plot[:segmentsize]
+  segmentsize = plot.segmentsize
 
   Makie.map!(plot, [:colorant, :object], :colors) do colorant, mesh
     colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
@@ -64,11 +64,11 @@ function vizmesh!(plot, ::Type, ::Val{1}, ::Val)
   end
 
   # visualize segments
-  Makie.lines!(plot, plot[:lcoords], color=plot[:lcolors], linewidth=segmentsize)
+  Makie.lines!(plot, plot.lcoords, color=plot.lcolors, linewidth=segmentsize)
 end
 
 function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
-  showsegments = plot[:showsegments]
+  showsegments = plot.showsegments
 
   # retrieve triangle mesh parameters
   Makie.map!(plot, [:object, :colorant], :tparams) do mesh, colorant
@@ -153,7 +153,7 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
   Makie.map!(GB.Mesh, plot, [:tverts, :telems], :mkemesh)
 
   # main visualization
-  Makie.mesh!(plot, plot[:mkemesh], color=plot[:tcolors], shading=plot[:tshading])
+  Makie.mesh!(plot, plot.mkemesh, color=plot.tcolors, shading=plot.tshading)
 
   if showsegments[]
     vizfacets!(plot)
@@ -167,7 +167,7 @@ function vizmesh!(plot, ::Type, ::Val{3}, ::Val)
   Makie.map!(plot, [:colorant, :object], :colors) do colorant, mesh
     colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
   end
-  vizmany!(plot, plot[:meshes], plot[:colors])
+  vizmany!(plot, plot.meshes, plot.colors)
 end
 
 # -------
@@ -175,7 +175,7 @@ end
 # -------
 
 function vizfacets!(plot::Viz{<:Tuple{Mesh}})
-  mesh = plot[:object][]
+  mesh = plot.object[]
   M = manifold(mesh)
   pdim = paramdim(mesh)
   edim = embeddim(mesh)
@@ -183,8 +183,8 @@ function vizfacets!(plot::Viz{<:Tuple{Mesh}})
 end
 
 function vizmeshfacets!(plot, ::Type, ::Val{2}, ::Val)
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
+  segmentcolor = plot.segmentcolor
+  segmentsize = plot.segmentsize
 
   # retrieve raw coordinates
   Makie.map!(plot, [:object], :coords) do mesh
@@ -229,5 +229,5 @@ function vizmeshfacets!(plot, ::Type, ::Val{2}, ::Val)
     xyz[inds]
   end
 
-  Makie.lines!(plot, plot[:coords], color=segmentcolor, linewidth=segmentsize)
+  Makie.lines!(plot, plot.coords, color=segmentcolor, linewidth=segmentsize)
 end

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -21,7 +21,7 @@ end
 # ---------------
 
 function vizmesh!(plot, ::Type, ::Val{1}, ::Val)
-  # compute line segment coordinates and colors
+  # retrieve segment coordinates and colors
   Makie.map!(plot, [:object, :colorant], [:lcoords, :lcolors]) do mesh, colorant
     # retrieve colors of segments
     colors = colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
@@ -51,11 +51,10 @@ function vizmesh!(plot, ::Type, ::Val{1}, ::Val)
   Makie.lines!(plot, plot.lcoords, color=plot.lcolors, linewidth=plot.segmentsize)
 end
 
-function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
-  # retrieve triangle mesh parameters
-  Makie.map!(plot, [:object, :colorant], :tparams) do mesh, colorant
+function vizmesh!(plot, ::Type, ::Val{2}, edim::Val)
+  # compute triangle mesh and colors
+  Makie.map!(plot, [:object, :colorant], [:tmesh, :tcolors]) do mesh, colorant
     # relevant settings
-    edim = embeddim(mesh)
     nvert = nvertices(mesh)
     nelem = nelements(mesh)
     verts = map(asmakie, eachvertex(mesh))
@@ -110,8 +109,8 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
         telems = tris
         tcolors = colorant
       else
-        throw(ArgumentError("Provided $ncolor colors but the mesh has
-                            $nvert vertices and $nelem elements."))
+        throw(ArgumentError("provided $ncolor colors but the mesh has
+                             $nvert vertices and $nelem elements."))
       end
     else # single color
       # nothing needs to be done
@@ -120,22 +119,17 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
       tcolors = colorant
     end
 
-    # enable shading in 3D
-    tshading = edim == 3
+    # triangle mesh
+    tmesh = GB.Mesh(tverts, telems)
 
-    tverts, telems, tcolors, tshading
+    tmesh, tcolors
   end
 
-  # unpack observable of parameters
-  Makie.map!(plot, [:tparams], [:tverts, :telems, :tcolors, :tshading]) do tparams
-    (tparams[1], tparams[2], tparams[3], tparams[4])
-  end
+  # enable shading in 3D
+  shading = edim == Val(3)
 
-  # Makie's triangle mesh
-  Makie.map!(GB.Mesh, plot, [:tverts, :telems], :mkemesh)
-
-  # main visualization
-  Makie.mesh!(plot, plot.mkemesh, color=plot.tcolors, shading=plot.tshading)
+  # visualize as triangle mesh
+  Makie.mesh!(plot, plot.tmesh, color=plot.tcolors, shading=shading)
 
   if plot.showsegments[]
     vizfacets!(plot)
@@ -143,11 +137,10 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
 end
 
 function vizmesh!(plot, ::Type, ::Val{3}, ::Val)
-  Makie.map!(plot, [:object], :meshes) do mesh
-    map(discretize ∘ boundary, mesh)
-  end
-  Makie.map!(plot, [:colorant, :object], :colors) do colorant, mesh
-    colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
+  Makie.map!(plot, [:object, :colorant], [:meshes, :colors]) do mesh, colorant
+    meshes = map(discretize ∘ boundary, mesh)
+    colors = colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
+    meshes, colors
   end
   vizmany!(plot, plot.meshes, plot.colors)
 end
@@ -165,11 +158,8 @@ function vizfacets!(plot::Viz{<:Tuple{Mesh}})
 end
 
 function vizmeshfacets!(plot, ::Type, ::Val{2}, ::Val)
-  segmentcolor = plot.segmentcolor
-  segmentsize = plot.segmentsize
-
   # retrieve raw coordinates
-  Makie.map!(plot, [:object], :coords) do mesh
+  Makie.map!(plot, :object, :coords) do mesh
     # relevant settings
     ℒ = Meshes.lentype(mesh)
     T = Unitful.numtype(ℒ)
@@ -211,5 +201,6 @@ function vizmeshfacets!(plot, ::Type, ::Val{2}, ::Val)
     xyz[inds]
   end
 
-  Makie.lines!(plot, plot.coords, color=segmentcolor, linewidth=segmentsize)
+  # visualize as built-in lines
+  Makie.lines!(plot, plot.coords, color=plot.segmentcolor, linewidth=plot.segmentsize)
 end

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -142,7 +142,7 @@ function vizmesh!(plot, ::Type, ::Val{3}, ::Val)
     colors = colorant isa AbstractVector ? colorant : fill(colorant, nelements(mesh))
 
     # merge into single boundary mesh
-    bmesh =  reduce(merge, meshes)
+    bmesh = reduce(merge, meshes)
     bcolor = [colors[i] for (i, m) in enumerate(meshes) for _ in 1:nelements(m)]
 
     bmesh, bcolor

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -145,10 +145,18 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
   end
 
   # unpack observable of parameters
-  Makie.map!(plot, [:tparams], :tverts) do tparams; tparams[1] end
-  Makie.map!(plot, [:tparams], :telems) do tparams; tparams[2] end
-  Makie.map!(plot, [:tparams], :tcolors) do tparams; tparams[3] end
-  Makie.map!(plot, [:tparams], :tshading) do tparams; tparams[4] end
+  Makie.map!(plot, [:tparams], :tverts) do tparams
+    tparams[1]
+  end
+  Makie.map!(plot, [:tparams], :telems) do tparams
+    tparams[2]
+  end
+  Makie.map!(plot, [:tparams], :tcolors) do tparams
+    tparams[3]
+  end
+  Makie.map!(plot, [:tparams], :tshading) do tparams
+    tparams[4]
+  end
 
   # Makie's triangle mesh
   Makie.map!(GB.Mesh, plot, [:tverts, :telems], :mkemesh)

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -145,17 +145,8 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val)
   end
 
   # unpack observable of parameters
-  Makie.map!(plot, [:tparams], :tverts) do tparams
-    tparams[1]
-  end
-  Makie.map!(plot, [:tparams], :telems) do tparams
-    tparams[2]
-  end
-  Makie.map!(plot, [:tparams], :tcolors) do tparams
-    tparams[3]
-  end
-  Makie.map!(plot, [:tparams], :tshading) do tparams
-    tparams[4]
+  Makie.map!(plot, [:tparams], [:tverts, :telems, :tcolors, :tshading]) do tparams
+    tparams[1], tparams[2], tparams[3], tparams[4]
   end
 
   # Makie's triangle mesh

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -3,38 +3,39 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
-  # collect geometries into geometry set
-  Makie.map!(plot, :object, :gset) do subdom
-    GeometrySet(collect(subdom))
-  end
+  # retrieve parent domain
+  Makie.map!(parent, plot, :object, :pdom)
 
-  # visualize as geometry set
-  viz!(
-    plot,
-    plot.gset,
-    color=plot.color,
-    alpha=plot.alpha,
-    colormap=plot.colormap,
-    colorrange=plot.colorrange,
-    showsegments=plot.showsegments,
-    segmentcolor=plot.segmentcolor,
-    segmentsize=plot.segmentsize,
-    showpoints=plot.showpoints,
-    pointmarker=plot.pointmarker,
-    pointcolor=plot.pointcolor,
-    pointsize=plot.pointsize
-  )
+  if plot.pdom[] isa CartesianGrid
+    # visualize with optimized method
+    colorant!(plot)
+    vizsubcartgrid!(plot)
+  else
+    # fallback to geometry set visualization
+    Makie.map!(sdom -> convert(GeometrySet, sdom), plot, :object, :gset)
+    viz!(
+      plot,
+      plot.gset,
+      color=plot.color,
+      alpha=plot.alpha,
+      colormap=plot.colormap,
+      colorrange=plot.colorrange,
+      showsegments=plot.showsegments,
+      segmentcolor=plot.segmentcolor,
+      segmentsize=plot.segmentsize,
+      showpoints=plot.showpoints,
+      pointmarker=plot.pointmarker,
+      pointcolor=plot.pointcolor,
+      pointsize=plot.pointsize
+    )
+  end
 end
 
 # ----------------
 # SPECIALIZATIONS
 # ----------------
 
-const SubCartesianGrid{M,CRS} = SubDomain{M,CRS,<:CartesianGrid}
-
-function Makie.plot!(plot::Viz{<:Tuple{SubCartesianGrid}})
-  colorant!(plot)
-
+function vizsubcartgrid!(plot)
   # retrieve grid paramaters
   Makie.map!(plot, :object, [:scoords, :smarker]) do subgrid
     grid = parent(subgrid)

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -33,7 +33,7 @@ end
 const SubCartesianGrid{M,CRS} = SubDomain{M,CRS,<:CartesianGrid}
 
 function Makie.plot!(plot::Viz{<:Tuple{SubCartesianGrid}})
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  colorant!(plot)
 
   # retrieve grid paramaters
   Makie.map!(plot, :object, [:scoords, :smarker]) do subgrid

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -84,10 +84,23 @@ function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val,
   end
 
   # unpack observable parameters
-  Makie.map!(plot, [:gparams], :coords) do gparams; gparams[1] end
-  Makie.map!(plot, [:gparams], :marker) do gparams; gparams[2] end
-  Makie.map!(plot, [:gparams], :shading) do gparams; gparams[3] end
+  Makie.map!(plot, [:gparams], :coords) do gparams
+    gparams[1]
+  end
+  Makie.map!(plot, [:gparams], :marker) do gparams
+    gparams[2]
+  end
+  Makie.map!(plot, [:gparams], :shading) do gparams
+    gparams[3]
+  end
 
   # all geometries are equal, use mesh scatter
-  Makie.meshscatter!(plot, plot[:coords], marker=plot[:marker], markersize=1, color=plot[:colorant], shading=plot[:shading])
+  Makie.meshscatter!(
+    plot,
+    plot[:coords],
+    marker=plot[:marker],
+    markersize=1,
+    color=plot[:colorant],
+    shading=plot[:shading]
+  )
 end

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -5,7 +5,7 @@
 Makie.plot!(plot::Viz{<:Tuple{SubDomain}}) = vizsubdom!(plot)
 
 function vizsubdom!(plot)
-  subdom = plot[:object][]
+  subdom = plot.object[]
   M = manifold(subdom)
   pdim = paramdim(subdom)
   edim = embeddim(subdom)
@@ -21,18 +21,6 @@ function vizsubdom!(plot, ::Type{<:🌐}, pdim::Val, edim::Val)
 end
 
 function vizsubdom!(plot, ::Type{<:𝔼}, ::Val, ::Val)
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
-  showsegments = plot[:showsegments]
-  segmentcolor = plot[:segmentcolor]
-  segmentsize = plot[:segmentsize]
-  showpoints = plot[:showpoints]
-  pointmarker = plot[:pointmarker]
-  pointcolor = plot[:pointcolor]
-  pointsize = plot[:pointsize]
-
   # construct the geometry set
   Makie.map!(plot, [:object], :gset) do subdom
     GeometrySet(collect(subdom))
@@ -41,18 +29,18 @@ function vizsubdom!(plot, ::Type{<:𝔼}, ::Val, ::Val)
   # forward attributes
   viz!(
     plot,
-    plot[:gset];
-    color,
-    alpha,
-    colormap,
-    colorrange,
-    showsegments,
-    segmentcolor,
-    segmentsize,
-    showpoints,
-    pointmarker,
-    pointcolor,
-    pointsize
+    plot.gset;
+    plot.color,
+    plot.alpha,
+    plot.colormap,
+    plot.colorrange,
+    plot.showsegments,
+    plot.segmentcolor,
+    plot.segmentsize,
+    plot.showpoints,
+    plot.pointmarker,
+    plot.pointcolor,
+    plot.pointsize
   )
 end
 
@@ -91,10 +79,10 @@ function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val,
   # all geometries are equal, use mesh scatter
   Makie.meshscatter!(
     plot,
-    plot[:coords],
-    marker=plot[:marker],
+    plot.coords,
+    marker=plot.marker,
     markersize=1,
-    color=plot[:colorant],
-    shading=plot[:shading]
+    color=plot.colorant,
+    shading=plot.shading
   )
 end

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -24,7 +24,7 @@ vizsubdom!(plot, M::Type, pdim::Val, edim::Val) = vizsubdomfallback!(plot, M, pd
 function vizsubdomfallback!(plot, ::Type, ::Val, ::Val)
   # visualize as geometry set
   gset = GeometrySet(collect(plot.object[]))
-  Mke.update!(plot, object=gset)
+  Makie.update!(plot, object=gset)
   vizgset!(plot)
 end
 

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -84,14 +84,8 @@ function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val,
   end
 
   # unpack observable parameters
-  Makie.map!(plot, [:gparams], :coords) do gparams
-    gparams[1]
-  end
-  Makie.map!(plot, [:gparams], :marker) do gparams
-    gparams[2]
-  end
-  Makie.map!(plot, [:gparams], :shading) do gparams
-    gparams[3]
+  Makie.map!(plot, [:gparams], [:coords, :marker, :shading]) do gparams
+    gparams[1], gparams[2], gparams[3]
   end
 
   # all geometries are equal, use mesh scatter

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -23,10 +23,8 @@ vizsubdom!(plot, M::Type, pdim::Val, edim::Val) = vizsubdomfallback!(plot, M, pd
 
 function vizsubdomfallback!(plot, ::Type, ::Val, ::Val)
   # visualize as geometry set
-  Makie.map!(plot, :object, :gset) do subdom
-    GeometrySet(collect(subdom))
-  end
-  plot.object = plot.gset
+  gset = GeometrySet(collect(plot.object[]))
+  Mke.update!(plot, object = gset)
   vizgset!(plot)
 end
 

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -2,7 +2,10 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-Makie.plot!(plot::Viz{<:Tuple{SubDomain}}) = vizsubdom!(plot)
+function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+  vizsubdom!(plot)
+end
 
 function vizsubdom!(plot)
   subdom = plot.object[]
@@ -16,40 +19,24 @@ end
 # IMPLEMENTATION
 # ---------------
 
-function vizsubdom!(plot, ::Type{<:🌐}, pdim::Val, edim::Val)
-  vizsubdom!(plot, 𝔼, pdim, edim)
-end
+vizsubdom!(plot, M::Type, pdim::Val, edim::Val) = vizsubdomfallback!(plot, M, pdim, edim)
 
-function vizsubdom!(plot, ::Type{<:𝔼}, ::Val, ::Val)
-  # construct geometry set
+function vizsubdomfallback!(plot, ::Type, ::Val, ::Val)
+  # visualize as geometry set
   Makie.map!(plot, :object, :gset) do subdom
     GeometrySet(collect(subdom))
   end
-
-  # forward attributes
-  viz!(
-    plot,
-    plot.gset;
-    plot.color,
-    plot.alpha,
-    plot.colormap,
-    plot.colorrange,
-    plot.showsegments,
-    plot.segmentcolor,
-    plot.segmentsize,
-    plot.showpoints,
-    plot.pointmarker,
-    plot.pointcolor,
-    plot.pointsize
-  )
+  plot.object = plot.gset
+  vizgset!(plot)
 end
+
+# ----------------
+# SPECIALIZATIONS
+# ----------------
 
 const SubCartesianGrid{M,CRS} = SubDomain{M,CRS,<:CartesianGrid}
 
-function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val, edim::Val)
-  # process color spec into colorant
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-
+function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type, ::Val, edim::Val)
   # retrieve grid paramaters
   Makie.map!(plot, :object, [:scoords, :smarker]) do subgrid
     grid = parent(subgrid)

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -21,8 +21,8 @@ function vizsubdom!(plot, ::Type{<:🌐}, pdim::Val, edim::Val)
 end
 
 function vizsubdom!(plot, ::Type{<:𝔼}, ::Val, ::Val)
-  # construct the geometry set
-  Makie.map!(plot, [:object], :gset) do subdom
+  # construct geometry set
+  Makie.map!(plot, :object, :gset) do subdom
     GeometrySet(collect(subdom))
   end
 
@@ -46,36 +46,29 @@ end
 
 const SubCartesianGrid{M,CRS} = SubDomain{M,CRS,<:CartesianGrid}
 
-function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val, ::Val)
-
+function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val, edim::Val)
   # process color spec into colorant
   Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
   # retrieve grid paramaters
-  Makie.map!(plot, [:object], :gparams) do subgrid
+  Makie.map!(plot, :object, [:scoords, :smarker]) do subgrid
     grid = parent(subgrid)
-    dim = embeddim(grid)
     sp = ustrip.(spacing(grid))
 
     # coordinates of markers
-    coords = map(subgrid) do e
+    scoords = map(subgrid) do e
       ustrip.(to(centroid(e))) .+ sp ./ 2
     end
 
     # rectangle markers
-    marker = Makie.Rect{dim}(-1 .* sp, sp)
+    smarker = Makie.Rect{length(sp)}(-1 .* sp, sp)
 
-    # enable shading in 3D
-    shading = dim == 3
-
-    coords, marker, shading
+    scoords, smarker
   end
 
-  # unpack observable parameters
-  Makie.map!(plot, [:gparams], [:coords, :marker, :shading]) do gparams
-    (gparams[1], gparams[2], gparams[3])
-  end
+  # enable shading in 3D
+  shading = edim == Val(3)
 
   # all geometries are equal, use mesh scatter
-  Makie.meshscatter!(plot, plot.coords, marker=plot.marker, markersize=1, color=plot.colorant, shading=plot.shading)
+  Makie.meshscatter!(plot, plot.scoords, marker=plot.smarker, markersize=1, color=plot.colorant, shading=shading)
 end

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -85,7 +85,7 @@ function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val,
 
   # unpack observable parameters
   Makie.map!(plot, [:gparams], [:coords, :marker, :shading]) do gparams
-    gparams[1], gparams[2], gparams[3]
+    (gparams[1], gparams[2], gparams[3])
   end
 
   # all geometries are equal, use mesh scatter

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -5,11 +5,11 @@
 Makie.plot!(plot::Viz{<:Tuple{SubDomain}}) = vizsubdom!(plot)
 
 function vizsubdom!(plot)
-  subdom = plot[:object]
-  M = Makie.@lift manifold($subdom)
-  pdim = Makie.@lift paramdim($subdom)
-  edim = Makie.@lift embeddim($subdom)
-  vizsubdom!(plot, M[], Val(pdim[]), Val(edim[]))
+  subdom = plot[:object][]
+  M = manifold(subdom)
+  pdim = paramdim(subdom)
+  edim = embeddim(subdom)
+  vizsubdom!(plot, M, Val(pdim), Val(edim))
 end
 
 # ---------------
@@ -21,7 +21,6 @@ function vizsubdom!(plot, ::Type{<:🌐}, pdim::Val, edim::Val)
 end
 
 function vizsubdom!(plot, ::Type{<:𝔼}, ::Val, ::Val)
-  subdom = plot[:object]
   color = plot[:color]
   alpha = plot[:alpha]
   colormap = plot[:colormap]
@@ -35,12 +34,14 @@ function vizsubdom!(plot, ::Type{<:𝔼}, ::Val, ::Val)
   pointsize = plot[:pointsize]
 
   # construct the geometry set
-  gset = Makie.@lift GeometrySet(collect($subdom))
+  Makie.map!(plot, [:object], :gset) do subdom
+    GeometrySet(collect(subdom))
+  end
 
   # forward attributes
   viz!(
     plot,
-    gset;
+    plot[:gset];
     color,
     alpha,
     colormap,
@@ -58,23 +59,18 @@ end
 const SubCartesianGrid{M,CRS} = SubDomain{M,CRS,<:CartesianGrid}
 
 function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val, ::Val)
-  subgrid = plot[:object]
-  color = plot[:color]
-  alpha = plot[:alpha]
-  colormap = plot[:colormap]
-  colorrange = plot[:colorrange]
 
   # process color spec into colorant
-  colorant = Makie.@lift process($color, $colormap, $colorrange, $alpha)
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
 
   # retrieve grid paramaters
-  gparams = Makie.@lift let
-    grid = parent($subgrid)
+  Makie.map!(plot, [:object], :gparams) do subgrid
+    grid = parent(subgrid)
     dim = embeddim(grid)
     sp = ustrip.(spacing(grid))
 
     # coordinates of markers
-    coords = map($subgrid) do e
+    coords = map(subgrid) do e
       ustrip.(to(centroid(e))) .+ sp ./ 2
     end
 
@@ -88,10 +84,10 @@ function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val,
   end
 
   # unpack observable parameters
-  coords = Makie.@lift $gparams[1]
-  marker = Makie.@lift $gparams[2]
-  shading = Makie.@lift $gparams[3]
+  Makie.map!(plot, [:gparams], :coords) do gparams; gparams[1] end
+  Makie.map!(plot, [:gparams], :marker) do gparams; gparams[2] end
+  Makie.map!(plot, [:gparams], :shading) do gparams; gparams[3] end
 
   # all geometries are equal, use mesh scatter
-  Makie.meshscatter!(plot, coords, marker=marker, markersize=1, color=colorant, shading=shading)
+  Makie.meshscatter!(plot, plot[:coords], marker=plot[:marker], markersize=1, color=plot[:colorant], shading=plot[:shading])
 end

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -10,21 +10,7 @@ function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
   else
     # visualize as geometry set
     Makie.map!(sdom -> GeometrySet(collect(sdom)), plot, :object, :gset)
-    viz!(
-      plot,
-      plot.gset,
-      color=plot.color,
-      alpha=plot.alpha,
-      colormap=plot.colormap,
-      colorrange=plot.colorrange,
-      showsegments=plot.showsegments,
-      segmentcolor=plot.segmentcolor,
-      segmentsize=plot.segmentsize,
-      showpoints=plot.showpoints,
-      pointmarker=plot.pointmarker,
-      pointcolor=plot.pointcolor,
-      pointsize=plot.pointsize
-    )
+    viz!(plot, plot.attributes, plot.gset)
   end
 end
 

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -7,11 +7,11 @@ function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
   Makie.map!(parent, plot, :object, :pdom)
 
   if plot.pdom[] isa CartesianGrid
-    # visualize with optimized method
+    # visualize as subset of Cartesian grid
     colorant!(plot)
     vizsubcartgrid!(plot)
   else
-    # fallback to geometry set visualization
+    # visualize as geometry set
     Makie.map!(sdom -> convert(GeometrySet, sdom), plot, :object, :gset)
     viz!(
       plot,
@@ -31,9 +31,9 @@ function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
   end
 end
 
-# ----------------
-# SPECIALIZATIONS
-# ----------------
+# --------------
+# OPTIMIZATIONS
+# --------------
 
 function vizsubcartgrid!(plot)
   # retrieve grid paramaters

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -37,25 +37,23 @@ end
 
 function vizsubcartgrid!(plot)
   # retrieve grid paramaters
-  Makie.map!(plot, :object, [:coords, :marker, :shading]) do sgrid
-    pgrid = parent(sgrid)
-    nd = embeddim(pgrid)
-    sp = ustrip.(spacing(pgrid))
+  Makie.map!(plot, :object, [:xyz, :rec]) do sgrid
+    sp = ustrip.(spacing(parent(sgrid)))
 
     # coordinates of markers
-    coords = map(sgrid) do e
+    xyz = map(sgrid) do e
       ustrip.(to(centroid(e))) .+ sp ./ 2
     end
 
     # rectangle markers
-    marker = Makie.Rect{length(sp)}(-1 .* sp, sp)
+    rec = Makie.Rect{length(sp)}(-1 .* sp, sp)
 
-    # enable shading in 3D
-    shading = nd == 3
-
-    coords, marker, shading
+    xyz, rec
   end
 
+  # enable shading in 3D
+  shading = embeddim(plot.object[]) == 3
+
   # all geometries are equal, use mesh scatter
-  Makie.meshscatter!(plot, plot.coords, marker=plot.marker, markersize=1, color=plot.colorant, shading=plot.shading)
+  Makie.meshscatter!(plot, plot.xyz, marker=plot.rec, markersize=1, color=plot.colorant, shading=shading)
 end

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -12,7 +12,7 @@ function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
     vizsubcartgrid!(plot)
   else
     # visualize as geometry set
-    Makie.map!(sdom -> convert(GeometrySet, sdom), plot, :object, :gset)
+    Makie.map!(sdom -> GeometrySet(collect(sdom)), plot, :object, :gset)
     viz!(
       plot,
       plot.gset,

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -3,29 +3,27 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
-  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
-  vizsubdom!(plot)
-end
+  # collect geometries into geometry set
+  Makie.map!(plot, :object, :gset) do subdom
+    GeometrySet(collect(subdom))
+  end
 
-function vizsubdom!(plot)
-  subdom = plot.object[]
-  M = manifold(subdom)
-  pdim = paramdim(subdom)
-  edim = embeddim(subdom)
-  vizsubdom!(plot, M, Val(pdim), Val(edim))
-end
-
-# ---------------
-# IMPLEMENTATION
-# ---------------
-
-vizsubdom!(plot, M::Type, pdim::Val, edim::Val) = vizsubdomfallback!(plot, M, pdim, edim)
-
-function vizsubdomfallback!(plot, ::Type, ::Val, ::Val)
   # visualize as geometry set
-  gset = GeometrySet(collect(plot.object[]))
-  Makie.update!(plot, object=gset)
-  vizgset!(plot)
+  viz!(
+    plot,
+    plot.gset,
+    color=plot.color,
+    alpha=plot.alpha,
+    colormap=plot.colormap,
+    colorrange=plot.colorrange,
+    showsegments=plot.showsegments,
+    segmentcolor=plot.segmentcolor,
+    segmentsize=plot.segmentsize,
+    showpoints=plot.showpoints,
+    pointmarker=plot.pointmarker,
+    pointcolor=plot.pointcolor,
+    pointsize=plot.pointsize
+  )
 end
 
 # ----------------
@@ -34,7 +32,9 @@ end
 
 const SubCartesianGrid{M,CRS} = SubDomain{M,CRS,<:CartesianGrid}
 
-function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type, ::Val, edim::Val)
+function Makie.plot!(plot::Viz{<:Tuple{SubCartesianGrid}})
+  Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+
   # retrieve grid paramaters
   Makie.map!(plot, :object, [:scoords, :smarker]) do subgrid
     grid = parent(subgrid)

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -77,12 +77,5 @@ function vizsubdom!(plot::Viz{<:Tuple{SubCartesianGrid}}, ::Type{<:𝔼}, ::Val,
   end
 
   # all geometries are equal, use mesh scatter
-  Makie.meshscatter!(
-    plot,
-    plot.coords,
-    marker=plot.marker,
-    markersize=1,
-    color=plot.colorant,
-    shading=plot.shading
-  )
+  Makie.meshscatter!(plot, plot.coords, marker=plot.marker, markersize=1, color=plot.colorant, shading=plot.shading)
 end

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -37,24 +37,25 @@ end
 
 function vizsubcartgrid!(plot)
   # retrieve grid paramaters
-  Makie.map!(plot, :object, [:scoords, :smarker]) do subgrid
-    grid = parent(subgrid)
-    sp = ustrip.(spacing(grid))
+  Makie.map!(plot, :object, [:coords, :marker, :shading]) do sgrid
+    pgrid = parent(sgrid)
+    nd = embeddim(pgrid)
+    sp = ustrip.(spacing(pgrid))
 
     # coordinates of markers
-    scoords = map(subgrid) do e
+    coords = map(sgrid) do e
       ustrip.(to(centroid(e))) .+ sp ./ 2
     end
 
     # rectangle markers
-    smarker = Makie.Rect{length(sp)}(-1 .* sp, sp)
+    marker = Makie.Rect{length(sp)}(-1 .* sp, sp)
 
-    scoords, smarker
+    # enable shading in 3D
+    shading = nd == 3
+
+    coords, marker, shading
   end
 
-  # enable shading in 3D
-  shading = edim == Val(3)
-
   # all geometries are equal, use mesh scatter
-  Makie.meshscatter!(plot, plot.scoords, marker=plot.smarker, markersize=1, color=plot.colorant, shading=shading)
+  Makie.meshscatter!(plot, plot.coords, marker=plot.marker, markersize=1, color=plot.colorant, shading=plot.shading)
 end

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -3,10 +3,7 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{SubDomain}})
-  # retrieve parent domain
-  Makie.map!(parent, plot, :object, :pdom)
-
-  if plot.pdom[] isa CartesianGrid
+  if parent(plot.object[]) isa CartesianGrid
     # visualize as subset of Cartesian grid
     colorant!(plot)
     vizsubcartgrid!(plot)

--- a/ext/subdomain.jl
+++ b/ext/subdomain.jl
@@ -24,7 +24,7 @@ vizsubdom!(plot, M::Type, pdim::Val, edim::Val) = vizsubdomfallback!(plot, M, pd
 function vizsubdomfallback!(plot, ::Type, ::Val, ::Val)
   # visualize as geometry set
   gset = GeometrySet(collect(plot.object[]))
-  Mke.update!(plot, object = gset)
+  Mke.update!(plot, object=gset)
   vizgset!(plot)
 end
 

--- a/ext/transfdomain.jl
+++ b/ext/transfdomain.jl
@@ -8,9 +8,7 @@ function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
 
   # add parent domain and transformation to compute graph
   Makie.map!(plot, :object, [:pdom, :trans]) do tdom
-    pdom = parent(tdom)
-    trans = transformation(tdom)
-    pdom, trans
+    parent(tdom), Meshes.transform(tdom)
   end
 
   if isoptimized(plot.trans[])

--- a/ext/transfdomain.jl
+++ b/ext/transfdomain.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
-  # retrieve parent domain and transformation
+  # add parent domain and transformation to compute graph
   Makie.map!(plot, :object, [:pdom, :trans]) do tdom
     pdom = parent(tdom)
     trans = transformation(tdom)
@@ -12,21 +12,7 @@ function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
 
   if isoptimized(plot.trans[])
     # visualize parent domain and transform visualization
-    viz!(
-      plot,
-      plot.pdom,
-      color=plot.color,
-      alpha=plot.alpha,
-      colormap=plot.colormap,
-      colorrange=plot.colorrange,
-      showsegments=plot.showsegments,
-      segmentcolor=plot.segmentcolor,
-      segmentsize=plot.segmentsize,
-      showpoints=plot.showpoints,
-      pointmarker=plot.pointmarker,
-      pointcolor=plot.pointcolor,
-      pointsize=plot.pointsize
-    )
+    viz!(plot, plot.attributes, plot.pdom)
     makietransform!(plot, plot.trans[])
   elseif plot.pdom[] isa Grid
     # visualize as grid

--- a/ext/transfdomain.jl
+++ b/ext/transfdomain.jl
@@ -27,7 +27,7 @@ function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
       pointcolor=plot.pointcolor,
       pointsize=plot.pointsize
     )
-    makietransform!(plot)
+    makietransform!(plot, plot.trans[])
   elseif plot.pdom[] isa Grid
     # visualize as grid
     colorant!(plot)
@@ -51,8 +51,6 @@ function isoptimized(t::Affine{2})
 end
 isoptimized(::TB.Identity) = true
 isoptimized(t::TB.SequentialTransform) = all(isoptimized, t)
-
-makietransform!(plot) = makietransform!(plot, plot.trans[])
 
 function makietransform!(plot, trans::Rotate{<:Angle2d})
   rot = first(TB.parameters(trans))

--- a/ext/transfdomain.jl
+++ b/ext/transfdomain.jl
@@ -3,6 +3,9 @@
 # ------------------------------------------------------------------
 
 function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
+  # add colorant to compute graph
+  colorant!(plot)
+
   # add parent domain and transformation to compute graph
   Makie.map!(plot, :object, [:pdom, :trans]) do tdom
     pdom = parent(tdom)
@@ -16,7 +19,6 @@ function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
     makietransform!(plot, plot.trans[])
   elseif plot.pdom[] isa Grid
     # visualize as grid
-    colorant!(plot)
     vizgrid!(plot)
   else
     error("not implemented")

--- a/ext/transfdomain.jl
+++ b/ext/transfdomain.jl
@@ -2,31 +2,38 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-function vizgrid!(plot::Viz{<:Tuple{TransformedGrid}}, M::Type{<:𝔼}, pdim::Val, edim::Val)
-  # retrieve parent grid and transformation
-  Makie.map!(plot, :object, [:pgrid, :trans]) do tgrid
-    pgrid = parent(tgrid)
-    trans = transformation(tgrid)
-    pgrid, trans
+function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
+  # retrieve parent domain and transformation
+  Makie.map!(plot, :object, [:pdom, :trans]) do tdom
+    pdom = parent(tdom)
+    trans = transformation(tdom)
+    pdom, trans
   end
 
   if isoptimized(plot.trans[])
-    # visualize parent grid and transform visualization
+    # visualize parent domain and transform visualization
     viz!(
       plot,
-      plot.pgrid,
+      plot.pdom,
       color=plot.color,
       alpha=plot.alpha,
       colormap=plot.colormap,
       colorrange=plot.colorrange,
       showsegments=plot.showsegments,
       segmentcolor=plot.segmentcolor,
-      segmentsize=plot.segmentsize
+      segmentsize=plot.segmentsize,
+      showpoints=plot.showpoints,
+      pointmarker=plot.pointmarker,
+      pointcolor=plot.pointcolor,
+      pointsize=plot.pointsize
     )
     makietransform!(plot)
+  elseif plot.pdom[] isa Grid
+    # visualize as grid
+    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+    vizgrid!(plot)
   else
-    # fallback to full grid visualization
-    vizgridfallback!(plot, M, pdim, edim)
+    error("not implemented")
   end
 end
 
@@ -79,3 +86,4 @@ end
 makietransform!(plot, trans::TB.Identity) = nothing
 
 makietransform!(plot, trans::TB.SequentialTransform) = foreach(t -> makietransform!(plot, t), trans)
+

--- a/ext/transfdomain.jl
+++ b/ext/transfdomain.jl
@@ -30,7 +30,7 @@ function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
     makietransform!(plot)
   elseif plot.pdom[] isa Grid
     # visualize as grid
-    Makie.map!(process, plot, [:color, :colormap, :colorrange, :alpha], :colorant)
+    colorant!(plot)
     vizgrid!(plot)
   else
     error("not implemented")
@@ -86,4 +86,3 @@ end
 makietransform!(plot, trans::TB.Identity) = nothing
 
 makietransform!(plot, trans::TB.SequentialTransform) = foreach(t -> makietransform!(plot, t), trans)
-

--- a/ext/transfdomain.jl
+++ b/ext/transfdomain.jl
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
+function Makie.plot!(plot::Viz{<:Tuple{TransformedGrid}})
   # add colorant to compute graph
   colorant!(plot)
 
@@ -15,11 +15,9 @@ function Makie.plot!(plot::Viz{<:Tuple{TransformedDomain}})
     # visualize parent domain and transform visualization
     viz!(plot, plot.attributes, plot.pdom)
     makietransform!(plot, plot.trans[])
-  elseif plot.pdom[] isa Grid
+  else
     # visualize as grid
     vizgrid!(plot)
-  else
-    error("not implemented")
   end
 end
 

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -13,18 +13,6 @@ function colorant!(plot)
   end
 end
 
-# assumes that meshes and colors have the same length
-function vizmany!(plot, meshes, colors)
-  meshid = Symbol(meshes, :_meshes)
-  colorid = Symbol(meshes, :_color)
-  Makie.map!(plot, [meshes, colors], [meshid, colorid]) do ms, cs
-    mesh = reduce(merge, ms)
-    color = [cs[i] for (i, m) in enumerate(ms) for _ in 1:nelements(m)]
-    mesh, color
-  end
-  viz!(plot, plot[meshid], color=plot[colorid], pointsize=plot.pointsize, segmentsize=plot.segmentsize)
-end
-
 asray(v::Vec) = Ray(Point(zero(v)...), v)
 
 asmakie(v::Vec) = Makie.Vec{length(v),numtype(eltype(v))}(Tuple(ustrip.(v)))

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -5,8 +5,8 @@
 # assumes that meshes and colors have the same length
 # and that colors are processed with alpha and colormap
 function vizmany!(plot, meshes, colors)
-  pointsize = plot[:pointsize]
-  segmentsize = plot[:segmentsize]
+  pointsize = plot.pointsize
+  segmentsize = plot.segmentsize
 
   rmesh = Makie.map(meshes) do ms
     reduce(merge, ms)

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -8,8 +8,12 @@ function vizmany!(plot, meshes, colors)
   pointsize = plot[:pointsize]
   segmentsize = plot[:segmentsize]
 
-  rmesh = Makie.@lift reduce(merge, $meshes)
-  color = Makie.@lift [$colors[i] for (i, m) in enumerate($meshes) for _ in 1:nelements(m)]
+  rmesh = Makie.map(meshes) do ms
+    reduce(merge, ms)
+  end
+  color = Makie.map(colors, meshes) do cs, ms
+    [cs[i] for (i, m) in enumerate(ms) for _ in 1:nelements(m)]
+  end
 
   viz!(plot, rmesh, color=color, pointsize=pointsize, segmentsize=segmentsize)
 end

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -2,9 +2,16 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-# preprocess colors provided by user
-process(values::AbstractVector, colorscheme, colorrange, alphas) = colorfy(values; alphas, colorscheme, colorrange)
-process(value, colorscheme, colorrange, alphas) = process([value], colorscheme, colorrange, alphas) |> first
+# update plot with processed colors
+function colorant!(plot)
+  Makie.map!(plot, [:color, :alpha, :colormap, :colorrange], :colorant) do color, alphas, colorscheme, colorrange
+    if color isa AbstractVector
+      colorfy(color; alphas, colorscheme, colorrange)
+    else
+      colorfy([color]; alphas, colorscheme, colorrange) |> first
+    end
+  end
+end
 
 # assumes that meshes and colors have the same length
 function vizmany!(plot, meshes, colors)

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -8,14 +8,16 @@ function vizmany!(plot, meshes, colors)
   pointsize = plot.pointsize
   segmentsize = plot.segmentsize
 
-  rmesh = Makie.map(meshes) do ms
-    reduce(merge, ms)
-  end
-  color = Makie.map(colors, meshes) do cs, ms
-    [cs[i] for (i, m) in enumerate(ms) for _ in 1:nelements(m)]
+  rmesh = Symbol(meshes, :_rmeshes)
+  rcolor = Symbol(meshes, :_rcolor)
+
+  Makie.map!(plot, [meshes, colors], [rmesh, rcolor]) do ms, cs
+    rmes = reduce(merge, ms)
+    color = [cs[i] for (i, m) in enumerate(ms) for _ in 1:nelements(m)]
+    (rmes, color)
   end
 
-  viz!(plot, rmesh, color=color, pointsize=pointsize, segmentsize=segmentsize)
+  viz!(plot, plot[rmesh], color=plot[rcolor], pointsize=pointsize, segmentsize=segmentsize)
 end
 
 asray(vec::Vec{Dim,ℒ}) where {Dim,ℒ} = Ray(Point(ntuple(i -> zero(ℒ), Dim)), vec)

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -8,19 +8,14 @@ process(value, colorscheme, colorrange, alphas) = process([value], colorscheme, 
 
 # assumes that meshes and colors have the same length
 function vizmany!(plot, meshes, colors)
-  pointsize = plot.pointsize
-  segmentsize = plot.segmentsize
-
-  rmesh = Symbol(meshes, :_rmeshes)
-  rcolor = Symbol(meshes, :_rcolor)
-
-  Makie.map!(plot, [meshes, colors], [rmesh, rcolor]) do ms, cs
-    rmes = reduce(merge, ms)
+  meshid = Symbol(meshes, :_meshes)
+  colorid = Symbol(meshes, :_color)
+  Makie.map!(plot, [meshes, colors], [meshid, colorid]) do ms, cs
+    mesh = reduce(merge, ms)
     color = [cs[i] for (i, m) in enumerate(ms) for _ in 1:nelements(m)]
-    (rmes, color)
+    mesh, color
   end
-
-  viz!(plot, plot[rmesh], color=plot[rcolor], pointsize=pointsize, segmentsize=segmentsize)
+  viz!(plot, plot[meshid], color=plot[colorid], pointsize=plot.pointsize, segmentsize=plot.segmentsize)
 end
 
 asray(v::Vec) = Ray(Point(zero(v)...), v)

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -2,8 +2,11 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
+# preprocess colors provided by user
+process(values::AbstractVector, colorscheme, colorrange, alphas) = colorfy(values; alphas, colorscheme, colorrange)
+process(value, colorscheme, colorrange, alphas) = process([value], colorscheme, colorrange, alphas) |> first
+
 # assumes that meshes and colors have the same length
-# and that colors are processed with alpha and colormap
 function vizmany!(plot, meshes, colors)
   pointsize = plot.pointsize
   segmentsize = plot.segmentsize
@@ -20,7 +23,7 @@ function vizmany!(plot, meshes, colors)
   viz!(plot, plot[rmesh], color=plot[rcolor], pointsize=pointsize, segmentsize=segmentsize)
 end
 
-asray(vec::Vec{Dim,ℒ}) where {Dim,ℒ} = Ray(Point(ntuple(i -> zero(ℒ), Dim)), vec)
+asray(v::Vec) = Ray(Point(zero(v)...), v)
 
 asmakie(v::Vec) = Makie.Vec{length(v),numtype(eltype(v))}(Tuple(ustrip.(v)))
 


### PR DESCRIPTION
I've asked Gemini to update the code (replace `@lift`s with `map!`) but I am still hesitant about this commit/PR. On one hand the issue is solved: geometries (and their color) can be updated without issues. On the other hand, I did not review the changes (other than scrolling through the files), because I don't understand the internals of the visualization code.

To be clear, I'm not asking you to review the LLM-generated code, that I generated, but want to start this discussion. I don't think I would be able to update this code manually, so I would rely on the LLM generated code. I was thinking on writing tests for visualizing all kind of geometries so we could verify that this works as expected, but I would ask for some input for that as well.