### PR TITLE
Use Makie docstring system for viz

### DIFF
--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -25,27 +25,27 @@ import Makie
     Viz
 """
 Makie.@recipe Viz (object,) begin
-  # scalar or vector of colors for geometries
+  "scalar or vector of colors for geometries"
   color = :slategray3
-  # scalar or vector of transparency values in [0, 1]
+  "scalar or vector of transparency values in [0, 1]"
   alpha = 1.0
-  # color scheme (a.k.a. map) from ColorSchemes.jl
+  "color scheme (a.k.a. map) from ColorSchemes.jl"
   colormap = :viridis
-  # minimum and maximum color values or symbol
+  "minimum and maximum color values or symbol"
   colorrange = :extrema
-  # visualize segments
+  "visualize segments"
   showsegments = false
-  # color of segments
+  "color of segments"
   segmentcolor = :gray30
-  # width of segments
+  "width of segments"
   segmentsize = 1.5
-  # visualize points
+  "visualize points"
   showpoints = false
-  # marker of points
+  "marker of points"
   pointmarker = :circle
-  # color of points
+  "color of points"
   pointcolor = :gray30
-  # size of points
+  "size of points"
   pointsize = 4
 end
 

--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -21,17 +21,31 @@ import Makie.GeometryBasics as GB
 import Meshes: viz, viz!
 import Makie
 
+"""
+    Viz
+"""
 Makie.@recipe Viz (object,) begin
+  # scalar or vector of colors for geometries
   color = :slategray3
+  # scalar or vector of transparency values in [0, 1]
   alpha = 1.0
+  # color scheme (a.k.a. map) from ColorSchemes.jl
   colormap = :viridis
+  # minimum and maximum color values or symbol
   colorrange = :extrema
+  # visualize segments
   showsegments = false
+  # color of segments
   segmentcolor = :gray30
+  # width of segments
   segmentsize = 1.5
+  # visualize points
   showpoints = false
+  # marker of points
   pointmarker = :circle
+  # color of points
   pointcolor = :gray30
+  # size of points
   pointsize = 4
 end
 

--- a/src/viz.jl
+++ b/src/viz.jl
@@ -7,7 +7,8 @@
 
 Visualize Meshes.jl `object` (e.g., mesh, geometry)
 with `options` such as `color` and `alpha` values for
-transparency. All available options are documented below.
+transparency. All available options will be documented
+below upon loading a Makie.jl backend.
 
 ## Examples
 

--- a/src/viz.jl
+++ b/src/viz.jl
@@ -5,29 +5,9 @@
 """
     viz(object; [options])
 
-Visualize Meshes.jl `object` with various `options`.
-
-## Available options
-
-* `color`        - scalar or vector of colors for geometries
-* `alpha`        - scalar or vector of transparency values in [0, 1]
-* `colormap`     - color scheme (a.k.a. map) from ColorSchemes.jl
-* `colorrange`   - minimum and maximum color values or symbol
-* `showsegments` - visualize segments
-* `segmentcolor` - color of segments
-* `segmentsize`  - width of segments
-* `showpoints`   - visualize points
-* `pointmarker`  - marker of points
-* `pointcolor`   - color of points
-* `pointsize`    - size of points
-
-For [`Mesh`](@ref) subtypes, the length of the vector of
-colors determines if the colors should be assigned to
-vertices or to elements.
-
-Values passed to `color` can be of any type, as long as they
-can be converted to colors by the `colorfy` function from the
-Colorfy.jl package.
+Visualize Meshes.jl `object` (e.g., mesh, geometry)
+with `options` such as `color` and `alpha` values for
+transparency. All available options are documented below.
 
 ## Examples
 
@@ -55,16 +35,24 @@ viz!(boundary(polygon))
 
 ### Notes
 
-This function will only work in the presence of
-a Makie.jl backend via package extensions in
-Julia v1.9 or later versions of the language.
+This function will only work in the presence of a Makie.jl
+backend via package extensions in Julia v1.9 or later
+versions of the language.
+
+Values passed to the `color` option can be of any type, as
+long as they can be converted to colors by the `colorfy`
+function from the Colorfy.jl package.
+
+For [`Mesh`](@ref) subtypes, the length of the vector of
+colors determines if the colors should be assigned to
+vertices or to elements.
 """
 function viz end
 
 """
     viz!(object; [options])
 
-Visualize Meshes.jl `object` in an existing
-scene with `options` forwarded to [`viz`](@ref).
+Visualize Meshes.jl `object` (e.g., mesh, geometry) in an
+existing scene with `options` forwarded to [`viz`](@ref).
 """
 function viz! end


### PR DESCRIPTION
I tried to follow the Makie documentation on recipes, but the docstring for each attribute is not showing up even after loading a Makie backend in the same session.

If anyone knows what is happening, please feel free to suggest changes.