### PR TITLE
Use TileIterator to plot large grids

### DIFF
--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -12,6 +12,8 @@ using LinearAlgebra
 using CoordRefSystems
 using Colorfy
 
+using TiledIteration: TileIterator
+
 import TransformsBase as TB
 import Makie.GeometryBasics as GB
 

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -4,9 +4,10 @@
 
 function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, ::Val{2})
   # visualize as built-in image with or without interpolation
-  Makie.map!(plot, [:object, :colorant], [:x, :y, :C, :interpolate]) do grid, colorant
+  Makie.map!(plot, [:object, :colorant], [:x, :y, :C, :interpolate, :usetiles]) do grid, colorant
     sz = size(grid)
     nv = nvertices(grid)
+    ne = nelements(grid)
     nc = colorant isa AbstractVector ? length(colorant) : 1
 
     x, y = map(Meshes.xyz(grid)) do c
@@ -21,9 +22,24 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
       reshape(colorant, sz)
     end
 
-    x, y, C, (nc == nv)
+    x, y, C, (nc == nv), (ne ≥ 100000)
   end
-  Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=plot.interpolate)
+
+  if plot.usetiles[] && plot.interpolate[]
+    for (i, (xs, ys)) in enumerate(TileIterator(axes(plot.C[]), (100, 100)))
+      xi = Symbol(:x, i)
+      yi = Symbol(:y, i)
+      Ci = Symbol(:C, i)
+      Makie.map!(plot, [:x, :y, :C], [xi, yi, Ci]) do x, y, C
+        xrange = first(xs):(last(xs) + 1)
+        yrange = first(ys):(last(ys) + 1)
+        view(x, xrange), view(y, yrange), view(C, xs, ys)
+      end
+      Makie.image!(plot, plot[xi], plot[yi], plot[Ci], interpolate=plot.interpolate)
+    end
+  else
+    Makie.image!(plot, plot.x, plot.y, plot.C, interpolate=plot.interpolate)
+  end
 
   if plot.showsegments[]
     vizfacets!(plot)

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -25,15 +25,16 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
     x, y, C, (nc == nv), (ne ≥ 100000)
   end
 
-  if plot.usetiles[] && plot.interpolate[]
+  if plot.usetiles[] && !plot.interpolate[]
     for (i, (xs, ys)) in enumerate(TileIterator(axes(plot.C[]), (100, 100)))
       xi = Symbol(:x, i)
       yi = Symbol(:y, i)
       Ci = Symbol(:C, i)
-      Makie.map!(plot, [:x, :y, :C], [xi, yi, Ci]) do x, y, C
+      Makie.map!(plot, [:object, :C], [xi, yi, Ci]) do grid, C
+        x, y = ustrip.(Meshes.xyz(grid))
         xrange = first(xs):(last(xs) + 1)
         yrange = first(ys):(last(ys) + 1)
-        view(x, xrange), view(y, yrange), view(C, xs, ys)
+        extrema(view(x, xrange)), extrema(view(y, yrange)), view(C, xs, ys)
       end
       Makie.image!(plot, plot[xi], plot[yi], plot[Ci], interpolate=plot.interpolate)
     end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -26,13 +26,15 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
   end
 
   if plot.usetiles[]
+    Makie.map!(plot, [:object], [:xcoord, :ycoord]) do grid
+      map(c -> ustrip.(c), Meshes.xyz(grid))
+    end
     for (i, tile) in enumerate(TileIterator(axes(plot.C[]), (100, 100)))
       xi = Symbol(:x, i)
       yi = Symbol(:y, i)
       Ci = Symbol(:C, i)
-      Makie.map!(plot, [:object, :C, :interpolate], [xi, yi, Ci]) do grid, C, interpolate
-        xy = map(c -> ustrip.(c), Meshes.xyz(grid))
-        xlims, ylims = map(xy, tile) do c, t
+      Makie.map!(plot, [:xcoord, :ycoord, :C, :interpolate], [xi, yi, Ci]) do x, y, C, interpolate
+        xlims, ylims = map((x, y), tile) do c, t
           # note: non-interpolate case requires adding 1 to the end of the tile range
           ctile = first(t):(last(t) + !interpolate)
           extrema(view(c, ctile))

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -22,7 +22,7 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
       reshape(colorant, sz)
     end
 
-    x, y, C, (nc == nv), (ne ≥ 100000 && nc == ne)
+    x, y, C, (nc == nv), (ne ≥ 100000)
   end
 
   if plot.usetiles[]
@@ -30,10 +30,12 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
       xi = Symbol(:x, i)
       yi = Symbol(:y, i)
       Ci = Symbol(:C, i)
-      Makie.map!(plot, [:object, :C], [xi, yi, Ci]) do grid, C
-        xy = ustrip.(Meshes.xyz(grid))
+      Makie.map!(plot, [:object, :C, :interpolate], [xi, yi, Ci]) do grid, C, interpolate
+        xy = map(c -> ustrip.(c), Meshes.xyz(grid))
         xlims, ylims = map(xy, tile) do c, t
-          extrema(view(c, first(t):(last(t) + 1)))
+          # note: non-interpolate case requires adding 1 to the end of the tile range
+          ctile = first(t):(last(t) + !interpolate)
+          extrema(view(c, ctile))
         end
         xlims, ylims, view(C, tile...)
       end

