### PR TITLE
adds specialized version of area and centroid for 2D polygons

### DIFF
--- a/src/centroid.jl
+++ b/src/centroid.jl
@@ -25,6 +25,32 @@ centroid(c::Circle) = center(c)
 
 centroid(c::Cylinder) = centroid(boundary(c))
 
+function centroid(p::Polygon{𝔼{2}})
+  # weighted average of the centroids by their
+  # signed (!!!) area (would be the mass, but it's uniform)
+  res = sum(rings(p)) do r
+    sum(segments(r)) do s
+      # calculates the centroid of the enclosed area by the ring
+      p₁, p₂ = to.(vertices(s))
+      x = (p₁[1], p₂[1])
+      y = (p₁[2], p₂[2])
+
+      k = x[1]*y[2] - x[2]*y[1]
+      SA[(x[2]+x[1])*k, (y[2]+y[1])*k]
+    end * 1/6 #= * 1/signedenclosedarea(r) * signedenclosedarea(r) =#
+    # the actual calculation needs dividing
+    # by  the enclosed area, but since we're
+    # doing a weighted average where the
+    # weight is the enclosed area we can simplify
+  end / sum(signedenclosedarea, rings(p))
+
+  # There is a subtle issue, if area is defined with "abs", then
+  # the centroid for a CW ring will be of flipped
+  # sign, while a signed area approach.
+
+  withcrs(p, res)
+end
+
 function centroid(c::CylinderSurface)
   a = centroid(bottom(c))
   b = centroid(top(c))

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -89,15 +89,7 @@ function measure(t::Tetrahedron)
   abs((A - D) ⋅ ((B - D) × (C - D))) / 6
 end
 
-function measure(p::Polygon{𝔼{2}})
-  Σ = sum(rings(p)) do r
-    v = vertices(r)
-    n = nvertices(r)
-    c = centroid(r)
-    sum(signarea(c, v[i], v[i + 1]) for i in 1:n)
-  end
-  abs(Σ)
-end
+measure(p::Polygon{𝔼{2}}) = abs(sum(signedenclosedarea, rings(p)))
 
 measure(m::Multi{<:𝔼}) = sum(measure, parent(m))
 

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -28,6 +28,11 @@ end
 
 orientation(r::Ring{𝔼{3}}) = orientation(proj2D(r))
 
+function orientation(r::Ring{𝔼{2}})
+  A = signedenclosedarea(r)
+  A ≥ zero(A) ? CCW : CW
+end
+
 function orientation(r::Ring)
   ℒ = lentype(r)
   v = vertices(r)

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -13,6 +13,21 @@ function signarea(A::Point, B::Point, C::Point)
 end
 
 """
+    signedenclosedarea(r)
+
+Computes the enclosed area of a ring using the shoelace formula on its vertices.
+"""
+function signedenclosedarea(r::Ring{𝔼{2}})
+  sum(segments(r)) do s
+    p₁, p₂ = to.(vertices(s))
+    x = (p₁[1], p₂[1])
+    y = (p₁[2], p₂[2])
+
+    (x[2]+x[1])*(y[2]-y[1])/2
+  end
+end
+
+"""
     householderbasis(n)
 
 Returns a pair of orthonormal tangent vectors `u` and `v` from a normal `n`,

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -650,9 +650,10 @@ end
   @test centroid(poly) ≈ cart(0.5, 0.5)
 
   # centroid is orientation-invariant
-  # (CW-oriented polygon should give the same centroid as CCW)
-  polyCW = PolyArea(reverse(vertices(Ring(cart.([(0, 0), (1, 0), (1, 1), (0, 1)])))))
-  @test centroid(polyCW) ≈ cart(0.5, 0.5)
+  verts = cart.([(0, 0), (1, 0), (1, 1), (0, 1)])
+  poly1 = PolyArea(verts)
+  poly2 = PolyArea(reverse(verts))
+  @test centroid(poly1) ≈ centroid(poly2)
 
   # single vertex access
   outer = cart.([(0, 0), (1, 0), (1, 1), (0, 1)])

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -649,6 +649,11 @@ end
   poly = PolyArea(cart.([(0, 0), (1, 0), (1, 1), (0, 1)]))
   @test centroid(poly) ≈ cart(0.5, 0.5)
 
+  # centroid is orientation-invariant
+  # (CW-oriented polygon should give the same centroid as CCW)
+  polyCW = PolyArea(reverse(vertices(Ring(cart.([(0, 0), (1, 0), (1, 1), (0, 1)])))))
+  @test centroid(polyCW) ≈ cart(0.5, 0.5)
+
   # single vertex access
   outer = cart.([(0, 0), (1, 0), (1, 1), (0, 1)])
   hole1 = cart.([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)])


### PR DESCRIPTION
Hello,

This PR introduces a few specializations for 2D Polygons. The formula use the shoelace formula (for the area) and it's extention (through green's theorem) to also the centroid (when seen as the first area moment of a shape).

This formulation to keep things fast and non allocating works on rings as the primary building block, so this introduces a private `signedenclosedarea` that works on rings (for polygons there is the usual `area` or `measure`).  The presence of this utility is needed at the ring level because we need to calculate the area enclosed by a ring to calculate the centroid of a polygon with holes. and instead of constructing a polygon each time we just use the ring directly. and also because we need a way to compute the signed area of a polygon (`measure` returns alwasy positive and it was kept like that).

the centroid calculation can maybe be extended  to 3D polygons using `proj2D` for the time being, but 

this approach is quite a bit faster (~1000x) than the current approach, is non allocating and fixes some numerical instabilities due to the generic integration approach for centroid:

This PR:
```
julia> @btime centroid($poly)
  42.298 ns (0 allocations: 0 bytes)
Point with Cartesian{NoDatum} coordinates
├─ x: 0.5 m
└─ y: 0.0 m

julia> @btime area($poly)
  21.104 ns (0 allocations: 0 bytes)
6.0 m²
```

master:
```
julia> @btime centroid($poly)
  39.792 μs (2018 allocations: 59.89 KiB)
Point with Cartesian{NoDatum} coordinates
├─ x: 0.5000000000000001 m
└─ y: 0.0 m

julia> @btime area($poly)
  870.000 ns (17 allocations: 1.17 KiB)
6.0 m²
```

Additionally adds a tests to catch the case where the centroid of a CW oriented polygon is not properly signed. (Was good before, just is a nice thing to check just in case)

No LLM used for this PR.