### PR TITLE
Fix StackOverflowError in atol/rtol for non-Float

### DIFF
--- a/src/tolerances.jl
+++ b/src/tolerances.jl
@@ -21,6 +21,7 @@ isapprox(a::T, b::T, atol=atol(T))
 atol(x) = atol(typeof(x))
 atol(::Type{Float32}) = ATOL32[]
 atol(::Type{Float64}) = ATOL64[]
+atol(::Type{T}) where {T<:AbstractFloat} = eps(T)^(3 // 4)
 atol(𝒬::Type{<:Quantity}) = atol(numtype(𝒬)) * unit(𝒬)
 atol(𝒟::Type{<:ForwardDiff.Dual}) = atol(ForwardDiff.valtype(𝒟))
 
@@ -39,6 +40,7 @@ source code for numerical integration for example.
 rtol(x) = rtol(typeof(x))
 rtol(::Type{Float32}) = RTOL32[]
 rtol(::Type{Float64}) = RTOL64[]
+rtol(::Type{T}) where {T<:AbstractFloat} = eps(T)^(1 // 3)
 rtol(𝒬::Type{<:Quantity}) = rtol(numtype(𝒬))
 rtol(𝒟::Type{<:ForwardDiff.Dual}) = rtol(ForwardDiff.valtype(𝒟))
 

--- a/test/tolerances.jl
+++ b/test/tolerances.jl
@@ -30,6 +30,12 @@
   @inferred Meshes.rtol(𝒜)
   @inferred Meshes.rtol(𝒱)
 
+  # generic AbstractFloat fallback (e.g. BigFloat)
+  @test Meshes.atol(BigFloat) == eps(BigFloat)^(3 // 4)
+  @test Meshes.rtol(BigFloat) == eps(BigFloat)^(1 // 3)
+  @test Meshes.atol(zero(BigFloat)) == Meshes.atol(BigFloat)
+  @test Meshes.rtol(zero(BigFloat)) == Meshes.rtol(BigFloat)
+
   # maximum length for discretization
   @test Meshes.maxlen() == 500u"km"
 end


### PR DESCRIPTION
Closes #1388

**Problem**

`atol` and `rtol` only had concrete methods for `Float32` and `Float64`. Any other `AbstractFloat` subtype (e.g. `BigFloat` or `Float64x2` from [MultiFloats.jl](https://github.com/dzhang314/MultiFloats.jl/)) fell through to the value-based generic:
```
atol(x) = atol(typeof(x))
```
With no matching `atol(::Type{SomeOtherFloat})` method, calling e.g. `atol(BigFloat)` dispatches to `atol(x::Type)` → `atol(typeof(DataType))` → `atol(DataType)` → ... infinite recursion → `StackOverflowError`.

**Fix**

Add generic `AbstractFloat` fallbacks in src/tolerances.jl, placed after the `Float32`/`Float64` methods:
```
atol(::Type{T}) where {T<:AbstractFloat} = eps(T)^(3 // 4)
rtol(::Type{T}) where {T<:AbstractFloat} = eps(T)^(1 // 3)
```
Julia's most-specific dispatch ensures Float32 and Float64 continue to hit their cached-constant methods; all other `AbstractFloat` subtypes now get a sensible value using the same formula already used for the common types.

**Tests**

Four tests added to test/tolerances.jl using `BigFloat` (stdlib, no new dependency):

- `atol(BigFloat)` / `rtol(BigFloat)` return the expected eps-based values
- `atol(zero(BigFloat))` / `rtol(zero(BigFloat))` correctly dispatch via the value-based fallback