### PR TITLE
WIP: Add support for optional shading

### DIFF
--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -33,7 +33,8 @@ Makie.@recipe(Viz, object) do scene
     showpoints=false,
     pointmarker=:circle,
     pointcolor=:gray30,
-    pointsize=4
+    pointsize=4,
+    shading=false,
   )
 end
 

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -58,6 +58,7 @@ end
 
 function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
   showsegments = plot[:showsegments]
+  shading = plot[:shading]
 
   # retrieve triangle mesh parameters
   tparams = Makie.@lift let
@@ -128,7 +129,7 @@ function vizmesh!(plot, ::Type, ::Val{2}, ::Val, mesh, colorant)
     end
 
     # enable shading in 3D
-    tshading = edim == 3
+    tshading = (dim == 3)&$shading
 
     tverts, telems, tcolors, tshading
   end


### PR DESCRIPTION
This adds a keyword `shading` to the `viz` recipe controlling whether a 3D mesh should use shading.