--- a/ext/grid/cartesian.jl
+++ b/ext/grid/cartesian.jl
@@ -22,19 +22,20 @@ function vizgrid!(plot::Viz{<:Tuple{CartesianGrid}}, ::Type{<:𝔼}, ::Val{2}, :
       reshape(colorant, sz)
     end
 
-    x, y, C, (nc == nv), (ne ≥ 100000)
+    x, y, C, (nc == nv), (ne ≥ 100000 && nc == ne)
   end
 
-  if plot.usetiles[] && !plot.interpolate[]
-    for (i, (xs, ys)) in enumerate(TileIterator(axes(plot.C[]), (100, 100)))
+  if plot.usetiles[]
+    for (i, tile) in enumerate(TileIterator(axes(plot.C[]), (100, 100)))
       xi = Symbol(:x, i)
       yi = Symbol(:y, i)
       Ci = Symbol(:C, i)
       Makie.map!(plot, [:object, :C], [xi, yi, Ci]) do grid, C
-        x, y = ustrip.(Meshes.xyz(grid))
-        xrange = first(xs):(last(xs) + 1)
-        yrange = first(ys):(last(ys) + 1)
-        extrema(view(x, xrange)), extrema(view(y, yrange)), view(C, xs, ys)
+        xy = ustrip.(Meshes.xyz(grid))
+        xlims, ylims = map(xy, tile) do c, t
+          extrema(view(c, first(t):(last(t) + 1)))
+        end
+        xlims, ylims, view(C, tile...)
       end
       Makie.image!(plot, plot[xi], plot[yi], plot[Ci], interpolate=plot.interpolate)
     end

--- a/ext/grid/rectilinear.jl
+++ b/ext/grid/rectilinear.jl
@@ -16,13 +16,32 @@ function vizgrid!(plot::Viz{<:Tuple{RectilinearGrid}}, M::Type{<:𝔼}, pdim::Va
       vizmesh!(plot)
     else
       # visualize as built-in heatmap
-      Makie.map!(plot, [:object, :colorant], [:x, :y, :C]) do grid, colorant
+      Makie.map!(plot, [:object, :colorant], [:x, :y, :C, :usetiles]) do grid, colorant
         sz = size(grid)
+        ne = nelements(grid)
         x, y = map(c -> ustrip.(c), Meshes.xyz(grid))
         C = colorant isa AbstractVector ? reshape(colorant, sz) : fill(colorant, sz)
-        x, y, C
+        x, y, C, (ne ≥ 100000)
       end
-      Makie.heatmap!(plot, plot.x, plot.y, plot.C)
+
+      if plot.usetiles[]
+        for (i, tile) in enumerate(TileIterator(axes(plot.C[]), (100, 100)))
+          xi = Symbol(:x, i)
+          yi = Symbol(:y, i)
+          Ci = Symbol(:C, i)
+          Makie.map!(plot, [:x, :y, :C], [xi, yi, Ci]) do x, y, C
+            xlims, ylims = map((x, y), tile) do c, t
+              # note: non-interpolate case requires adding 1 to the end of the tile range
+              ctile = first(t):(last(t) + 1)
+              extrema(view(c, ctile))
+            end
+            xlims, ylims, view(C, tile...)
+          end
+          Makie.heatmap!(plot, plot[xi], plot[yi], plot[Ci])
+        end
+      else
+        Makie.heatmap!(plot, plot.x, plot.y, plot.C)
+      end
     end
 
     if plot.showsegments[]

--- a/ext/grid/structured.jl
+++ b/ext/grid/structured.jl
@@ -13,12 +13,26 @@ function vizgrid!(plot::Viz{<:Tuple{StructuredGrid}}, M::Type{<:𝔼}, pdim::Val
 
     if plot.nc[] == plot.nv[]
       # visualize as built-in surface
-      Makie.map!(plot, [:object, :colorant], [:X, :Y, :C]) do grid, colorant
+      Makie.map!(plot, [:object, :colorant], [:X, :Y, :C, :usetiles]) do grid, colorant
+        ne = nelements(grid)
         X, Y = map(c -> ustrip.(c), Meshes.XYZ(grid))
         C = reshape(colorant, Meshes.vsize(grid))
-        X, Y, C
+        X, Y, C, (ne ≥ 100000)
       end
-      Makie.surface!(plot, plot.X, plot.Y, color=plot.C)
+
+      if plot.usetiles[]
+        for (i, tile) in enumerate(TileIterator(axes(plot.C[]), (100, 100)))
+          Xi = Symbol(:X, i)
+          Yi = Symbol(:Y, i)
+          Ci = Symbol(:C, i)
+          Makie.map!(plot, [:X, :Y, :C], [Xi, Yi, Ci]) do X, Y, C
+            view(X, tile...), view(Y, tile...), view(C, tile...)
+          end
+          Makie.surface!(plot, plot[Xi], plot[Yi], color=plot[Ci])
+        end
+      else
+        Makie.surface!(plot, plot.X, plot.Y, color=plot.C)
+      end
 
       if plot.showsegments[]
         vizfacets!(plot)


### PR DESCRIPTION
This PR implements the `vizgrid!` using separate tiles for cases where the grid is very large, optimizing GPU memory usage.
@juliohm we need to define the minimum size for the grid to use this technique, as well as the tile size.