### PR TITLE
Add `Segment`-`Polygon` intersection method

### DIFF
--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -224,7 +224,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       intersects(sbox, boundingbox(edge)) || continue
       intersection(seg, edge) do I
         if type(I) == NotIntersecting
-          continue
+          return nothing
         elseif type(I) == Overlapping
           s = get(I)
           push!(splitpoints, vertices(s)...)

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -209,7 +209,7 @@ end
 # 3. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 4. the segment is degenerate and is outside the polygon (NotIntersecting -> Nothing)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
-function intersection(f, seg::Segment, poly::Polygon)
+function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
   a, b = vertices(seg)
 
@@ -229,25 +229,27 @@ function intersection(f, seg::Segment, poly::Polygon)
   boundarypoints = Point[]
   for ring in rings(poly)
     for edge in segments(ring)
-      I = intersection(seg, edge)
-      itype = type(I)
-      # no intersection
-      if itype == NotIntersecting
-        continue
-      end
-      # some intersection
-      geom = get(I)
-      if geom isa Point # crosses or touches 
-        push!(boundarypoints, geom)
-        λ = ustrip((geom-a) ⋅ v / (v ⋅ v))
-        push!(segλs, λ)
-      elseif geom isa Segment # overlaps
-        c, d = vertices(geom)
-        λc = ustrip((c-a) ⋅ v / (v ⋅ v))
-        λd = ustrip((d-a) ⋅ v / (v ⋅ v))
-        push!(segλs, λc, λd)
-      else
-        @error "Unexpected Segment × Polygon edge intersection geometry: " * "$(typeof(geometry))"
+      if intersects(boundingbox(seg), boundingbox(edge))
+        intersection(seg, edge) do I
+          # no intersection
+          if type(I) == NotIntersecting
+            return
+          end
+          # some intersection
+          geom = get(I)
+          if geom isa Point # Crossing, EdgeTouching, CornerTouching, etc.
+            push!(boundarypoints, geom)
+            λ = ustrip((geom-a) ⋅ v / (v ⋅ v))
+            push!(segλs, λ)
+          elseif geom isa Segment # Overlapping collinear segments
+            c, d = vertices(geom)
+            λc = ustrip((c-a) ⋅ v / (v ⋅ v))
+            λd = ustrip((d-a) ⋅ v / (v ⋅ v))
+            push!(segλs, λc, λd)
+          else
+            @error "Unexpected Segment × Polygon edge intersection geometry: " * "$(typeof(geom))"
+          end
+        end
       end
     end
   end
@@ -270,7 +272,7 @@ function intersection(f, seg::Segment, poly::Polygon)
     geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces) 
     return @IT Overlapping geometry f # Case 1
   elseif !isempty(boundarypoints) # no segments, but some intersection
-    geometry = length(boundarypoints) == 1 ? only(pieces) : first(pieces) # it gotta be a single point!
+    geometry = length(boundarypoints) == 1 ? only(boundarypoints) : first(boundarypoints) # it gotta be a single point!
     return @IT Touching geometry f # Case 2
   else
     return @IT NotIntersecting nothing f # Case 5 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -215,10 +215,13 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
   # check for degenerate segments
   a, b = vertices(seg)
-  if a ≈ b && a ∈ poly && !any(v -> a ≈ v, vertices(poly))
-    return @IT Touching a f
-  elseif a ≈ b && any(v -> a ≈ v, vertices(poly))
-    return @IT CornerTouching a f
+  if a ≈ b
+    isvertex = any(≈(a), eachvertex(poly))
+    if a ∈ poly && !isvertex
+      return @IT Touching a f
+    elseif isvertex
+      return @IT CornerTouching a f
+    end
   end
 
   # extract flat xy coordinates

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -268,21 +268,18 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
   resize!(events, i)
 
-  # create geometry from pieces
-  piecegeometry(ps) = length(ps) == 1 ? only(ps) : Multi(ps)
+  # glue pieces together into a single geometry
+  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
 
-  # create auxiliary variables
-  ncross = count(e -> e[2], events)
-  hasinterior = any(isinterior)
+  # number of crossing events
+  ncrosses = count(e -> e[2], events)
 
   # classify intersection
-  if hasinterior
-    geometry = piecegeometry(pieces)
-    return @IT Intersecting geometry f
+  if any(isinterior)
+    return @IT Intersecting glue(pieces) f
   elseif !isempty(pieces)
-    geometry = piecegeometry(pieces)
-    return @IT EdgeTouching geometry f
-  elseif ncross == 1
+    return @IT EdgeTouching glue(pieces) f
+  elseif ncrosses == 1
     i = findfirst(e -> e[2], events)
     p = events[i][1]
     isendpoint = p ≈ a || p ≈ b
@@ -292,7 +289,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     else
       return @IT CornerTouching p f
     end
-  elseif ncross > 1
+  elseif ncrosses > 1
     points = typeof(a)[e[1] for e in events if e[2]]
     return @IT Intersecting Multi(points) f
   else

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -257,11 +257,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       # event is fully merged, connect it with the next event
       depth += eᵢ[3]
       piece = Segment(eᵢ[1], eⱼ[1])
-      if depth > 0 
-        push!(pieces, piece) 
-      elseif center(piece) ∈ poly 
-        inpoly = true 
-        push!(pieces, piece) 
+      if depth > 0
+        push!(pieces, piece)
+      elseif center(piece) ∈ poly
+        inpoly = true
+        push!(pieces, piece)
       end
       i += 1
       events[i] = eⱼ

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -223,8 +223,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       intersects(sbox, boundingbox(edge)) || continue
       intersection(seg, edge) do I
         itype = type(I)
-        itype == NotIntersecting && return
-        if itype == Overlapping
+        if itype == NotIntersecting
+          return nothing
+        elseif itype == Overlapping
           c, d = vertices(get(I))
           if λ(d) < λ(c)
             c, d = d, c

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -209,8 +209,6 @@ end
 # 5. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 6. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
-  a, b = vertices(seg)
-
   # check bounding boxes for early exit
   sbox = boundingbox(seg)
   pbox = boundingbox(poly)
@@ -219,6 +217,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
 
   # check for degenerate segments
+  a, b = vertices(seg)
   if a ≈ b && a ∈ poly && !any(v -> a ≈ v, vertices(poly))
     return @IT Touching a f
   elseif a ≈ b && any(v -> a ≈ v, vertices(poly))

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -213,28 +213,22 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   pbox = boundingbox(poly)
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
 
-  # assess intersections
-  a, b = vertices(seg)
-  splitpoints = typeof(a)[a, b]
-  boundarypoints = typeof(a)[]
+  # store and classify intersection points
+  splitpoints = collect(eachvertex(seg))
+  boundarypoints = empty(splitpoints)
   boundaryoverlaps = typeof(seg)[]
-
   for ring in rings(poly)
     rbox = boundingbox(ring)
-    # check for obvious no intersection case beforehand
     intersects(sbox, rbox) || continue
     for edge in segments(ring)
-      # the selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
       intersects(sbox, boundingbox(edge)) || continue
       intersection(seg, edge) do I
-        itype = type(I)
-        if itype == NotIntersecting
-          return nothing
-        elseif itype == Overlapping
-          overlap = get(I)
-          c, d = vertices(overlap)
-          push!(splitpoints, c, d)
-          push!(boundaryoverlaps, overlap)
+        if type(I) == NotIntersecting
+          continue
+        elseif type(I) == Overlapping
+          s = get(I)
+          push!(splitpoints, vertices(s)...)
+          push!(boundaryoverlaps, s)
         else
           p = get(I)
           push!(splitpoints, p)
@@ -243,10 +237,14 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       end
     end
   end
-  unique!(boundarypoints)
-  dir = normalize(b-a)
-  λ(p) = ustrip((p - a) ⋅ dir)
+
+  # sort intersection points along the segment
+  a, b = vertices(seg)
+  λ(p) = (p - a) ⋅ (b - a)
   sort!(splitpoints, by=λ)
+
+  # remove duplicate points in boundary
+  unique!(boundarypoints)
 
   # create resulting intersection segments from base intersection points
   pieces = typeof(seg)[]

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -204,7 +204,7 @@ function intersection(f, seg::Segment, line::Line)
 end
 
 # intersection between a segment and a polygon
-# 1. overlap of line and polygon (Overlapping -> Segment)
+# 1. overlap of segment and polygon (Overlapping -> Segment)
 # 2. intersect at one an point, exactly (Touching -> Point)
 # 3. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 4. the segment is degenerate and is outside the polygon (NotIntersecting -> Nothing)

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -208,7 +208,6 @@ end
 # 4. intersect at a single non-vertex point (Touching -> Point)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
-  # early exit if bounding boxes do not intersect
   sbox = boundingbox(seg)
   pbox = boundingbox(poly)
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
@@ -236,7 +235,6 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
         p = get(I)
         push!(events, (p, true, Int8(0)))
       end
-    end
     end
   end
 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -203,6 +203,203 @@ function intersection(f, seg::Segment, line::Line)
   end
 end
 
+# intersection between a segment and a polygon
+# 1. overlap with the polygon interior (Intersecting -> Segment or Multi)
+# 2. overlap with a polygon edge only (EdgeTouching -> Segment or Multi)
+# 3. intersect at an interior point of the segment and a polygon vertex (CornerTouching -> Point)
+# 4. intersect only at an endpoint of the segment (Touching -> Point)
+# 5. the segment is degenerate and is inside the polygon (Touching -> Point)
+# 6. do not overlap nor intersect (NotIntersecting -> Nothing)
+function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
+  a, b = vertices(seg)
+  segbbox = boundingbox(seg)
+  polybbox = boundingbox(poly)
+
+  # check for degenerate segments
+  if a ≈ b && a ∈ poly
+    return @IT Touching a f # Case 5
+  end
+
+  # assess obvious no intersection case beforehand
+  if !intersects(segbbox, polybbox)
+    return @IT NotIntersecting nothing f # Case 6
+  end
+
+  # segment endpoints as scalars + segment vector
+  segλs = [0.0, 1.0]
+  v = b - a
+  v² = v ⋅ v
+
+  # extract the first Cartesian coordinate
+  x(p) = flat(coords(p)).x
+  y(p) = flat(coords(p)).y
+
+  # choose the polygon's longest bounding-box axis
+  polymin, polymax = extrema(polybbox)
+  xside = x(polymax) - x(polymin)
+  yside = y(polymax) - y(polymin)
+  axiscoord = xside ≥ yside ? x : y
+
+  # segment range along the chosen axis
+  segmin, segmax = extrema(segbbox)
+  segstart = axiscoord(segmin)
+  segstop = axiscoord(segmax)
+
+  # assess intersections
+  boundarypoints = typeof(a)[]
+  boundaryoverlaps = Tuple{Float64,Float64}[]
+
+  for ring in rings(poly)
+    ringbbox = boundingbox(ring)
+
+    # check for obvious no intersection case beforehand
+    intersects(segbbox, ringbbox) || continue
+
+    edges = collect(segments(ring))
+    boxes = boundingbox.(edges)
+
+    # edge ranges
+    starts = map(boxes) do box
+      pmin, _ = extrema(box)
+      axiscoord(pmin)
+    end
+    stops = map(boxes) do box
+      _, pmax = extrema(box)
+      axiscoord(pmax)
+    end
+
+    # Sort by minimum coordinate
+    inds = sortperm(starts)
+    edges = edges[inds]
+    boxes = boxes[inds]
+    starts = starts[inds]
+    stops = stops[inds]
+
+    for i in eachindex(edges)
+      # edge ends before the segment begins. Later edges may still overlap, so skip only this edge.
+      stops[i] < segstart && continue
+
+      # edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right.
+      starts[i] > segstop && break
+
+      # the selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
+      intersects(segbbox, boxes[i]) || continue
+
+      edge = edges[i]
+      intersection(seg, edge) do I
+        itype = type(I)
+        # no intersection
+        if itype == NotIntersecting
+          return
+        elseif itype == Overlapping
+          # Overlapping segments
+          overlap = get(I)
+          c, d = vertices(overlap)
+          λc = ustrip((c - a) ⋅ v / v²)
+          λd = ustrip((d - a) ⋅ v / v²)
+          λ₁, λ₂ = minmax(λc, λd)
+          push!(segλs, λ₁, λ₂)
+          push!(boundaryoverlaps, (λ₁, λ₂))
+        else
+          # Crossing, EdgeTouching, CornerTouching, etc.
+          p = get(I)
+          push!(boundarypoints, p)
+          λ = ustrip((p - a) ⋅ v / v²)
+          push!(segλs, λ)
+        end
+      end
+    end
+  end
+
+  # get unique boundary points
+  uniquepoints = typeof(a)[]
+  for p in boundarypoints
+    any(q -> q ≈ p, uniquepoints) || push!(uniquepoints, p)
+  end
+  boundarypoints = uniquepoints
+
+  # remove duplicate λ values and sort them
+  sort!(segλs)
+  for i in 2:length(segλs)
+    segλs[i] = mayberound(segλs[i], segλs[i - 1])
+  end
+  unique!(segλs)
+
+  # check if a λ value lies in a boundary overlap
+  function inboundaryoverlap(λ)
+    any(boundaryoverlaps) do (λ₁, λ₂)
+      λ₁ < λ < λ₂ || λ ≈ λ₁ || λ ≈ λ₂
+    end
+  end
+
+  # create segments from the λ values
+  pieces = typeof(seg)[]
+  interiorpieces = typeof(seg)[]
+  boundarypieces = typeof(seg)[]
+  for (λ₁, λ₂) in zip(segλs[1:(end - 1)], segλs[2:end])
+    λ₁ ≈ λ₂ && continue
+    λmid = (λ₁ + λ₂) / 2
+    piece = Segment(seg(λ₁), seg(λ₂))
+
+    if inboundaryoverlap(λmid)
+      push!(pieces, piece)
+      push!(boundarypieces, piece)
+    elseif seg(λmid) ∈ poly
+      push!(pieces, piece)
+      push!(interiorpieces, piece)
+    end
+  end
+
+  # merge continuous segments
+  function mergepieces(pieces)
+    length(pieces) ≤ 1 && return pieces
+
+    merged = eltype(pieces)[]
+    for piece in pieces
+      if isempty(merged)
+        push!(merged, piece)
+      else
+        previous = last(merged)
+        p₁, p₂ = vertices(previous)
+        q₁, q₂ = vertices(piece)
+        if p₂ ≈ q₁
+          merged[end] = Segment(p₁, q₂)
+        else
+          push!(merged, piece)
+        end
+      end
+    end
+    merged
+  end
+
+  pieces = mergepieces(pieces)
+  interiorpieces = mergepieces(interiorpieces)
+  boundarypieces = mergepieces(boundarypieces)
+
+  # create geometry from pieces
+  piecegeometry(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
+
+  # classifying intersections
+  if !isempty(interiorpieces)
+    geometry = piecegeometry(pieces)
+    return @IT Intersecting geometry f # Case 1
+  elseif !isempty(boundarypieces)
+    geometry = piecegeometry(boundarypieces)
+    return @IT EdgeTouching geometry f # Case 2
+  elseif length(boundarypoints) == 1
+    p = only(boundarypoints)
+    if p ≈ a || p ≈ b
+      return @IT Touching p f # Case 4
+    else
+      return @IT CornerTouching p f # Case 3
+    end
+  elseif !isempty(boundarypoints)
+    return @IT Intersecting Multi(boundarypoints) f # Case 1
+  else
+    return @IT NotIntersecting nothing f # Case 6
+  end
+end
+
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.
 # (https://www.sciencedirect.com/science/article/pii/S0925772109001448?via%3Dihub)
 function intersection(f, seg::Segment{𝔼{3}}, tri::Triangle{𝔼{3}})
@@ -329,156 +526,6 @@ function intersection(f, seg::Segment{𝔼{3}}, tri::Triangle{𝔼{3}})
   p = Segment(Q1, Q2)(λ)
 
   return @IT Intersecting p f
-end
-
-# intersection between a segment and a polygon
-# 1. overlap of segment and polygon (Overlapping -> Segment)
-# 2. intersect at one point, exactly (Touching -> Point)
-# 3. the segment is degenerate and is inside the polygon (Touching -> Point)
-# 4. do not overlap nor intersect (NotIntersecting -> Nothing)
-function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
-  a, b = vertices(seg)
-  segbbox = boundingbox(seg)
-  polybbox = boundingbox(poly)
-
-  # check for degenerate segments
-  if a ≈ b && a ∈ poly
-    return @IT Touching a f # Case 3
-  end
-
-  # assess obvious no intersection case beforehand
-  if !intersects(segbbox, polybbox)
-    return @IT NotIntersecting nothing f # Case 4
-  end
-
-  # segment endpoints as scalars + segment vector
-  segλs = [0.0, 1.0]
-  v = b - a
-
-  # Extract the first Cartesian coordinate
-  x(p) = flat(coords(p)).x
-  y(p) = flat(coords(p)).y
-
-  # Choose the polygon's longest bounding-box axis
-  polymin, polymax = extrema(polybbox)
-  xside = x(polymax) - x(polymin)
-  yside = y(polymax) - y(polymin)
-  axiscoord = xside ≥ yside ? x : y
-
-  # Segment range along the chosen axis
-  segmin, segmax = extrema(segbbox)
-  segstart = axiscoord(segmin)
-  segstop = axiscoord(segmax)
-
-  # assess intersections
-  boundarypoints = typeof(a)[]
-  for ring in rings(poly)
-    ringbbox = boundingbox(ring)
-    # check for obvious no intersection case beforehand
-    intersects(segbbox, ringbbox) || continue
-    edges = collect(segments(ring))
-    boxes = boundingbox.(edges)
-    # Edge ranges
-    starts = map(boxes) do box
-      pmin, _ = extrema(box)
-      axiscoord(pmin)
-    end
-    stops = map(boxes) do box
-      _, pmax = extrema(box)
-      axiscoord(pmax)
-    end
-
-    # Sort by minimum coordinate
-    inds = sortperm(starts)
-    edges = edges[inds]
-    boxes = boxes[inds]
-    starts = starts[inds]
-    stops = stops[inds]
-    for i in eachindex(edges)
-      # Edge ends before the segment begins. Later edges may still overlap, so skip only this edge.
-      stops[i] < segstart && continue
-
-      # Edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right.
-      starts[i] > segstop && break
-
-      # The selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
-      intersects(segbbox, boxes[i]) || continue
-
-      edge = edges[i]
-      intersection(seg, edge) do I
-        itype = type(I)
-        # no intersection
-        if itype == NotIntersecting
-          return
-        elseif itype == Overlapping
-          # Overlapping segments
-          seg = get(I)
-          c, d = vertices(seg)
-          λc = ustrip((c-a) ⋅ v / (v ⋅ v))
-          λd = ustrip((d-a) ⋅ v / (v ⋅ v))
-          push!(segλs, λc, λd)
-        else
-          # Crossing, EdgeTouching, CornerTouching, etc.
-          p = get(I)
-          push!(boundarypoints, p)
-          λ = ustrip((p-a) ⋅ v / (v ⋅ v))
-          push!(segλs, λ)
-        end
-      end
-    end
-  end
-
-  # get unique boundary points
-  unique!(boundarypoints)
-  # remove duplicate λ values and sort them
-  sort!(segλs)
-  for i in 2:length(segλs)
-    segλs[i] = mayberound(segλs[i], segλs[i - 1])
-  end
-  unique!(segλs)
-  # create segments from the λ values that are inside the polygon
-  pieces = typeof(seg)[]
-  for (λ₁, λ₂) in zip(segλs[1:(end - 1)], segλs[2:end])
-    λ₁ ≈ λ₂ && continue
-    λmid = (λ₁ + λ₂) / 2
-    if seg(λmid) ∈ poly
-      push!(pieces, Segment(seg(λ₁), seg(λ₂)))
-    end
-  end
-  # merge continuous segments
-  if length(pieces) > 1
-    merged = typeof(seg)[]
-    for piece in pieces
-      if isempty(merged)
-        push!(merged, piece)
-      else
-        previous = last(merged)
-        if !intersects(boundingbox(previous), boundingbox(piece))
-          push!(merged, piece)
-          continue
-        end
-        p₁, p₂ = vertices(previous)
-        q₁, q₂ = vertices(piece)
-        if p₂ ≈ q₁
-          merged[end] = Segment(p₁, q₂)
-        else
-          push!(merged, piece)
-        end
-      end
-    end
-    pieces = merged
-  end
-
-  # classifying intersections
-  if !isempty(pieces) # positive-length intersection
-    geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces)
-    return @IT Overlapping geometry f # Case 1
-  elseif !isempty(boundarypoints) # no segments, but some intersection
-    geometry = length(boundarypoints) == 1 ? only(boundarypoints) : Multi(boundarypoints)
-    return @IT Touching geometry f # Case 2
-  else
-    return @IT NotIntersecting nothing f # Case 5 
-  end
 end
 
 # sorts four numbers using a sorting network 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -283,8 +283,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   elseif ncrosses == 1
     i = findfirst(e -> e[2], events)
     p = events[i][1]
-    isvertex = any(v -> p ≈ v, eachvertex(poly))
-    if isvertex
+    if any(≈(p), eachvertex(poly))
       return @IT CornerTouching p f
     else
       return @IT Touching p f

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -208,7 +208,7 @@ end
 # 4. intersect at a single non-vertex point (Touching -> Point)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
-  # check bounding boxes for early exit
+  # early exit if bounding boxes do not intersect
   sbox = boundingbox(seg)
   pbox = boundingbox(poly)
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
@@ -224,18 +224,16 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     end
   end
 
-  # extract flat xy coordinates
+  # coordinate with largest bounding box side
+  xside, yside = sides(pbox)
   x(p) = flat(coords(p)).x
   y(p) = flat(coords(p)).y
-
-  # choose the polygon's longest bounding box axis
-  xside, yside = sides(pbox)
-  axiscoord = xside ≥ yside ? x : y
+  coord = xside ≥ yside ? x : y
 
   # segment range along the chosen axis
   smin, smax = extrema(sbox)
-  sstart = axiscoord(smin)
-  sstop = axiscoord(smax)
+  sstart = coord(smin)
+  sstop = coord(smax)
 
   # assess intersections
   boundarypoints = typeof(a)[]
@@ -257,11 +255,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     # edge ranges
     estart = map(ebox) do box
       pmin, _ = extrema(box)
-      axiscoord(pmin)
+      coord(pmin)
     end
     estop = map(ebox) do box
       _, pmax = extrema(box)
-      axiscoord(pmax)
+      coord(pmax)
     end
 
     # sort by minimum coordinate

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -283,7 +283,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   elseif ncrosses == 1
     i = findfirst(e -> e[2], events)
     p = events[i][1]
-    isvertex = any(v -> p ≈ v, vertices(poly))
+    isvertex = any(v -> p ≈ v, eachvertex(poly))
     if isvertex
       return @IT CornerTouching p f
     else

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -215,20 +215,19 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   sbox = boundingbox(seg)
   pbox = boundingbox(poly)
   if !intersects(sbox, pbox)
-    return @IT NotIntersecting nothing f # Case 6
+    return @IT NotIntersecting nothing f
   end
 
   # check for degenerate segments
   if a ≈ b && a ∈ poly && !any(v -> a ≈ v, vertices(poly))
-    return @IT Touching a f # Case 5
+    return @IT Touching a f
   elseif a ≈ b && any(v -> a ≈ v, vertices(poly))
-    return @IT CornerTouching a f # Case 3
+    return @IT CornerTouching a f
   end
 
   # segment endpoints as scalars + segment vector
-  segλs = [0.0, 1.0]
-  v = b - a
-  v² = v ⋅ v
+  λs = [0.0, 1.0]
+  v = normalize(b - a)
 
   # extract flat xy coordinates
   x(p) = flat(coords(p)).x
@@ -268,7 +267,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       axiscoord(pmax)
     end
 
-    # Sort by minimum coordinate
+    # sort by minimum coordinate
     inds = sortperm(starts)
     edges = edges[inds]
     boxes = boxes[inds]
@@ -288,24 +287,21 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       edge = edges[i]
       intersection(seg, edge) do I
         itype = type(I)
-        # no intersection
         if itype == NotIntersecting
-          return
+          return nothing
         elseif itype == Overlapping
-          # Overlapping segments
           overlap = get(I)
           c, d = vertices(overlap)
-          λc = ustrip((c - a) ⋅ v / v²)
-          λd = ustrip((d - a) ⋅ v / v²)
+          λc = ustrip((c - a) ⋅ v)
+          λd = ustrip((d - a) ⋅ v)
           λ₁, λ₂ = minmax(λc, λd)
-          push!(segλs, λ₁, λ₂)
+          push!(λs, λ₁, λ₂)
           push!(boundaryoverlaps, (λ₁, λ₂))
         else
-          # Crossing, EdgeTouching, CornerTouching, etc.
           p = get(I)
           push!(boundarypoints, p)
-          λ = ustrip((p - a) ⋅ v / v²)
-          push!(segλs, λ)
+          λ = ustrip((p - a) ⋅ v)
+          push!(λs, λ)
         end
       end
     end
@@ -319,11 +315,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   boundarypoints = uniquepoints
 
   # remove duplicate λ values and sort them
-  sort!(segλs)
-  for i in 2:length(segλs)
-    segλs[i] = mayberound(segλs[i], segλs[i - 1])
+  sort!(λs)
+  for i in 2:length(λs)
+    λs[i] = mayberound(λs[i], λs[i - 1])
   end
-  unique!(segλs)
+  unique!(λs)
 
   # check if a λ value lies in a boundary overlap
   function inboundaryoverlap(λ)
@@ -336,7 +332,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   pieces = typeof(seg)[]
   interiorpieces = typeof(seg)[]
   boundarypieces = typeof(seg)[]
-  for (λ₁, λ₂) in zip(segλs[1:(end - 1)], segλs[2:end])
+  for (λ₁, λ₂) in zip(λs[1:(end - 1)], λs[2:end])
     λ₁ ≈ λ₂ && continue
     λmid = (λ₁ + λ₂) / 2
     piece = Segment(seg(λ₁), seg(λ₂))
@@ -360,27 +356,27 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # classifying intersections
   if !isempty(interiorpieces)
     geometry = piecegeometry(pieces)
-    return @IT Intersecting geometry f # Case 1
+    return @IT Intersecting geometry f
   elseif !isempty(boundarypieces)
     geometry = piecegeometry(boundarypieces)
-    return @IT EdgeTouching geometry f # Case 2
+    return @IT EdgeTouching geometry f
   elseif length(boundarypoints) == 1
     p = only(boundarypoints)
     isendpoint = (p ≈ a || p ≈ b)
     isvertex = any(v -> p ≈ v, vertices(poly))
     if isendpoint && !isvertex
-      return @IT Touching p f # Case 4
+      return @IT Touching p f
     else
-      return @IT CornerTouching p f # Case 3
+      return @IT CornerTouching p f
     end
   elseif !isempty(boundarypoints)
-    return @IT Intersecting Multi(boundarypoints) f # Case 1
+    return @IT Intersecting Multi(boundarypoints) f
   else
-    return @IT NotIntersecting nothing f # Case 6
+    return @IT NotIntersecting nothing f
   end
 end
 
-# Merge the continuous segments of a segment list (`pieces`) into a single geometry
+# merge the continuous segments of a segment list (`pieces`) into a single geometry
 function _mergepieces(pieces)
   length(pieces) ≤ 1 && return pieces
   merged = eltype(pieces)[]

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -221,22 +221,22 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     intersects(sbox, boundingbox(ring)) || continue
     for edge in segments(ring)
       intersects(sbox, boundingbox(edge)) || continue
-      intersection(seg, edge) do I
-        itype = type(I)
-        if itype == NotIntersecting
-          return nothing
-        elseif itype == Overlapping
-          c, d = vertices(get(I))
-          if λ(d) < λ(c)
-            c, d = d, c
-          end
-          push!(events, (c, false, Int8(1)))
-          push!(events, (d, false, Int8(-1)))
-        else
-          p = get(I)
-          push!(events, (p, true, Int8(0)))
+      I = intersection(seg, edge)
+      itype = type(I)
+      if itype == NotIntersecting
+        return nothing
+      elseif itype == Overlapping
+        c, d = vertices(get(I))
+        if λ(d) < λ(c)
+          c, d = d, c
         end
+        push!(events, (c, false, Int8(1)))
+        push!(events, (d, false, Int8(-1)))
+      else
+        p = get(I)
+        push!(events, (p, true, Int8(0)))
       end
+    end
     end
   end
 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -211,7 +211,7 @@ end
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
-  a, b = vertices(seg)
+  a, b = vertices(seg); segbbox = boundingbox(seg); polybbox = boundingbox(poly)
 
   # check for degenerate segments
   if a ≈ b
@@ -222,14 +222,22 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     end
   end
 
+  # assess obvious no intersection case beforehand
+  if !intersects(segbbox, polybbox)
+    return @IT NotIntersecting nothing f # Case 5
+  end
+  
   # segment endpoints as scalars + segment vector
   segλs = [0.0, 1.0]; v = b-a;
 
   # assess intersections with the edges
   boundarypoints = Point[]
   for ring in rings(poly)
+    ringbbox = boundingbox(ring)
     for edge in segments(ring)
-      if intersects(boundingbox(seg), boundingbox(edge))
+      intersects(segbbox, ringbbox) || continue
+      edgebbox = boundingbox(edge)
+      if intersects(segbbox, edgebbox)
         intersection(seg, edge) do I
           # no intersection
           if type(I) == NotIntersecting
@@ -272,7 +280,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces) 
     return @IT Overlapping geometry f # Case 1
   elseif !isempty(boundarypoints) # no segments, but some intersection
-    geometry = length(boundarypoints) == 1 ? only(boundarypoints) : first(boundarypoints) # it gotta be a single point!
+    geometry = length(boundarypoints) == 1 ? only(boundarypoints) : Multi(boundarypoints) 
     return @IT Touching geometry f # Case 2
   else
     return @IT NotIntersecting nothing f # Case 5 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -297,7 +297,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
 end
 
-# merge the continuous segments of a segment list (`pieces`) into a single geometry and push then, indicating whether they are an interior segment in the `isinterior` vector.
+# merge the continuous segments of a segment list (`pieces`) into
+# a single geometry and push then, indicating whether they are an
+# interior segment in the `isinterior` vector.
 function _pushpiece!(pieces, isinterior, piece, isint)
   if !isempty(pieces)
     prev = last(pieces)

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -10,91 +10,91 @@
 # 4. overlap of segments (Overlapping -> Segments)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg₁::Segment, seg₂::Segment)
-  a, b = vertices(seg₁)
-  c, d = vertices(seg₂)
+	a, b = vertices(seg₁)
+	c, d = vertices(seg₂)
 
-  # handle degenerate segments
-  if a == b && c == d
-    if a ≈ c
-      return @IT CornerTouching a f
-    else
-      return @IT NotIntersecting nothing f
-    end
-  elseif a == b
-    if a ≈ c || a ≈ d
-      return @IT CornerTouching a f
-    elseif a ∈ seg₂
-      return @IT EdgeTouching a f
-    else
-      return @IT NotIntersecting nothing f
-    end
-  elseif c == d
-    if c ≈ a || c ≈ b
-      return @IT CornerTouching c f
-    elseif c ∈ seg₁
-      return @IT EdgeTouching c f
-    else
-      return @IT NotIntersecting nothing f
-    end
-  end
+	# handle degenerate segments
+	if a == b && c == d
+		if a ≈ c
+			return @IT CornerTouching a f
+		else
+			return @IT NotIntersecting nothing f
+		end
+	elseif a == b
+		if a ≈ c || a ≈ d
+			return @IT CornerTouching a f
+		elseif a ∈ seg₂
+			return @IT EdgeTouching a f
+		else
+			return @IT NotIntersecting nothing f
+		end
+	elseif c == d
+		if c ≈ a || c ≈ b
+			return @IT CornerTouching c f
+		elseif c ∈ seg₁
+			return @IT EdgeTouching c f
+		else
+			return @IT NotIntersecting nothing f
+		end
+	end
 
-  l₁ = ustrip(length(seg₁))
-  l₂ = ustrip(length(seg₂))
-  b₀ = a + 1 / l₁ * (b - a)
-  d₀ = c + 1 / l₂ * (d - c)
+	l₁ = ustrip(length(seg₁))
+	l₂ = ustrip(length(seg₂))
+	b₀ = a + 1 / l₁ * (b - a)
+	d₀ = c + 1 / l₂ * (d - c)
 
-  # arc length parameters λ₁ ∈ [0, l₁], λ₂ ∈ [0, l₂]: 
-  λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
+	# arc length parameters λ₁ ∈ [0, l₁], λ₂ ∈ [0, l₂]: 
+	λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
 
-  if r ≠ rₐ # not in same plane or parallel
-    return @IT NotIntersecting nothing f #CASE 5
-  elseif r == rₐ == 1 # collinear
-    # find parameters λc and λd for points c and d in seg₁
-    # use dimension with largest vector component to avoid division by zero
-    v = b₀ - a
-    i = last(findmax(abs, v))
-    vc = c - a
-    vd = d - a
-    λc = vc[i] / v[i]
-    λd = vd[i] / v[i]
-    λc = mayberound(mayberound(λc, zero(λc)), l₁)
-    λd = mayberound(mayberound(λd, zero(λd)), l₁)
-    if (λc > l₁ && λd > l₁) || (λc < 0 && λd < 0)
-      return @IT NotIntersecting nothing f # CASE 5
-    elseif (λc == 0 && λd < 0) || (λd == 0 && λc < 0)
-      return @IT CornerTouching a f # CASE 3
-    elseif (λc == l₁ && λd > l₁) || (λd == l₁ && λc > l₁)
-      return @IT CornerTouching b f # CASE 3
-    else
-      t₁, t₂ = _sort4vals(zero(λc), one(λc), λc / l₁, λd / l₁)
-      p₁ = seg₁(t₁)
-      p₂ = seg₁(t₂)
-      return @IT Overlapping Segment(p₁, p₂) f # CASE 4
-    end
-  else # in same plane, not parallel
-    λ₁ = mayberound(mayberound(λ₁, zero(λ₁)), l₁)
-    λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
-    if λ₁ < 0 || λ₂ < 0 || λ₁ > l₁ || λ₂ > l₂
-      return @IT NotIntersecting nothing f # CASE 5
-    # 8 cases remain
-    elseif λ₁ == 0
-      if λ₂ == 0 || λ₂ == l₂
-        return @IT CornerTouching a f # CASE 3
-      else
-        return @IT EdgeTouching a f # CASE 2
-      end
-    elseif λ₁ == l₁
-      if λ₂ == 0 || λ₂ == l₂
-        return @IT CornerTouching b f # CASE 3
-      else
-        return @IT EdgeTouching b f # CASE 2
-      end
-    elseif λ₂ == 0 || λ₂ == l₂
-      return @IT EdgeTouching (λ₂ == 0 ? c : d) f # CASE 2
-    else
-      return @IT Crossing seg₁(λ₁ / l₁) f # CASE 1: equal to seg₂(λ₂/l₂)
-    end
-  end
+	if r ≠ rₐ # not in same plane or parallel
+		return @IT NotIntersecting nothing f #CASE 5
+	elseif r == rₐ == 1 # collinear
+		# find parameters λc and λd for points c and d in seg₁
+		# use dimension with largest vector component to avoid division by zero
+		v = b₀ - a
+		i = last(findmax(abs, v))
+		vc = c - a
+		vd = d - a
+		λc = vc[i] / v[i]
+		λd = vd[i] / v[i]
+		λc = mayberound(mayberound(λc, zero(λc)), l₁)
+		λd = mayberound(mayberound(λd, zero(λd)), l₁)
+		if (λc > l₁ && λd > l₁) || (λc < 0 && λd < 0)
+			return @IT NotIntersecting nothing f # CASE 5
+		elseif (λc == 0 && λd < 0) || (λd == 0 && λc < 0)
+			return @IT CornerTouching a f # CASE 3
+		elseif (λc == l₁ && λd > l₁) || (λd == l₁ && λc > l₁)
+			return @IT CornerTouching b f # CASE 3
+		else
+			t₁, t₂ = _sort4vals(zero(λc), one(λc), λc / l₁, λd / l₁)
+			p₁ = seg₁(t₁)
+			p₂ = seg₁(t₂)
+			return @IT Overlapping Segment(p₁, p₂) f # CASE 4
+		end
+	else # in same plane, not parallel
+		λ₁ = mayberound(mayberound(λ₁, zero(λ₁)), l₁)
+		λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
+		if λ₁ < 0 || λ₂ < 0 || λ₁ > l₁ || λ₂ > l₂
+			return @IT NotIntersecting nothing f # CASE 5
+		# 8 cases remain
+		elseif λ₁ == 0
+			if λ₂ == 0 || λ₂ == l₂
+				return @IT CornerTouching a f # CASE 3
+			else
+				return @IT EdgeTouching a f # CASE 2
+			end
+		elseif λ₁ == l₁
+			if λ₂ == 0 || λ₂ == l₂
+				return @IT CornerTouching b f # CASE 3
+			else
+				return @IT EdgeTouching b f # CASE 2
+			end
+		elseif λ₂ == 0 || λ₂ == l₂
+			return @IT EdgeTouching (λ₂ == 0 ? c : d) f # CASE 2
+		else
+			return @IT Crossing seg₁(λ₁ / l₁) f # CASE 1: equal to seg₂(λ₂/l₂)
+		end
+	end
 end
 
 # The intersection type can be one of five types:
@@ -105,68 +105,68 @@ end
 # 4. overlap at more than one point (Overlapping -> Segment)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment, ray::Ray)
-  Dim = embeddim(seg)
-  a, b = ray(0), ray(1)
-  c, d = seg(0), seg(1)
+	Dim = embeddim(seg)
+	a, b = ray(0), ray(1)
+	c, d = seg(0), seg(1)
 
-  # normalize points to gain parameters λ₁, λ₂ corresponding to arc lengths
-  l₁ = ustrip(norm(b - a))
-  l₂ = ustrip(length(seg))
-  b₀ = a + 1 / l₁ * (b - a)
-  d₀ = c + 1 / l₂ * (d - c)
+	# normalize points to gain parameters λ₁, λ₂ corresponding to arc lengths
+	l₁ = ustrip(norm(b - a))
+	l₂ = ustrip(length(seg))
+	b₀ = a + 1 / l₁ * (b - a)
+	d₀ = c + 1 / l₂ * (d - c)
 
-  λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
+	λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
 
-  # not in same plane or parallel
-  if r ≠ rₐ
-    return @IT NotIntersecting nothing f # CASE 5
-  # collinear
-  elseif r == rₐ == 1
-    rc = sum((c - a) ./ (b - a)) / Dim
-    rd = sum((d - a) ./ (b - a)) / Dim
-    rc = mayberound(rc, zero(rc))
-    rd = mayberound(rd, zero(rd))
-    if rc > 0 # c ∈ ray
-      if rd ≥ 0
-        return @IT Overlapping seg f # CASE 4
-      else
-        return @IT Overlapping Segment(ray(0), c) f # CASE 4
-      end
-    elseif rc == 0
-      if rd > 0
-        return @IT Overlapping seg f # CASE 4
-      else
-        return @IT CornerTouching a f # CASE 3
-      end
-    else # rc < 0
-      if rd > 0
-        return @IT Overlapping (Segment(ray(0), d)) f # CASE 4
-      elseif rd == 0
-        return @IT CornerTouching a f # CASE 3
-      else
-        return @IT NotIntersecting nothing f
-      end
-    end
-    # in same plane, not parallel
-  else
-    λ₁ = mayberound(λ₁, zero(λ₁))
-    λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
-    if λ₁ < 0 || (λ₂ < 0 || λ₂ > l₂)
-      return @IT NotIntersecting nothing f
-    elseif λ₁ == 0
-      if λ₂ == 0 || λ₂ == l₂
-        return @IT CornerTouching a f # CASE 3
-      else
-        return @IT EdgeTouching a f # CASE 2
-      end
-    else
-      if λ₂ == 0 || λ₂ == l₂
-        return @IT EdgeTouching (λ₂ < l₂ / 2 ? c : d) f # CASE 2
-      else
-        return @IT Crossing ray(λ₁ / l₁) f # CASE 1, equal to seg(λ₂/l₂)
-      end
-    end
-  end
+	# not in same plane or parallel
+	if r ≠ rₐ
+		return @IT NotIntersecting nothing f # CASE 5
+	# collinear
+	elseif r == rₐ == 1
+		rc = sum((c - a) ./ (b - a)) / Dim
+		rd = sum((d - a) ./ (b - a)) / Dim
+		rc = mayberound(rc, zero(rc))
+		rd = mayberound(rd, zero(rd))
+		if rc > 0 # c ∈ ray
+			if rd ≥ 0
+				return @IT Overlapping seg f # CASE 4
+			else
+				return @IT Overlapping Segment(ray(0), c) f # CASE 4
+			end
+		elseif rc == 0
+			if rd > 0
+				return @IT Overlapping seg f # CASE 4
+			else
+				return @IT CornerTouching a f # CASE 3
+			end
+		else # rc < 0
+			if rd > 0
+				return @IT Overlapping (Segment(ray(0), d)) f # CASE 4
+			elseif rd == 0
+				return @IT CornerTouching a f # CASE 3
+			else
+				return @IT NotIntersecting nothing f
+			end
+		end
+		# in same plane, not parallel
+	else
+		λ₁ = mayberound(λ₁, zero(λ₁))
+		λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
+		if λ₁ < 0 || (λ₂ < 0 || λ₂ > l₂)
+			return @IT NotIntersecting nothing f
+		elseif λ₁ == 0
+			if λ₂ == 0 || λ₂ == l₂
+				return @IT CornerTouching a f # CASE 3
+			else
+				return @IT EdgeTouching a f # CASE 2
+			end
+		else
+			if λ₂ == 0 || λ₂ == l₂
+				return @IT EdgeTouching (λ₂ < l₂ / 2 ? c : d) f # CASE 2
+			else
+				return @IT Crossing ray(λ₁ / l₁) f # CASE 1, equal to seg(λ₂/l₂)
+			end
+		end
+	end
 end
 
 # The intersection type can be one of six types:
@@ -175,32 +175,32 @@ end
 # 3. overlap of line and segment (Overlapping -> Segment)
 # 4. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment, line::Line)
-  a, b = line(0), line(1)
-  c, d = seg(0), seg(1)
+	a, b = line(0), line(1)
+	c, d = seg(0), seg(1)
 
-  # normalize points to gain parameter λ₂ corresponding to arc lengths
-  l₂ = ustrip(length(seg))
-  d₀ = c + 1 / l₂ * (d - c)
+	# normalize points to gain parameter λ₂ corresponding to arc lengths
+	l₂ = ustrip(length(seg))
+	d₀ = c + 1 / l₂ * (d - c)
 
-  _, λ₂, r, rₐ = intersectparameters(a, b, c, d₀)
+	_, λ₂, r, rₐ = intersectparameters(a, b, c, d₀)
 
-  # not in same plane or parallel
-  if r ≠ rₐ
-    return @IT NotIntersecting nothing f # CASE 4
-  # collinear
-  elseif r == rₐ == 1
-    return @IT Overlapping seg f # CASE 3
-  # in same plane, not parallel
-  else
-    λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
-    if λ₂ > 0 && λ₂ < l₂
-      return @IT Crossing seg(λ₂ / l₂) f # CASE 1, equal to line(λ₁)
-    elseif λ₂ == 0 || λ₂ == l₂
-      return @IT Touching ((λ₂ == 0) ? c : d) f # CASE 2
-    else
-      return @IT NotIntersecting nothing f # CASE 4
-    end
-  end
+	# not in same plane or parallel
+	if r ≠ rₐ
+		return @IT NotIntersecting nothing f # CASE 4
+	# collinear
+	elseif r == rₐ == 1
+		return @IT Overlapping seg f # CASE 3
+	# in same plane, not parallel
+	else
+		λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
+		if λ₂ > 0 && λ₂ < l₂
+			return @IT Crossing seg(λ₂ / l₂) f # CASE 1, equal to line(λ₁)
+		elseif λ₂ == 0 || λ₂ == l₂
+			return @IT Touching ((λ₂ == 0) ? c : d) f # CASE 2
+		else
+			return @IT NotIntersecting nothing f # CASE 4
+		end
+	end
 end
 
 # intersection between a segment and a polygon
@@ -211,218 +211,263 @@ end
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
-  a, b = vertices(seg); segbbox = boundingbox(seg); polybbox = boundingbox(poly)
+	a, b = vertices(seg)
+	segbbox = boundingbox(seg)
+	polybbox = boundingbox(poly)
 
-  # check for degenerate segments
-  if a ≈ b
-    if a ∈ poly
-      return @IT Touching a f # Case 3
-    else
-      return @IT NotIntersecting nothing f # Case 4
-    end
-  end
+	# check for degenerate segments
+	if a ≈ b
+		if a ∈ poly
+			return @IT Touching a f # Case 3
+		else
+			return @IT NotIntersecting nothing f # Case 4
+		end
+	end
 
-  # assess obvious no intersection case beforehand
-  if !intersects(segbbox, polybbox)
-    return @IT NotIntersecting nothing f # Case 5
-  end
-  
-  # segment endpoints as scalars + segment vector
-  segλs = [0.0, 1.0]; v = b-a;
+	# assess obvious no intersection case beforehand
+	if !intersects(segbbox, polybbox)
+		return @IT NotIntersecting nothing f # Case 5
+	end
 
-  # assess intersections with the edges
-  boundarypoints = Point[]
-  for ring in rings(poly)
-    ringbbox = boundingbox(ring)
-    for edge in segments(ring)
-      intersects(segbbox, ringbbox) || continue
-      edgebbox = boundingbox(edge)
-      if intersects(segbbox, edgebbox)
-        intersection(seg, edge) do I
-          # no intersection
-          if type(I) == NotIntersecting
-            return
-          end
-          # some intersection
-          geom = get(I)
-          if geom isa Point # Crossing, EdgeTouching, CornerTouching, etc.
-            push!(boundarypoints, geom)
-            λ = ustrip((geom-a) ⋅ v / (v ⋅ v))
-            push!(segλs, λ)
-          elseif geom isa Segment # Overlapping collinear segments
-            c, d = vertices(geom)
-            λc = ustrip((c-a) ⋅ v / (v ⋅ v))
-            λd = ustrip((d-a) ⋅ v / (v ⋅ v))
-            push!(segλs, λc, λd)
-          else
-            @error "Unexpected Segment × Polygon edge intersection geometry: " * "$(typeof(geom))"
-          end
-        end
-      end
-    end
-  end
+	# segment endpoints as scalars + segment vector
+	segλs = [0.0, 1.0];
+	v = b-a;
 
-  # Define collection of intersected segment pieces
-  sort!(segλs); pieces = Segment[]
-  for (λ₁, λ₂) in zip(segλs[1:(end - 1)], segλs[2:end])
-    λ₁ ≈ λ₂ && continue
-    λmid = (λ₁ + λ₂) / 2
-    if seg(λmid) ∈ poly
-      push!(
-        pieces,
-        Segment(seg(λ₁), seg(λ₂))
-      )
-    end
-  end
+	# Extract the first Cartesian coordinate
+	x(p) = flat(coords(p)).x
+	y(p) = flat(coords(p)).y
 
-  # classifying intersections
-  if !isempty(pieces) # Positive-length intersection
-    geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces) 
-    return @IT Overlapping geometry f # Case 1
-  elseif !isempty(boundarypoints) # no segments, but some intersection
-    geometry = length(boundarypoints) == 1 ? only(boundarypoints) : Multi(boundarypoints) 
-    return @IT Touching geometry f # Case 2
-  else
-    return @IT NotIntersecting nothing f # Case 5 
-  end 
+	# Choose the polygon's longest bounding-box axis
+	polymin, polymax = extrema(polybbox)
+	xspan = x(polymax) - x(polymin)
+	yspan = y(polymax) - y(polymin)
+	axiscoord = xspan ≥ yspan ? x : y
+
+	# Segment range along the chosen axis
+	segmin, segmax = extrema(segbbox)
+	segstart = axiscoord(segmin)
+	segstop = axiscoord(segmax)
+
+	# assess intersections
+	boundarypoints = Point[]
+	for ring in rings(poly)
+		ringbbox = boundingbox(ring)
+		# check for obvious no intersection case beforehand
+		intersects(segbbox, ringbbox) || continue
+		edges = collect(segments(ring))
+		boxes = boundingbox.(edges)
+		# Edge ranges
+		starts = map(boxes) do box
+			pmin, _ = extrema(box)
+			axiscoord(pmin)
+		end
+		stops = map(boxes) do box
+			_, pmax = extrema(box)
+			axiscoord(pmax)
+		end
+
+		# Sort by minimum coordinate
+		inds = sortperm(starts)
+		edges = edges[inds]
+		boxes = boxes[inds]
+		starts = starts[inds]
+		stops = stops[inds]
+		for i in eachindex(edges)
+			# Edge ends before the segment begins. Later edges may still overlap, so skip only this edge.
+			stops[i] < segstart && continue
+
+			# Edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right.
+			starts[i] > segstop && break
+
+			# The selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
+			intersects(segbbox, boxes[i]) || continue
+
+			edge = edges[i]
+			intersection(seg, edge) do I
+				itype = type(I)
+				# no intersection
+				if itype == NotIntersecting
+					return
+				elseif itype == Overlapping
+					# Overlapping segments
+					seg = get(I)
+					c, d = vertices(seg)
+					λc = ustrip((c-a) ⋅ v / (v ⋅ v))
+					λd = ustrip((d-a) ⋅ v / (v ⋅ v))
+					push!(segλs, λc, λd)
+				else
+					# Crossing, EdgeTouching, CornerTouching, etc.
+					p = get(I)
+					push!(boundarypoints, p)
+					λ = ustrip((p-a) ⋅ v / (v ⋅ v))
+					push!(segλs, λ)
+				end
+			end
+		end
+	end
+
+	# Define collection of intersected segment pieces
+	sort!(segλs);
+	pieces = Segment[]
+	for (λ₁, λ₂) in zip(segλs[1:(end-1)], segλs[2:end])
+		λ₁ ≈ λ₂ && continue
+		λmid = (λ₁ + λ₂) / 2
+		if seg(λmid) ∈ poly
+			push!(
+				pieces,
+				Segment(seg(λ₁), seg(λ₂)),
+			)
+		end
+	end
+
+	# classifying intersections
+	if !isempty(pieces) # Positive-length intersection
+		geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces)
+		return @IT Overlapping geometry f # Case 1
+	elseif !isempty(boundarypoints) # no segments, but some intersection
+		geometry = length(boundarypoints) == 1 ? only(boundarypoints) : Multi(boundarypoints)
+		return @IT Touching geometry f # Case 2
+	else
+		return @IT NotIntersecting nothing f # Case 5 
+	end
 
 end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.
 # (https://www.sciencedirect.com/science/article/pii/S0925772109001448?via%3Dihub)
 function intersection(f, seg::Segment{𝔼{3}}, tri::Triangle{𝔼{3}})
-  Q1, Q2 = vertices(seg)
-  V1, V2, V3 = vertices(tri)
+	Q1, Q2 = vertices(seg)
+	V1, V2, V3 = vertices(tri)
 
-  # according to theorem 1, the algorithm only works
-  # when Q1 is not coplanar with the triangle, we need
-  # to swap Q1 with Q2 in that case
-  if iscoplanar(Q1, V1, V2, V3)
-    (Q1, Q2) = (Q2, Q1)
-  end
+	# according to theorem 1, the algorithm only works
+	# when Q1 is not coplanar with the triangle, we need
+	# to swap Q1 with Q2 in that case
+	if iscoplanar(Q1, V1, V2, V3)
+		(Q1, Q2) = (Q2, Q1)
+	end
 
-  A = Q1 - V3
-  B = V1 - V3
-  C = V2 - V3
+	A = Q1 - V3
+	B = V1 - V3
+	C = V2 - V3
 
-  W₁ = B × C
-  w = A ⋅ W₁
+	W₁ = B × C
+	w = A ⋅ W₁
 
-  D = Q2 - V3
-  s = D ⋅ W₁
+	D = Q2 - V3
+	s = D ⋅ W₁
 
-  if w > atol(w)
-    # rejection 2
-    if s > atol(s)
-      return @IT NotIntersecting nothing f
-    end
+	if w > atol(w)
+		# rejection 2
+		if s > atol(s)
+			return @IT NotIntersecting nothing f
+		end
 
-    W₂ = A × D
-    t = W₂ ⋅ C
+		W₂ = A × D
+		t = W₂ ⋅ C
 
-    # rejection 3
-    if t < -atol(t)
-      return @IT NotIntersecting nothing f
-    end
+		# rejection 3
+		if t < -atol(t)
+			return @IT NotIntersecting nothing f
+		end
 
-    u = -(W₂ ⋅ B)
+		u = -(W₂ ⋅ B)
 
-    # rejection 4
-    if u < -atol(u)
-      return @IT NotIntersecting nothing f
-    end
+		# rejection 4
+		if u < -atol(u)
+			return @IT NotIntersecting nothing f
+		end
 
-    # rejection 5
-    if w < (s + t + u)
-      return @IT NotIntersecting nothing f
-    end
-  elseif w < -atol(w)
-    # rejection 2
-    if s < -atol(s)
-      return @IT NotIntersecting nothing f
-    end
+		# rejection 5
+		if w < (s + t + u)
+			return @IT NotIntersecting nothing f
+		end
+	elseif w < -atol(w)
+		# rejection 2
+		if s < -atol(s)
+			return @IT NotIntersecting nothing f
+		end
 
-    W₂ = A × D
-    t = W₂ ⋅ C
+		W₂ = A × D
+		t = W₂ ⋅ C
 
-    # rejection 3
-    if t > atol(t)
-      return @IT NotIntersecting nothing f
-    end
+		# rejection 3
+		if t > atol(t)
+			return @IT NotIntersecting nothing f
+		end
 
-    u = -(W₂ ⋅ B)
+		u = -(W₂ ⋅ B)
 
-    # rejection 4
-    if u > atol(u)
-      return @IT NotIntersecting nothing f
-    end
+		# rejection 4
+		if u > atol(u)
+			return @IT NotIntersecting nothing f
+		end
 
-    # rejection 5
-    if w > (s + t + u)
-      return @IT NotIntersecting nothing f
-    end
-  else # w ≈ 0
-    if s > atol(s)
-      W₂ = D × A
-      t = W₂ ⋅ C
+		# rejection 5
+		if w > (s + t + u)
+			return @IT NotIntersecting nothing f
+		end
+	else # w ≈ 0
+		if s > atol(s)
+			W₂ = D × A
+			t = W₂ ⋅ C
 
-      # rejection 3
-      if t < -atol(t)
-        return @IT NotIntersecting nothing f
-      end
+			# rejection 3
+			if t < -atol(t)
+				return @IT NotIntersecting nothing f
+			end
 
-      u = -(W₂ ⋅ B)
+			u = -(W₂ ⋅ B)
 
-      # rejection 4
-      if u < -atol(u)
-        return @IT NotIntersecting nothing f
-      end
+			# rejection 4
+			if u < -atol(u)
+				return @IT NotIntersecting nothing f
+			end
 
-      # rejection 5
-      if -s < (t + u)
-        return @IT NotIntersecting nothing f
-      end
-    elseif s < -atol(s)
-      W₂ = D × A
-      t = W₂ ⋅ C
+			# rejection 5
+			if -s < (t + u)
+				return @IT NotIntersecting nothing f
+			end
+		elseif s < -atol(s)
+			W₂ = D × A
+			t = W₂ ⋅ C
 
-      # rejection 3
-      if t > atol(t)
-        return @IT NotIntersecting nothing f
-      end
+			# rejection 3
+			if t > atol(t)
+				return @IT NotIntersecting nothing f
+			end
 
-      u = -(W₂ ⋅ B)
+			u = -(W₂ ⋅ B)
 
-      # rejection 4
-      if u > atol(u)
-        return @IT NotIntersecting nothing f
-      end
+			# rejection 4
+			if u > atol(u)
+				return @IT NotIntersecting nothing f
+			end
 
-      # rejection 5
-      if -s > (t + u)
-        return @IT NotIntersecting nothing f
-      end
-    else # s ≈ 0
-      # rejection 1, coplanar segment
-      return @IT NotIntersecting nothing f
-    end
-  end
+			# rejection 5
+			if -s > (t + u)
+				return @IT NotIntersecting nothing f
+			end
+		else # s ≈ 0
+			# rejection 1, coplanar segment
+			return @IT NotIntersecting nothing f
+		end
+	end
 
-  λ = w / (w - s)
-  λ = clamp(λ, zero(λ), one(λ))
+	λ = w / (w - s)
+	λ = clamp(λ, zero(λ), one(λ))
 
-  p = Segment(Q1, Q2)(λ)
+	p = Segment(Q1, Q2)(λ)
 
-  return @IT Intersecting p f
+	return @IT Intersecting p f
 end
 
 # sorts four numbers using a sorting network 
 # and returns the 2nd and 3rd
 function _sort4vals(a, b, c, d)
-  a > c && ((a, c) = (c, a))
-  b > d && ((b, d) = (d, b))
-  a > b && ((a, b) = (b, a))
-  c > d && ((c, d) = (d, c))
-  b > c && ((b, c) = (c, b))
-  b, c
+	a > c && ((a, c) = (c, a))
+	b > d && ((b, d) = (d, b))
+	a > b && ((a, b) = (b, a))
+	c > d && ((c, d) = (d, c))
+	b > c && ((b, c) = (c, b))
+	b, c
 end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -258,10 +258,10 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       depth += eᵢ[3]
       piece = Segment(eᵢ[1], eⱼ[1])
       if depth > 0 
-        _pushpiece!(pieces, piece) 
+        push!(pieces, piece) 
       elseif center(piece) ∈ poly 
         inpoly = true 
-        _pushpiece!(pieces, piece) 
+        push!(pieces, piece) 
       end
       i += 1
       events[i] = eⱼ
@@ -296,21 +296,6 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   else
     return @IT NotIntersecting nothing f
   end
-end
-
-# merge the continuous segments of a segment list (`pieces`) into
-# a single geometry and push then.
-function _pushpiece!(pieces, piece)
-  if !isempty(pieces)
-    prev = last(pieces)
-    p₁, p₂ = vertices(prev)
-    q₁, q₂ = vertices(piece)
-    if p₂ ≈ q₁
-      pieces[end] = Segment(p₁, q₂)
-      return
-    end
-  end
-  push!(pieces, piece)
 end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -317,7 +317,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
 
   # classifying intersections
-  if !isempty(pieces) # Positive-length intersection
+  if !isempty(pieces) # positive-length intersection
     geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces)
     return @IT Overlapping geometry f # Case 1
   elseif !isempty(boundarypoints) # no segments, but some intersection

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -213,73 +213,19 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   pbox = boundingbox(poly)
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
 
-  # check for degenerate segments
-  a, b = vertices(seg)
-  if a ≈ b
-    isvertex = any(≈(a), eachvertex(poly))
-    if a ∈ poly && !isvertex
-      return @IT Touching a f
-    elseif isvertex
-      return @IT CornerTouching a f
-    end
-  end
-
-  # coordinate with largest bounding box side
-  xside, yside = sides(pbox)
-  x(p) = flat(coords(p)).x
-  y(p) = flat(coords(p)).y
-  coord = xside ≥ yside ? x : y
-
-  # segment range along the chosen axis
-  smin, smax = extrema(sbox)
-  sstart = coord(smin)
-  sstop = coord(smax)
-
   # assess intersections
+  a, b = vertices(seg)
+  splitpoints = typeof(a)[a, b]
   boundarypoints = typeof(a)[]
-  boundaryoverlaps = Tuple{Float64,Float64}[]
-
-  # segment endpoints as scalars + segment vector
-  λs = [0.0, 1.0]
-  v = (b-a) / ((b-a) ⋅ (b-a))
+  boundaryoverlaps = typeof(seg)[]
 
   for ring in rings(poly)
     rbox = boundingbox(ring)
-
     # check for obvious no intersection case beforehand
     intersects(sbox, rbox) || continue
-
-    edges = collect(segments(ring))
-    ebox = boundingbox.(edges)
-
-    # edge ranges
-    estart = map(ebox) do box
-      pmin, _ = extrema(box)
-      coord(pmin)
-    end
-    estop = map(ebox) do box
-      _, pmax = extrema(box)
-      coord(pmax)
-    end
-
-    # sort by minimum coordinate
-    inds = sortperm(estart)
-    edges = edges[inds]
-    ebox = ebox[inds]
-    estart = estart[inds]
-    estop = estop[inds]
-
-    for i in eachindex(edges)
-      # edge ends before the segment begins. Later edges may still overlap, so skip only this edge.
-      estop[i] < sstart && continue
-
-      # edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right.
-      estart[i] > sstop && break
-
+    for edge in segments(ring)
       # the selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
-      intersects(sbox, ebox[i]) || continue
-
-      edge = edges[i]
+      intersects(sbox, boundingbox(edge)) || continue
       intersection(seg, edge) do I
         itype = type(I)
         if itype == NotIntersecting
@@ -287,58 +233,38 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
         elseif itype == Overlapping
           overlap = get(I)
           c, d = vertices(overlap)
-          λc = ustrip((c - a) ⋅ v)
-          λd = ustrip((d - a) ⋅ v)
-          λ₁, λ₂ = minmax(λc, λd)
-          push!(λs, λ₁, λ₂)
-          push!(boundaryoverlaps, (λ₁, λ₂))
+          push!(splitpoints, c, d)
+          push!(boundaryoverlaps, overlap)
         else
           p = get(I)
+          push!(splitpoints, p)
           push!(boundarypoints, p)
-          λ = ustrip((p - a) ⋅ v)
-          push!(λs, λ)
         end
       end
     end
   end
+  unique!(boundarypoints)
+  dir = normalize(b-a)
+  λ(p) = ustrip((p - a) ⋅ dir)
+  sort!(splitpoints, by=λ)
 
-  # get unique boundary points
-  uniquepoints = typeof(a)[]
-  for p in boundarypoints
-    any(q -> q ≈ p, uniquepoints) || push!(uniquepoints, p)
-  end
-  boundarypoints = uniquepoints
-
-  # remove duplicate λ values and sort them
-  sort!(λs)
-  for i in 2:length(λs)
-    λs[i] = mayberound(λs[i], λs[i - 1])
-  end
-  unique!(λs)
-
-  # check if a λ value lies in a boundary overlap
-  function inboundaryoverlap(λ)
-    any(boundaryoverlaps) do (λ₁, λ₂)
-      λ₁ < λ < λ₂ || λ ≈ λ₁ || λ ≈ λ₂
-    end
-  end
-
-  # create segments from the λ values
+  # create resulting intersection segments from base intersection points
   pieces = typeof(seg)[]
   interiorpieces = typeof(seg)[]
   boundarypieces = typeof(seg)[]
-  for i in 1:(length(λs) - 1)
-    λ₁ = λs[i]
-    λ₂ = λs[i + 1]
+  for i in 1:(length(splitpoints) - 1)
+    p₁ = splitpoints[i]
+    p₂ = splitpoints[i + 1]
 
-    λ₁ ≈ λ₂ && continue
+    p₁ ≈ p₂ && continue
 
-    λₘ = (λ₁ + λ₂) / 2
-    piece = Segment(seg(λ₁), seg(λ₂))
-    if inboundaryoverlap(λₘ)
+    piece = Segment(p₁, p₂)
+    midpoint = piece(0.5)
+
+    if any(overlap -> midpoint ∈ overlap, boundaryoverlaps)
       push!(pieces, piece)
       push!(boundarypieces, piece)
-      elseif seg(λₘ) ∈ poly
+    elseif midpoint ∈ poly
       push!(pieces, piece)
       push!(interiorpieces, piece)
     end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -209,7 +209,7 @@ end
 # 3. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 4. the segment is degenerate and is outside the polygon (NotIntersecting -> Nothing)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
-function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
+function intersection(f, seg::Segment, poly::Polygon)
 
   a, b = vertices(seg)
 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -215,8 +215,8 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
   # collect and classify boundary events
   a, b = vertices(seg)
-  events = [(a, false, Int8(0)), (b, false, Int8(0))] # event = (point, docross, overlap)
   λ(p) = (p - a) ⋅ (b - a)
+  events = [(a, false, 0), (b, false, 0)] # event = (point, crosses, overlaps)
   for ring in rings(poly)
     intersects(sbox, boundingbox(ring)) || continue
     for edge in segments(ring)
@@ -229,11 +229,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
         if λ(d) < λ(c)
           c, d = d, c
         end
-        push!(events, (c, false, Int8(1)))
-        push!(events, (d, false, Int8(-1)))
+        push!(events, (c, false, 1))
+        push!(events, (d, false, -1))
       else
         p = get(I)
-        push!(events, (p, true, Int8(0)))
+        push!(events, (p, true, 0))
       end
     end
   end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -210,8 +210,13 @@ end
 # 6. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   a, b = vertices(seg)
-  segbbox = boundingbox(seg)
-  polybbox = boundingbox(poly)
+
+  # check bounding boxes for early exit
+  sbox = boundingbox(seg)
+  pbox = boundingbox(poly)
+  if !intersects(sbox, pbox)
+    return @IT NotIntersecting nothing f # Case 6
+  end
 
   # check for degenerate segments
   if a ≈ b && a ∈ poly && !any(v -> a ≈ v, vertices(poly))
@@ -220,28 +225,23 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     return @IT CornerTouching a f # Case 3
   end
 
-  # assess obvious no intersection case beforehand
-  if !intersects(segbbox, polybbox)
-    return @IT NotIntersecting nothing f # Case 6
-  end
-
   # segment endpoints as scalars + segment vector
   segλs = [0.0, 1.0]
   v = b - a
   v² = v ⋅ v
 
-  # extract the first Cartesian coordinate
+  # extract flat xy coordinates
   x(p) = flat(coords(p)).x
   y(p) = flat(coords(p)).y
 
   # choose the polygon's longest bounding-box axis
-  polymin, polymax = extrema(polybbox)
+  polymin, polymax = extrema(pbox)
   xside = x(polymax) - x(polymin)
   yside = y(polymax) - y(polymin)
   axiscoord = xside ≥ yside ? x : y
 
   # segment range along the chosen axis
-  segmin, segmax = extrema(segbbox)
+  segmin, segmax = extrema(sbox)
   segstart = axiscoord(segmin)
   segstop = axiscoord(segmax)
 
@@ -253,7 +253,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     ringbbox = boundingbox(ring)
 
     # check for obvious no intersection case beforehand
-    intersects(segbbox, ringbbox) || continue
+    intersects(sbox, ringbbox) || continue
 
     edges = collect(segments(ring))
     boxes = boundingbox.(edges)
@@ -283,7 +283,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       starts[i] > segstop && break
 
       # the selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
-      intersects(segbbox, boxes[i]) || continue
+      intersects(sbox, boxes[i]) || continue
 
       edge = edges[i]
       intersection(seg, edge) do I

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -246,7 +246,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   i = 1
   depth = 0
   pieces = typeof(seg)[]
-  isinterior = Bool[]
+  anyinterior = false
   for j in 2:length(events)
     eᵢ = events[i]
     eⱼ = events[j]
@@ -257,10 +257,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       # eᵢ is fully merged, so piece it with the next distinct event
       depth += eᵢ[3]
       piece = Segment(eᵢ[1], eⱼ[1])
-      if depth > 0
-        _pushpiece!(pieces, isinterior, piece, false)
-      elseif center(piece) ∈ poly
-        _pushpiece!(pieces, isinterior, piece, true)
+      if depth > 0 
+        _pushpiece!(pieces, piece) 
+      elseif center(piece) ∈ poly 
+        _pushpiece!(pieces, piece) 
+        anyinterior = true 
       end
       i += 1
       events[i] = eⱼ
@@ -275,7 +276,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   ncrosses = count(e -> e[2], events)
 
   # classify intersection
-  if any(isinterior)
+  if anyinterior
     return @IT Intersecting glue(pieces) f
   elseif !isempty(pieces)
     return @IT EdgeTouching glue(pieces) f
@@ -298,21 +299,18 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 end
 
 # merge the continuous segments of a segment list (`pieces`) into
-# a single geometry and push then, indicating whether they are an
-# interior segment in the `isinterior` vector.
-function _pushpiece!(pieces, isinterior, piece, isint)
+# a single geometry and push then.
+function _pushpiece!(pieces, piece)
   if !isempty(pieces)
     prev = last(pieces)
     p₁, p₂ = vertices(prev)
     q₁, q₂ = vertices(piece)
     if p₂ ≈ q₁
       pieces[end] = Segment(p₁, q₂)
-      isinterior[end] |= isint
       return
     end
   end
   push!(pieces, piece)
-  push!(isinterior, isint)
 end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -216,7 +216,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # collect and classify boundary events, which are of the
   # form (point, iscrossing, endtype). The endtype is +1 if
   # the segment is entering the polygon, -1 if it is leaving
-  # the polygon, and 0 if it is neither (e.g. crossing)
+  # the polygon, and 0 otherwise
   a, b = vertices(seg)
   λ(p) = (p - a) ⋅ (b - a)
   events = [(a, false, Int8(0)), (b, false, Int8(0))]

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -201,15 +201,14 @@ function intersection(f, seg::Segment, line::Line)
   end
 end
 
-# The intersection type can be one of six types:
+# intersection between a segment and a polygon
 # 1. overlap with the polygon interior (Intersecting -> Segment or Multi)
-# 2. overlap with a polygon edge (EdgeTouching -> Segment or Multi)
+# 2. overlap with a polygon edge only (EdgeTouching -> Segment or Multi)
 # 3. intersect at a polygon vertex (CornerTouching -> Point)
-# 4. intersect at an endpoint of the segment (Touching -> Point)
-# 5. the segment is degenerate and is inside the polygon (Touching -> Point)
-# 6. do not overlap nor intersect (NotIntersecting -> Nothing)
+# 4. intersect at a single non-vertex point (Touching -> Point)
+# 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
-  # check bounding boxes for early exit
+  # check bounding ebox for early exit
   sbox = boundingbox(seg)
   pbox = boundingbox(poly)
   if !intersects(sbox, pbox)
@@ -224,64 +223,64 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     return @IT CornerTouching a f
   end
 
-  # segment endpoints as scalars + segment vector
-  λs = [0.0, 1.0]
-  v = normalize(b - a)
-
   # extract flat xy coordinates
   x(p) = flat(coords(p)).x
   y(p) = flat(coords(p)).y
 
   # choose the polygon's longest bounding-box axis
-  polymin, polymax = extrema(pbox)
-  xside = x(polymax) - x(polymin)
-  yside = y(polymax) - y(polymin)
+  pmin, pmax = extrema(pbox)
+  xside = x(pmax) - x(pmin)
+  yside = y(pmax) - y(pmin)
   axiscoord = xside ≥ yside ? x : y
 
   # segment range along the chosen axis
-  segmin, segmax = extrema(sbox)
-  segstart = axiscoord(segmin)
-  segstop = axiscoord(segmax)
+  smin, smax = extrema(sbox)
+  sstart = axiscoord(smin)
+  sstop = axiscoord(smax)
 
   # assess intersections
   boundarypoints = typeof(a)[]
   boundaryoverlaps = Tuple{Float64,Float64}[]
 
+  # segment endpoints as scalars + segment vector
+  λs = [0.0, 1.0]
+  v = (b-a) / ((b-a) ⋅ (b-a))
+
   for ring in rings(poly)
-    ringbbox = boundingbox(ring)
+    rbox = boundingbox(ring)
 
     # check for obvious no intersection case beforehand
-    intersects(sbox, ringbbox) || continue
+    intersects(sbox, rbox) || continue
 
     edges = collect(segments(ring))
-    boxes = boundingbox.(edges)
+    ebox = boundingbox.(edges)
 
     # edge ranges
-    starts = map(boxes) do box
+    estart = map(ebox) do box
       pmin, _ = extrema(box)
       axiscoord(pmin)
     end
-    stops = map(boxes) do box
+    estop = map(ebox) do box
       _, pmax = extrema(box)
       axiscoord(pmax)
     end
 
     # sort by minimum coordinate
-    inds = sortperm(starts)
+    inds = sortperm(estart)
     edges = edges[inds]
-    boxes = boxes[inds]
-    starts = starts[inds]
-    stops = stops[inds]
+    ebox = ebox[inds]
+    estart = estart[inds]
+    estop = estop[inds]
 
     for i in eachindex(edges)
       # edge ends before the segment begins. Later edges may still overlap, so skip only this edge.
-      stops[i] < segstart && continue
+      estop[i] < sstart && continue
 
       # edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right.
-      starts[i] > segstop && break
+      estart[i] > sstop && break
 
       # the selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
-      intersects(sbox, boxes[i]) || continue
+      intersects(sbox, ebox[i]) || continue
 
       edge = edges[i]
       intersection(seg, edge) do I

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -245,8 +245,8 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # collect unique intersection pieces
   i = 1
   depth = 0
+  inpoly = false
   pieces = typeof(seg)[]
-  anyinterior = false
   for j in 2:length(events)
     eᵢ = events[i]
     eⱼ = events[j]
@@ -260,8 +260,8 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       if depth > 0 
         _pushpiece!(pieces, piece) 
       elseif center(piece) ∈ poly 
+        inpoly = true 
         _pushpiece!(pieces, piece) 
-        anyinterior = true 
       end
       i += 1
       events[i] = eⱼ
@@ -276,7 +276,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   ncrosses = count(e -> e[2], events)
 
   # classify intersection
-  if anyinterior
+  if inpoly
     return @IT Intersecting glue(pieces) f
   elseif !isempty(pieces)
     return @IT EdgeTouching glue(pieces) f

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -214,7 +214,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
   # collect boundary events
   a, b = vertices(seg)
-  events = Tuple{typeof(a),Bool,Int8}[(a, false, Int8(0)), (b, false, Int8(0))] # event = (point, docross, overlap)
+  events = [(a, false, Int8(0)), (b, false, Int8(0))] # event = (point, docross, overlap)
   λ(p) = (p - a) ⋅ (b - a)
   for ring in rings(poly)
     intersects(sbox, boundingbox(ring)) || continue

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -3,7 +3,6 @@
 # ------------------------------------------------------------------
 
 # The intersection type can be one of five types:
-#
 # 1. intersect at one inner point (Crossing -> Point)
 # 2. intersect at one endpoint of one segment (EdgeTouching -> Point)
 # 3. intersect at one endpoint of both segments (CornerTouching -> Point)
@@ -98,7 +97,6 @@ function intersection(f, seg₁::Segment, seg₂::Segment)
 end
 
 # The intersection type can be one of five types:
-# 
 # 1. intersect at one inner point (Crossing -> Point)
 # 2. intersect at one end point of segment xor origin of ray (EdgeTouching -> Point)
 # 3. intersects at one end point of segment and origin of ray (CornerTouching -> Point)
@@ -169,7 +167,7 @@ function intersection(f, seg::Segment, ray::Ray)
   end
 end
 
-# The intersection type can be one of six types:
+# The intersection type can be one of four types:
 # 1. intersect at one inner point (Crossing -> Point)
 # 2. intersect at an end point of segment (Touching -> Point)
 # 3. overlap of line and segment (Overlapping -> Segment)
@@ -203,11 +201,11 @@ function intersection(f, seg::Segment, line::Line)
   end
 end
 
-# intersection between a segment and a polygon
+# The intersection type can be one of six types:
 # 1. overlap with the polygon interior (Intersecting -> Segment or Multi)
-# 2. overlap with a polygon edge only (EdgeTouching -> Segment or Multi)
+# 2. overlap with a polygon edge (EdgeTouching -> Segment or Multi)
 # 3. intersect at a polygon vertex (CornerTouching -> Point)
-# 4. intersect only at an endpoint of the segment, though not at a poligon vertex (Touching -> Point)
+# 4. intersect at an endpoint of the segment (Touching -> Point)
 # 5. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 6. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -208,11 +208,12 @@ end
 # 4. intersect at a single non-vertex point (Touching -> Point)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
+  # early exit if bounding boxes do not intersect
   sbox = boundingbox(seg)
   pbox = boundingbox(poly)
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
 
-  # collect boundary events
+  # collect and classify boundary events
   a, b = vertices(seg)
   events = [(a, false, Int8(0)), (b, false, Int8(0))] # event = (point, docross, overlap)
   λ(p) = (p - a) ⋅ (b - a)
@@ -221,10 +222,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     for edge in segments(ring)
       intersects(sbox, boundingbox(edge)) || continue
       I = intersection(seg, edge)
-      itype = type(I)
-      if itype == NotIntersecting
+      if type(I) == NotIntersecting
         continue
-      elseif itype == Overlapping
+      elseif type(I) == Overlapping
         c, d = vertices(get(I))
         if λ(d) < λ(c)
           c, d = d, c
@@ -241,10 +241,8 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # sort events along the segment
   sort!(events, by=e -> λ(e[1]))
 
-  # collect intersection pieces
-  pieces = typeof(seg)[]
-  interiorpieces = typeof(seg)[]
-  boundarypieces = typeof(seg)[]
+  # collect unique intersection pieces
+  pieces = Tuple{typeof(seg),Bool}[] # pieces = (piece, isinterior)
   j = 1
   overlapdepth = 0
   for i in 2:length(events)
@@ -258,13 +256,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       overlapdepth += eⱼ[3]
       piece = Segment(eⱼ[1], eᵢ[1])
       if overlapdepth > 0
-        push!(pieces, piece)
-        push!(boundarypieces, piece)
+        _pushpiece!(pieces, piece, false)
       else
         midpoint = center(piece)
         if midpoint ∈ poly
-          push!(pieces, piece)
-          push!(interiorpieces, piece)
+          _pushpiece!(pieces, piece, true)
         end
       end
       j += 1
@@ -273,21 +269,19 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
   resize!(events, j)
 
-  # merge continuous segments
-  pieces = _mergepieces(pieces)
-  interiorpieces = _mergepieces(interiorpieces)
-  boundarypieces = _mergepieces(boundarypieces)
-  ncross = count(e -> e[2], events)
-
   # create geometry from pieces
   piecegeometry(ps) = length(ps) == 1 ? only(ps) : Multi(ps)
 
+  # create auxiliary variables
+  ncross = count(e -> e[2], events)
+  hasinterior = any(p -> p[2], pieces)
+
   # classify intersection
-  if !isempty(interiorpieces)
-    geometry = piecegeometry(pieces)
+  if hasinterior
+    geometry = piecegeometry(first.(pieces))
     return @IT Intersecting geometry f
-  elseif !isempty(boundarypieces)
-    geometry = piecegeometry(boundarypieces)
+  elseif !isempty(pieces)
+    geometry = piecegeometry(first.(pieces))
     return @IT EdgeTouching geometry f
   elseif ncross == 1
     i = findfirst(e -> e[2], events)
@@ -307,25 +301,20 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
 end
 
-# merge the continuous segments of a segment list (`pieces`) into a single geometry
-function _mergepieces(pieces)
-  length(pieces) ≤ 1 && return pieces
-  merged = eltype(pieces)[]
-  for piece in pieces
-    if isempty(merged)
-      push!(merged, piece)
-    else
-      previous = last(merged)
-      p₁, p₂ = vertices(previous)
-      q₁, q₂ = vertices(piece)
-      if p₂ ≈ q₁
-        merged[end] = Segment(p₁, q₂)
-      else
-        push!(merged, piece)
-      end
+# merge the continuous segments of a segment list (`pieces`) into a single geometry and push then, indicating whether they are an interior segment
+function _pushpiece!(pieces, piece, isinterior)
+  if !isempty(pieces)
+    previous, previous_isinterior = last(pieces)
+    p₁, p₂ = vertices(previous)
+    q₁, q₂ = vertices(piece)
+    if p₂ ≈ q₁
+      mergedpiece = Segment(p₁, q₂)
+      pieces[end] = (mergedpiece, previous_isinterior || isinterior)
+      return nothing
     end
   end
-  merged
+  push!(pieces, (piece, isinterior))
+  return nothing
 end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -243,7 +243,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
   # collect unique intersection pieces
   j = 1
-  overlapdepth = 0
+  depth = 0
   pieces = typeof(seg)[]
   isinterior = Bool[]
   for i in 2:length(events)
@@ -254,15 +254,12 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       events[j] = (eⱼ[1], eⱼ[2] || eᵢ[2], eⱼ[3] + eᵢ[3])
     else
       # eⱼ is now fully merged, so piece it with the next distinct event
-      overlapdepth += eⱼ[3]
+      depth += eⱼ[3]
       piece = Segment(eⱼ[1], eᵢ[1])
-      if overlapdepth > 0
+      if depth > 0
         _pushpiece!(pieces, isinterior, piece, false)
-      else
-        midpoint = center(piece)
-        if midpoint ∈ poly
-          _pushpiece!(pieces, isinterior, piece, true)
-        end
+      elseif center(piece) ∈ poly
+        _pushpiece!(pieces, isinterior, piece, true)
       end
       j += 1
       events[j] = eᵢ

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -207,30 +207,25 @@ end
 # 1. overlap of segment and polygon (Overlapping -> Segment)
 # 2. intersect at one an point, exactly (Touching -> Point)
 # 3. the segment is degenerate and is inside the polygon (Touching -> Point)
-# 4. the segment is degenerate and is outside the polygon (NotIntersecting -> Nothing)
-# 5. do not overlap nor intersect (NotIntersecting -> Nothing)
+# 4. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   a, b = vertices(seg)
   segbbox = boundingbox(seg)
   polybbox = boundingbox(poly)
 
   # check for degenerate segments
-  if a ≈ b
-    if a ∈ poly
-      return @IT Touching a f # Case 3
-    else
-      return @IT NotIntersecting nothing f # Case 4
-    end
+  if a ≈ b && a ∈ poly
+    return @IT Touching a f # Case 3
   end
 
   # assess obvious no intersection case beforehand
   if !intersects(segbbox, polybbox)
-    return @IT NotIntersecting nothing f # Case 5
+    return @IT NotIntersecting nothing f # Case 4
   end
 
   # segment endpoints as scalars + segment vector
-  segλs = [0.0, 1.0];
-  v = b-a;
+  segλs = [0.0, 1.0]
+  v = b - a
 
   # Extract the first Cartesian coordinate
   x(p) = flat(coords(p)).x
@@ -238,9 +233,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
   # Choose the polygon's longest bounding-box axis
   polymin, polymax = extrema(polybbox)
-  xspan = x(polymax) - x(polymin)
-  yspan = y(polymax) - y(polymin)
-  axiscoord = xspan ≥ yspan ? x : y
+  xside = x(polymax) - x(polymin)
+  yside = y(polymax) - y(polymin)
+  axiscoord = xside ≥ yside ? x : y
 
   # Segment range along the chosen axis
   segmin, segmax = extrema(segbbox)
@@ -248,7 +243,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   segstop = axiscoord(segmax)
 
   # assess intersections
-  boundarypoints = Point[]
+  boundarypoints = typeof(a)[]
   for ring in rings(poly)
     ringbbox = boundingbox(ring)
     # check for obvious no intersection case beforehand
@@ -272,10 +267,10 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     starts = starts[inds]
     stops = stops[inds]
     for i in eachindex(edges)
-      # Edge ends before the segment begins. Later edges may still overlap, so skip only this edge
+      # Edge ends before the segment begins. Later edges may still overlap, so skip only this edge.
       stops[i] < segstart && continue
 
-      # Edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right
+      # Edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right.
       starts[i] > segstop && break
 
       # The selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
@@ -305,15 +300,45 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     end
   end
 
-  # Define collection of intersected segment pieces
-  sort!(segλs);
-  pieces = Segment[]
+  # get unique boundary points
+  unique!(boundarypoints)
+  # remove duplicate λ values and sort them
+  sort!(segλs)
+  for i in 2:length(segλs)
+    segλs[i] = mayberound(segλs[i], segλs[i - 1])
+  end
+  unique!(segλs)
+  # create segments from the λ values that are inside the polygon
+  pieces = typeof(seg)[]
   for (λ₁, λ₂) in zip(segλs[1:(end - 1)], segλs[2:end])
     λ₁ ≈ λ₂ && continue
     λmid = (λ₁ + λ₂) / 2
     if seg(λmid) ∈ poly
       push!(pieces, Segment(seg(λ₁), seg(λ₂)))
     end
+  end
+  # merge continuous segments
+  if length(pieces) > 1
+    merged = typeof(seg)[]
+    for piece in pieces
+      if isempty(merged)
+        push!(merged, piece)
+      else
+        previous = last(merged)
+        if !intersects(boundingbox(previous), boundingbox(piece))
+          push!(merged, piece)
+          continue
+        end
+        p₁, p₂ = vertices(previous)
+        q₁, q₂ = vertices(piece)
+        if p₂ ≈ q₁
+          merged[end] = Segment(p₁, q₂)
+        else
+          push!(merged, piece)
+        end
+      end
+    end
+    pieces = merged
   end
 
   # classifying intersections

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -254,7 +254,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       # merge coincident events
       events[i] = (eᵢ[1], eᵢ[2] || eⱼ[2], eᵢ[3] + eⱼ[3])
     else
-      # eᵢ is fully merged, so piece it with the next distinct event
+      # eᵢ is fully merged, connect it with the next event
       depth += eᵢ[3]
       piece = Segment(eᵢ[1], eⱼ[1])
       if depth > 0 
@@ -269,11 +269,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
   resize!(events, i)
 
-  # glue pieces together into a single geometry
-  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
-
   # number of crossing events
   ncrosses = count(e -> e[2], events)
+
+  # glue pieces together into a single geometry
+  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
 
   # classify intersection
   if inpoly

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -244,7 +244,8 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # collect unique intersection pieces
   j = 1
   overlapdepth = 0
-  pieces = Tuple{typeof(seg),Bool}[] # pieces = (piece, isinterior)
+  pieces = typeof(seg)[]
+  isinterior = Bool[]
   for i in 2:length(events)
     eᵢ = events[i]
     eⱼ = events[j]
@@ -252,15 +253,15 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       # merge coincident events
       events[j] = (eⱼ[1], eⱼ[2] || eᵢ[2], eⱼ[3] + eᵢ[3])
     else
-      # eⱼ is now fully merged, so piece it with the next distinct event (eᵢ)
+      # eⱼ is now fully merged, so piece it with the next distinct event
       overlapdepth += eⱼ[3]
       piece = Segment(eⱼ[1], eᵢ[1])
       if overlapdepth > 0
-        _pushpiece!(pieces, piece, false)
+        _pushpiece!(pieces, isinterior, piece, false)
       else
         midpoint = center(piece)
         if midpoint ∈ poly
-          _pushpiece!(pieces, piece, true)
+          _pushpiece!(pieces, isinterior, piece, true)
         end
       end
       j += 1
@@ -301,20 +302,20 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
 end
 
-# merge the continuous segments of a segment list (`pieces`) into a single geometry and push then, indicating whether they are an interior segment
-function _pushpiece!(pieces, piece, isinterior)
+# merge the continuous segments of a segment list (`pieces`) into a single geometry and push then, indicating whether they are an interior segment in the `isinterior` vector.
+function _pushpiece!(pieces, isinterior, piece, isint)
   if !isempty(pieces)
-    previous, previous_isinterior = last(pieces)
-    p₁, p₂ = vertices(previous)
+    prev = last(pieces)
+    p₁, p₂ = vertices(prev)
     q₁, q₂ = vertices(piece)
     if p₂ ≈ q₁
-      mergedpiece = Segment(p₁, q₂)
-      pieces[end] = (mergedpiece, previous_isinterior || isinterior)
-      return nothing
+      pieces[end] = Segment(p₁, q₂)
+      isinterior[end] |= isint
+      return
     end
   end
-  push!(pieces, (piece, isinterior))
-  return nothing
+  push!(pieces, piece)
+  push!(isinterior, isint)
 end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -243,30 +243,30 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   sort!(events, by=e -> λ(e[1]))
 
   # collect unique intersection pieces
-  j = 1
+  i = 1
   depth = 0
   pieces = typeof(seg)[]
   isinterior = Bool[]
-  for i in 2:length(events)
+  for j in 2:length(events)
     eᵢ = events[i]
     eⱼ = events[j]
     if eᵢ[1] ≈ eⱼ[1]
       # merge coincident events
-      events[j] = (eⱼ[1], eⱼ[2] || eᵢ[2], eⱼ[3] + eᵢ[3])
+      events[i] = (eᵢ[1], eᵢ[2] || eⱼ[2], eᵢ[3] + eⱼ[3])
     else
-      # eⱼ is now fully merged, so piece it with the next distinct event
-      depth += eⱼ[3]
-      piece = Segment(eⱼ[1], eᵢ[1])
+      # eᵢ is fully merged, so piece it with the next distinct event
+      depth += eᵢ[3]
+      piece = Segment(eᵢ[1], eⱼ[1])
       if depth > 0
         _pushpiece!(pieces, isinterior, piece, false)
       elseif center(piece) ∈ poly
         _pushpiece!(pieces, isinterior, piece, true)
       end
-      j += 1
-      events[j] = eᵢ
+      i += 1
+      events[i] = eⱼ
     end
   end
-  resize!(events, j)
+  resize!(events, i)
 
   # create geometry from pieces
   piecegeometry(ps) = length(ps) == 1 ? only(ps) : Multi(ps)

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -203,6 +203,134 @@ function intersection(f, seg::Segment, line::Line)
   end
 end
 
+# Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.
+# (https://www.sciencedirect.com/science/article/pii/S0925772109001448?via%3Dihub)
+function intersection(f, seg::Segment{𝔼{3}}, tri::Triangle{𝔼{3}})
+  Q1, Q2 = vertices(seg)
+  V1, V2, V3 = vertices(tri)
+
+  # according to theorem 1, the algorithm only works
+  # when Q1 is not coplanar with the triangle, we need
+  # to swap Q1 with Q2 in that case
+  if iscoplanar(Q1, V1, V2, V3)
+    (Q1, Q2) = (Q2, Q1)
+  end
+
+  A = Q1 - V3
+  B = V1 - V3
+  C = V2 - V3
+
+  W₁ = B × C
+  w = A ⋅ W₁
+
+  D = Q2 - V3
+  s = D ⋅ W₁
+
+  if w > atol(w)
+    # rejection 2
+    if s > atol(s)
+      return @IT NotIntersecting nothing f
+    end
+
+    W₂ = A × D
+    t = W₂ ⋅ C
+
+    # rejection 3
+    if t < -atol(t)
+      return @IT NotIntersecting nothing f
+    end
+
+    u = -(W₂ ⋅ B)
+
+    # rejection 4
+    if u < -atol(u)
+      return @IT NotIntersecting nothing f
+    end
+
+    # rejection 5
+    if w < (s + t + u)
+      return @IT NotIntersecting nothing f
+    end
+  elseif w < -atol(w)
+    # rejection 2
+    if s < -atol(s)
+      return @IT NotIntersecting nothing f
+    end
+
+    W₂ = A × D
+    t = W₂ ⋅ C
+
+    # rejection 3
+    if t > atol(t)
+      return @IT NotIntersecting nothing f
+    end
+
+    u = -(W₂ ⋅ B)
+
+    # rejection 4
+    if u > atol(u)
+      return @IT NotIntersecting nothing f
+    end
+
+    # rejection 5
+    if w > (s + t + u)
+      return @IT NotIntersecting nothing f
+    end
+  else # w ≈ 0
+    if s > atol(s)
+      W₂ = D × A
+      t = W₂ ⋅ C
+
+      # rejection 3
+      if t < -atol(t)
+        return @IT NotIntersecting nothing f
+      end
+
+      u = -(W₂ ⋅ B)
+
+      # rejection 4
+      if u < -atol(u)
+        return @IT NotIntersecting nothing f
+      end
+
+      # rejection 5
+      if -s < (t + u)
+        return @IT NotIntersecting nothing f
+      end
+    elseif s < -atol(s)
+      W₂ = D × A
+      t = W₂ ⋅ C
+
+      # rejection 3
+      if t > atol(t)
+        return @IT NotIntersecting nothing f
+      end
+
+      u = -(W₂ ⋅ B)
+
+      # rejection 4
+      if u > atol(u)
+        return @IT NotIntersecting nothing f
+      end
+
+      # rejection 5
+      if -s > (t + u)
+        return @IT NotIntersecting nothing f
+      end
+    else # s ≈ 0
+      # rejection 1, coplanar segment
+      return @IT NotIntersecting nothing f
+    end
+  end
+
+  λ = w / (w - s)
+  λ = clamp(λ, zero(λ), one(λ))
+
+  p = Segment(Q1, Q2)(λ)
+
+  return @IT Intersecting p f
+end
+
 # intersection between a segment and a polygon
 # 1. overlap of segment and polygon (Overlapping -> Segment)
 # 2. intersect at one an point, exactly (Touching -> Point)
@@ -351,134 +479,6 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   else
     return @IT NotIntersecting nothing f # Case 5 
   end
-end
-
-# Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.
-# (https://www.sciencedirect.com/science/article/pii/S0925772109001448?via%3Dihub)
-function intersection(f, seg::Segment{𝔼{3}}, tri::Triangle{𝔼{3}})
-  Q1, Q2 = vertices(seg)
-  V1, V2, V3 = vertices(tri)
-
-  # according to theorem 1, the algorithm only works
-  # when Q1 is not coplanar with the triangle, we need
-  # to swap Q1 with Q2 in that case
-  if iscoplanar(Q1, V1, V2, V3)
-    (Q1, Q2) = (Q2, Q1)
-  end
-
-  A = Q1 - V3
-  B = V1 - V3
-  C = V2 - V3
-
-  W₁ = B × C
-  w = A ⋅ W₁
-
-  D = Q2 - V3
-  s = D ⋅ W₁
-
-  if w > atol(w)
-    # rejection 2
-    if s > atol(s)
-      return @IT NotIntersecting nothing f
-    end
-
-    W₂ = A × D
-    t = W₂ ⋅ C
-
-    # rejection 3
-    if t < -atol(t)
-      return @IT NotIntersecting nothing f
-    end
-
-    u = -(W₂ ⋅ B)
-
-    # rejection 4
-    if u < -atol(u)
-      return @IT NotIntersecting nothing f
-    end
-
-    # rejection 5
-    if w < (s + t + u)
-      return @IT NotIntersecting nothing f
-    end
-  elseif w < -atol(w)
-    # rejection 2
-    if s < -atol(s)
-      return @IT NotIntersecting nothing f
-    end
-
-    W₂ = A × D
-    t = W₂ ⋅ C
-
-    # rejection 3
-    if t > atol(t)
-      return @IT NotIntersecting nothing f
-    end
-
-    u = -(W₂ ⋅ B)
-
-    # rejection 4
-    if u > atol(u)
-      return @IT NotIntersecting nothing f
-    end
-
-    # rejection 5
-    if w > (s + t + u)
-      return @IT NotIntersecting nothing f
-    end
-  else # w ≈ 0
-    if s > atol(s)
-      W₂ = D × A
-      t = W₂ ⋅ C
-
-      # rejection 3
-      if t < -atol(t)
-        return @IT NotIntersecting nothing f
-      end
-
-      u = -(W₂ ⋅ B)
-
-      # rejection 4
-      if u < -atol(u)
-        return @IT NotIntersecting nothing f
-      end
-
-      # rejection 5
-      if -s < (t + u)
-        return @IT NotIntersecting nothing f
-      end
-    elseif s < -atol(s)
-      W₂ = D × A
-      t = W₂ ⋅ C
-
-      # rejection 3
-      if t > atol(t)
-        return @IT NotIntersecting nothing f
-      end
-
-      u = -(W₂ ⋅ B)
-
-      # rejection 4
-      if u > atol(u)
-        return @IT NotIntersecting nothing f
-      end
-
-      # rejection 5
-      if -s > (t + u)
-        return @IT NotIntersecting nothing f
-      end
-    else # s ≈ 0
-      # rejection 1, coplanar segment
-      return @IT NotIntersecting nothing f
-    end
-  end
-
-  λ = w / (w - s)
-  λ = clamp(λ, zero(λ), one(λ))
-
-  p = Segment(Q1, Q2)(λ)
-
-  return @IT Intersecting p f
 end
 
 # sorts four numbers using a sorting network 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -257,11 +257,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       overlapdepth += eⱼ[3]
       piece = Segment(eⱼ[1], eᵢ[1])
       if overlapdepth > 0
-        _pushpiece!(pieces, isinterior, piece, false)
+        _pushflagpiece!(pieces, isinterior, piece, false)
       else
         midpoint = center(piece)
         if midpoint ∈ poly
-          _pushpiece!(pieces, isinterior, piece, true)
+          _pushflagpiece!(pieces, isinterior, piece, true)
         end
       end
       j += 1
@@ -275,14 +275,14 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
 
   # create auxiliary variables
   ncross = count(e -> e[2], events)
-  hasinterior = any(p -> p[2], pieces)
+  hasinterior = any(isinterior)
 
   # classify intersection
   if hasinterior
-    geometry = piecegeometry(first.(pieces))
+    geometry = piecegeometry(pieces)
     return @IT Intersecting geometry f
   elseif !isempty(pieces)
-    geometry = piecegeometry(first.(pieces))
+    geometry = piecegeometry(pieces)
     return @IT EdgeTouching geometry f
   elseif ncross == 1
     i = findfirst(e -> e[2], events)

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -329,14 +329,18 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   pieces = typeof(seg)[]
   interiorpieces = typeof(seg)[]
   boundarypieces = typeof(seg)[]
-  for (λ₁, λ₂) in zip(λs[1:(end - 1)], λs[2:end])
+  for i in 1:(length(λs) - 1)
+    λ₁ = λs[i]
+    λ₂ = λs[i + 1]
+
     λ₁ ≈ λ₂ && continue
-    λmid = (λ₁ + λ₂) / 2
+
+    λₘ = (λ₁ + λ₂) / 2
     piece = Segment(seg(λ₁), seg(λ₂))
-    if inboundaryoverlap(λmid)
+    if inboundaryoverlap(λₘ)
       push!(pieces, piece)
       push!(boundarypieces, piece)
-    elseif seg(λmid) ∈ poly
+      elseif seg(λₘ) ∈ poly
       push!(pieces, piece)
       push!(interiorpieces, piece)
     end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -207,7 +207,7 @@ end
 # 1. overlap with the polygon interior (Intersecting -> Segment or Multi)
 # 2. overlap with a polygon edge only (EdgeTouching -> Segment or Multi)
 # 3. intersect at an interior point of the segment and a polygon vertex (CornerTouching -> Point)
-# 4. intersect only at an endpoint of the segment (Touching -> Point)
+# 4. intersect at an endpoint of the segment (Touching -> Point)
 # 5. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 6. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -213,10 +213,13 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   pbox = boundingbox(poly)
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
 
-  # collect and classify boundary events
+  # collect and classify boundary events, which are of the
+  # form (point, iscrossing, enteringmode). The enteringmode
+  # is +1 if the segment is entering the polygon, -1 if it is
+  # leaving the polygon, and 0 if it is neither (e.g. crossing)
   a, b = vertices(seg)
   λ(p) = (p - a) ⋅ (b - a)
-  events = [(a, false, 0), (b, false, 0)] # event = (point, crosses, overlaps)
+  events = [(a, false, 0), (b, false, 0)]
   for ring in rings(poly)
     intersects(sbox, boundingbox(ring)) || continue
     for edge in segments(ring)
@@ -237,8 +240,6 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       end
     end
   end
-
-  # sort events along the segment
   sort!(events, by=e -> λ(e[1]))
 
   # collect unique intersection pieces

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -224,7 +224,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       I = intersection(seg, edge)
       itype = type(I)
       if itype == NotIntersecting
-        return nothing
+        continue
       elseif itype == Overlapping
         c, d = vertices(get(I))
         if λ(d) < λ(c)

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -333,7 +333,7 @@ end
 
 # intersection between a segment and a polygon
 # 1. overlap of segment and polygon (Overlapping -> Segment)
-# 2. intersect at one an point, exactly (Touching -> Point)
+# 2. intersect at one point, exactly (Touching -> Point)
 # 3. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 4. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -246,7 +246,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # remove duplicate points in boundary
   unique!(boundarypoints)
 
-  # create resulting intersection segments from base intersection points
+  # collect intersection segments
   pieces = typeof(seg)[]
   interiorpieces = typeof(seg)[]
   boundarypieces = typeof(seg)[]
@@ -257,7 +257,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     p₁ ≈ p₂ && continue
 
     piece = Segment(p₁, p₂)
-    midpoint = piece(0.5)
+    midpoint = center(piece)
 
     if any(overlap -> midpoint ∈ overlap, boundaryoverlaps)
       push!(pieces, piece)

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -242,9 +242,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   sort!(events, by=e -> λ(e[1]))
 
   # collect unique intersection pieces
-  pieces = Tuple{typeof(seg),Bool}[] # pieces = (piece, isinterior)
   j = 1
   overlapdepth = 0
+  pieces = Tuple{typeof(seg),Bool}[] # pieces = (piece, isinterior)
   for i in 2:length(events)
     eᵢ = events[i]
     eⱼ = events[j]

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -257,11 +257,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       overlapdepth += eⱼ[3]
       piece = Segment(eⱼ[1], eᵢ[1])
       if overlapdepth > 0
-        _pushflagpiece!(pieces, isinterior, piece, false)
+        _pushpiece!(pieces, isinterior, piece, false)
       else
         midpoint = center(piece)
         if midpoint ∈ poly
-          _pushflagpiece!(pieces, isinterior, piece, true)
+          _pushpiece!(pieces, isinterior, piece, true)
         end
       end
       j += 1

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -290,7 +290,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       return @IT CornerTouching p f
     end
   elseif ncrosses > 1
-    points = typeof(a)[e[1] for e in events if e[2]]
+    points = [e[1] for e in events if e[2]]
     return @IT Intersecting Multi(points) f
   else
     return @IT NotIntersecting nothing f

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -213,87 +213,96 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   pbox = boundingbox(poly)
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
 
-  # store and classify intersection points
-  splitpoints = collect(eachvertex(seg))
-  boundarypoints = empty(splitpoints)
-  boundaryoverlaps = typeof(seg)[]
+  # collect boundary events
+  a, b = vertices(seg)
+  events = Tuple{typeof(a),Bool,Int8}[(a, false, Int8(0)), (b, false, Int8(0))] # event = (point, docross, overlap)
+  λ(p) = (p - a) ⋅ (b - a)
   for ring in rings(poly)
-    rbox = boundingbox(ring)
-    intersects(sbox, rbox) || continue
+    intersects(sbox, boundingbox(ring)) || continue
     for edge in segments(ring)
       intersects(sbox, boundingbox(edge)) || continue
       intersection(seg, edge) do I
-        if type(I) == NotIntersecting
-          return nothing
-        elseif type(I) == Overlapping
-          s = get(I)
-          push!(splitpoints, vertices(s)...)
-          push!(boundaryoverlaps, s)
+        itype = type(I)
+        itype == NotIntersecting && return
+        if itype == Overlapping
+          c, d = vertices(get(I))
+          if λ(d) < λ(c)
+            c, d = d, c
+          end
+          push!(events, (c, false, Int8(1)))
+          push!(events, (d, false, Int8(-1)))
         else
           p = get(I)
-          push!(splitpoints, p)
-          push!(boundarypoints, p)
+          push!(events, (p, true, Int8(0)))
         end
       end
     end
   end
 
-  # sort intersection points along the segment
-  a, b = vertices(seg)
-  λ(p) = (p - a) ⋅ (b - a)
-  sort!(splitpoints, by=λ)
+  # sort events along the segment
+  sort!(events, by=e -> λ(e[1]))
 
-  # remove duplicate points in boundary
-  unique!(boundarypoints)
-
-  # collect intersection segments
+  # collect intersection pieces
   pieces = typeof(seg)[]
   interiorpieces = typeof(seg)[]
   boundarypieces = typeof(seg)[]
-  for i in 1:(length(splitpoints) - 1)
-    p₁ = splitpoints[i]
-    p₂ = splitpoints[i + 1]
-
-    p₁ ≈ p₂ && continue
-
-    piece = Segment(p₁, p₂)
-    midpoint = center(piece)
-
-    if any(overlap -> midpoint ∈ overlap, boundaryoverlaps)
-      push!(pieces, piece)
-      push!(boundarypieces, piece)
-    elseif midpoint ∈ poly
-      push!(pieces, piece)
-      push!(interiorpieces, piece)
+  j = 1
+  overlapdepth = 0
+  for i in 2:length(events)
+    eᵢ = events[i]
+    eⱼ = events[j]
+    if eᵢ[1] ≈ eⱼ[1]
+      # merge coincident events
+      events[j] = (eⱼ[1], eⱼ[2] || eᵢ[2], eⱼ[3] + eᵢ[3])
+    else
+      # eⱼ is now fully merged, so piece it with the next distinct event (eᵢ)
+      overlapdepth += eⱼ[3]
+      piece = Segment(eⱼ[1], eᵢ[1])
+      if overlapdepth > 0
+        push!(pieces, piece)
+        push!(boundarypieces, piece)
+      else
+        midpoint = center(piece)
+        if midpoint ∈ poly
+          push!(pieces, piece)
+          push!(interiorpieces, piece)
+        end
+      end
+      j += 1
+      events[j] = eᵢ
     end
   end
+  resize!(events, j)
 
   # merge continuous segments
   pieces = _mergepieces(pieces)
   interiorpieces = _mergepieces(interiorpieces)
   boundarypieces = _mergepieces(boundarypieces)
+  ncross = count(e -> e[2], events)
 
   # create geometry from pieces
-  piecegeometry(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
+  piecegeometry(ps) = length(ps) == 1 ? only(ps) : Multi(ps)
 
-  # classifying intersections
+  # classify intersection
   if !isempty(interiorpieces)
     geometry = piecegeometry(pieces)
     return @IT Intersecting geometry f
   elseif !isempty(boundarypieces)
     geometry = piecegeometry(boundarypieces)
     return @IT EdgeTouching geometry f
-  elseif length(boundarypoints) == 1
-    p = only(boundarypoints)
-    isendpoint = (p ≈ a || p ≈ b)
+  elseif ncross == 1
+    i = findfirst(e -> e[2], events)
+    p = events[i][1]
+    isendpoint = p ≈ a || p ≈ b
     isvertex = any(v -> p ≈ v, vertices(poly))
     if isendpoint && !isvertex
       return @IT Touching p f
     else
       return @IT CornerTouching p f
     end
-  elseif !isempty(boundarypoints)
-    return @IT Intersecting Multi(boundarypoints) f
+  elseif ncross > 1
+    points = typeof(a)[e[1] for e in events if e[2]]
+    return @IT Intersecting Multi(points) f
   else
     return @IT NotIntersecting nothing f
   end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -283,12 +283,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   elseif ncrosses == 1
     i = findfirst(e -> e[2], events)
     p = events[i][1]
-    isendpoint = p ≈ a || p ≈ b
     isvertex = any(v -> p ≈ v, vertices(poly))
-    if isendpoint && !isvertex
-      return @IT Touching p f
-    else
+    if isvertex
       return @IT CornerTouching p f
+    else
+      return @IT Touching p f
     end
   elseif ncrosses > 1
     points = [e[1] for e in events if e[2]]

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -206,8 +206,8 @@ end
 # intersection between a segment and a polygon
 # 1. overlap with the polygon interior (Intersecting -> Segment or Multi)
 # 2. overlap with a polygon edge only (EdgeTouching -> Segment or Multi)
-# 3. intersect at an interior point of the segment and a polygon vertex (CornerTouching -> Point)
-# 4. intersect at an endpoint of the segment (Touching -> Point)
+# 3. intersect at a polygon vertex (CornerTouching -> Point)
+# 4. intersect only at an endpoint of the segment, though not at a poligon vertex (Touching -> Point)
 # 5. the segment is degenerate and is inside the polygon (Touching -> Point)
 # 6. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
@@ -216,8 +216,10 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   polybbox = boundingbox(poly)
 
   # check for degenerate segments
-  if a ≈ b && a ∈ poly
+  if a ≈ b && a ∈ poly && !any(v -> a ≈ v, vertices(poly))
     return @IT Touching a f # Case 5
+  elseif a ≈ b && any(v -> a ≈ v, vertices(poly))
+    return @IT CornerTouching a f # Case 3
   end
 
   # assess obvious no intersection case beforehand
@@ -340,7 +342,6 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     λ₁ ≈ λ₂ && continue
     λmid = (λ₁ + λ₂) / 2
     piece = Segment(seg(λ₁), seg(λ₂))
-
     if inboundaryoverlap(λmid)
       push!(pieces, piece)
       push!(boundarypieces, piece)
@@ -351,30 +352,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
 
   # merge continuous segments
-  function mergepieces(pieces)
-    length(pieces) ≤ 1 && return pieces
-
-    merged = eltype(pieces)[]
-    for piece in pieces
-      if isempty(merged)
-        push!(merged, piece)
-      else
-        previous = last(merged)
-        p₁, p₂ = vertices(previous)
-        q₁, q₂ = vertices(piece)
-        if p₂ ≈ q₁
-          merged[end] = Segment(p₁, q₂)
-        else
-          push!(merged, piece)
-        end
-      end
-    end
-    merged
-  end
-
-  pieces = mergepieces(pieces)
-  interiorpieces = mergepieces(interiorpieces)
-  boundarypieces = mergepieces(boundarypieces)
+  pieces = _mergepieces(pieces)
+  interiorpieces = _mergepieces(interiorpieces)
+  boundarypieces = _mergepieces(boundarypieces)
 
   # create geometry from pieces
   piecegeometry(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
@@ -388,7 +368,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
     return @IT EdgeTouching geometry f # Case 2
   elseif length(boundarypoints) == 1
     p = only(boundarypoints)
-    if p ≈ a || p ≈ b
+    isendpoint = (p ≈ a || p ≈ b)
+    isvertex = any(v -> p ≈ v, vertices(poly))
+    if isendpoint && !isvertex
       return @IT Touching p f # Case 4
     else
       return @IT CornerTouching p f # Case 3
@@ -398,6 +380,27 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   else
     return @IT NotIntersecting nothing f # Case 6
   end
+end
+
+# Merge the continuous segments of a segment list (`pieces`) into a single geometry
+function _mergepieces(pieces)
+  length(pieces) ≤ 1 && return pieces
+  merged = eltype(pieces)[]
+  for piece in pieces
+    if isempty(merged)
+      push!(merged, piece)
+    else
+      previous = last(merged)
+      p₁, p₂ = vertices(previous)
+      q₁, q₂ = vertices(piece)
+      if p₂ ≈ q₁
+        merged[end] = Segment(p₁, q₂)
+      else
+        push!(merged, piece)
+      end
+    end
+  end
+  merged
 end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -201,19 +201,17 @@ function intersection(f, seg::Segment, line::Line)
   end
 end
 
-# intersection between a segment and a polygon
+# The intersection type can be one of five types:
 # 1. overlap with the polygon interior (Intersecting -> Segment or Multi)
 # 2. overlap with a polygon edge only (EdgeTouching -> Segment or Multi)
 # 3. intersect at a polygon vertex (CornerTouching -> Point)
 # 4. intersect at a single non-vertex point (Touching -> Point)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
-  # check bounding ebox for early exit
+  # check bounding boxes for early exit
   sbox = boundingbox(seg)
   pbox = boundingbox(poly)
-  if !intersects(sbox, pbox)
-    return @IT NotIntersecting nothing f
-  end
+  intersects(sbox, pbox) || return @IT NotIntersecting nothing f
 
   # check for degenerate segments
   a, b = vertices(seg)
@@ -227,10 +225,8 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   x(p) = flat(coords(p)).x
   y(p) = flat(coords(p)).y
 
-  # choose the polygon's longest bounding-box axis
-  pmin, pmax = extrema(pbox)
-  xside = x(pmax) - x(pmin)
-  yside = y(pmax) - y(pmin)
+  # choose the polygon's longest bounding box axis
+  xside, yside = sides(pbox)
   axiscoord = xside ≥ yside ? x : y
 
   # segment range along the chosen axis

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -10,91 +10,91 @@
 # 4. overlap of segments (Overlapping -> Segments)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg₁::Segment, seg₂::Segment)
-	a, b = vertices(seg₁)
-	c, d = vertices(seg₂)
+  a, b = vertices(seg₁)
+  c, d = vertices(seg₂)
 
-	# handle degenerate segments
-	if a == b && c == d
-		if a ≈ c
-			return @IT CornerTouching a f
-		else
-			return @IT NotIntersecting nothing f
-		end
-	elseif a == b
-		if a ≈ c || a ≈ d
-			return @IT CornerTouching a f
-		elseif a ∈ seg₂
-			return @IT EdgeTouching a f
-		else
-			return @IT NotIntersecting nothing f
-		end
-	elseif c == d
-		if c ≈ a || c ≈ b
-			return @IT CornerTouching c f
-		elseif c ∈ seg₁
-			return @IT EdgeTouching c f
-		else
-			return @IT NotIntersecting nothing f
-		end
-	end
+  # handle degenerate segments
+  if a == b && c == d
+    if a ≈ c
+      return @IT CornerTouching a f
+    else
+      return @IT NotIntersecting nothing f
+    end
+  elseif a == b
+    if a ≈ c || a ≈ d
+      return @IT CornerTouching a f
+    elseif a ∈ seg₂
+      return @IT EdgeTouching a f
+    else
+      return @IT NotIntersecting nothing f
+    end
+  elseif c == d
+    if c ≈ a || c ≈ b
+      return @IT CornerTouching c f
+    elseif c ∈ seg₁
+      return @IT EdgeTouching c f
+    else
+      return @IT NotIntersecting nothing f
+    end
+  end
 
-	l₁ = ustrip(length(seg₁))
-	l₂ = ustrip(length(seg₂))
-	b₀ = a + 1 / l₁ * (b - a)
-	d₀ = c + 1 / l₂ * (d - c)
+  l₁ = ustrip(length(seg₁))
+  l₂ = ustrip(length(seg₂))
+  b₀ = a + 1 / l₁ * (b - a)
+  d₀ = c + 1 / l₂ * (d - c)
 
-	# arc length parameters λ₁ ∈ [0, l₁], λ₂ ∈ [0, l₂]: 
-	λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
+  # arc length parameters λ₁ ∈ [0, l₁], λ₂ ∈ [0, l₂]: 
+  λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
 
-	if r ≠ rₐ # not in same plane or parallel
-		return @IT NotIntersecting nothing f #CASE 5
-	elseif r == rₐ == 1 # collinear
-		# find parameters λc and λd for points c and d in seg₁
-		# use dimension with largest vector component to avoid division by zero
-		v = b₀ - a
-		i = last(findmax(abs, v))
-		vc = c - a
-		vd = d - a
-		λc = vc[i] / v[i]
-		λd = vd[i] / v[i]
-		λc = mayberound(mayberound(λc, zero(λc)), l₁)
-		λd = mayberound(mayberound(λd, zero(λd)), l₁)
-		if (λc > l₁ && λd > l₁) || (λc < 0 && λd < 0)
-			return @IT NotIntersecting nothing f # CASE 5
-		elseif (λc == 0 && λd < 0) || (λd == 0 && λc < 0)
-			return @IT CornerTouching a f # CASE 3
-		elseif (λc == l₁ && λd > l₁) || (λd == l₁ && λc > l₁)
-			return @IT CornerTouching b f # CASE 3
-		else
-			t₁, t₂ = _sort4vals(zero(λc), one(λc), λc / l₁, λd / l₁)
-			p₁ = seg₁(t₁)
-			p₂ = seg₁(t₂)
-			return @IT Overlapping Segment(p₁, p₂) f # CASE 4
-		end
-	else # in same plane, not parallel
-		λ₁ = mayberound(mayberound(λ₁, zero(λ₁)), l₁)
-		λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
-		if λ₁ < 0 || λ₂ < 0 || λ₁ > l₁ || λ₂ > l₂
-			return @IT NotIntersecting nothing f # CASE 5
-		# 8 cases remain
-		elseif λ₁ == 0
-			if λ₂ == 0 || λ₂ == l₂
-				return @IT CornerTouching a f # CASE 3
-			else
-				return @IT EdgeTouching a f # CASE 2
-			end
-		elseif λ₁ == l₁
-			if λ₂ == 0 || λ₂ == l₂
-				return @IT CornerTouching b f # CASE 3
-			else
-				return @IT EdgeTouching b f # CASE 2
-			end
-		elseif λ₂ == 0 || λ₂ == l₂
-			return @IT EdgeTouching (λ₂ == 0 ? c : d) f # CASE 2
-		else
-			return @IT Crossing seg₁(λ₁ / l₁) f # CASE 1: equal to seg₂(λ₂/l₂)
-		end
-	end
+  if r ≠ rₐ # not in same plane or parallel
+    return @IT NotIntersecting nothing f #CASE 5
+  elseif r == rₐ == 1 # collinear
+    # find parameters λc and λd for points c and d in seg₁
+    # use dimension with largest vector component to avoid division by zero
+    v = b₀ - a
+    i = last(findmax(abs, v))
+    vc = c - a
+    vd = d - a
+    λc = vc[i] / v[i]
+    λd = vd[i] / v[i]
+    λc = mayberound(mayberound(λc, zero(λc)), l₁)
+    λd = mayberound(mayberound(λd, zero(λd)), l₁)
+    if (λc > l₁ && λd > l₁) || (λc < 0 && λd < 0)
+      return @IT NotIntersecting nothing f # CASE 5
+    elseif (λc == 0 && λd < 0) || (λd == 0 && λc < 0)
+      return @IT CornerTouching a f # CASE 3
+    elseif (λc == l₁ && λd > l₁) || (λd == l₁ && λc > l₁)
+      return @IT CornerTouching b f # CASE 3
+    else
+      t₁, t₂ = _sort4vals(zero(λc), one(λc), λc / l₁, λd / l₁)
+      p₁ = seg₁(t₁)
+      p₂ = seg₁(t₂)
+      return @IT Overlapping Segment(p₁, p₂) f # CASE 4
+    end
+  else # in same plane, not parallel
+    λ₁ = mayberound(mayberound(λ₁, zero(λ₁)), l₁)
+    λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
+    if λ₁ < 0 || λ₂ < 0 || λ₁ > l₁ || λ₂ > l₂
+      return @IT NotIntersecting nothing f # CASE 5
+    # 8 cases remain
+    elseif λ₁ == 0
+      if λ₂ == 0 || λ₂ == l₂
+        return @IT CornerTouching a f # CASE 3
+      else
+        return @IT EdgeTouching a f # CASE 2
+      end
+    elseif λ₁ == l₁
+      if λ₂ == 0 || λ₂ == l₂
+        return @IT CornerTouching b f # CASE 3
+      else
+        return @IT EdgeTouching b f # CASE 2
+      end
+    elseif λ₂ == 0 || λ₂ == l₂
+      return @IT EdgeTouching (λ₂ == 0 ? c : d) f # CASE 2
+    else
+      return @IT Crossing seg₁(λ₁ / l₁) f # CASE 1: equal to seg₂(λ₂/l₂)
+    end
+  end
 end
 
 # The intersection type can be one of five types:
@@ -105,68 +105,68 @@ end
 # 4. overlap at more than one point (Overlapping -> Segment)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment, ray::Ray)
-	Dim = embeddim(seg)
-	a, b = ray(0), ray(1)
-	c, d = seg(0), seg(1)
+  Dim = embeddim(seg)
+  a, b = ray(0), ray(1)
+  c, d = seg(0), seg(1)
 
-	# normalize points to gain parameters λ₁, λ₂ corresponding to arc lengths
-	l₁ = ustrip(norm(b - a))
-	l₂ = ustrip(length(seg))
-	b₀ = a + 1 / l₁ * (b - a)
-	d₀ = c + 1 / l₂ * (d - c)
+  # normalize points to gain parameters λ₁, λ₂ corresponding to arc lengths
+  l₁ = ustrip(norm(b - a))
+  l₂ = ustrip(length(seg))
+  b₀ = a + 1 / l₁ * (b - a)
+  d₀ = c + 1 / l₂ * (d - c)
 
-	λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
+  λ₁, λ₂, r, rₐ = intersectparameters(a, b₀, c, d₀)
 
-	# not in same plane or parallel
-	if r ≠ rₐ
-		return @IT NotIntersecting nothing f # CASE 5
-	# collinear
-	elseif r == rₐ == 1
-		rc = sum((c - a) ./ (b - a)) / Dim
-		rd = sum((d - a) ./ (b - a)) / Dim
-		rc = mayberound(rc, zero(rc))
-		rd = mayberound(rd, zero(rd))
-		if rc > 0 # c ∈ ray
-			if rd ≥ 0
-				return @IT Overlapping seg f # CASE 4
-			else
-				return @IT Overlapping Segment(ray(0), c) f # CASE 4
-			end
-		elseif rc == 0
-			if rd > 0
-				return @IT Overlapping seg f # CASE 4
-			else
-				return @IT CornerTouching a f # CASE 3
-			end
-		else # rc < 0
-			if rd > 0
-				return @IT Overlapping (Segment(ray(0), d)) f # CASE 4
-			elseif rd == 0
-				return @IT CornerTouching a f # CASE 3
-			else
-				return @IT NotIntersecting nothing f
-			end
-		end
-		# in same plane, not parallel
-	else
-		λ₁ = mayberound(λ₁, zero(λ₁))
-		λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
-		if λ₁ < 0 || (λ₂ < 0 || λ₂ > l₂)
-			return @IT NotIntersecting nothing f
-		elseif λ₁ == 0
-			if λ₂ == 0 || λ₂ == l₂
-				return @IT CornerTouching a f # CASE 3
-			else
-				return @IT EdgeTouching a f # CASE 2
-			end
-		else
-			if λ₂ == 0 || λ₂ == l₂
-				return @IT EdgeTouching (λ₂ < l₂ / 2 ? c : d) f # CASE 2
-			else
-				return @IT Crossing ray(λ₁ / l₁) f # CASE 1, equal to seg(λ₂/l₂)
-			end
-		end
-	end
+  # not in same plane or parallel
+  if r ≠ rₐ
+    return @IT NotIntersecting nothing f # CASE 5
+  # collinear
+  elseif r == rₐ == 1
+    rc = sum((c - a) ./ (b - a)) / Dim
+    rd = sum((d - a) ./ (b - a)) / Dim
+    rc = mayberound(rc, zero(rc))
+    rd = mayberound(rd, zero(rd))
+    if rc > 0 # c ∈ ray
+      if rd ≥ 0
+        return @IT Overlapping seg f # CASE 4
+      else
+        return @IT Overlapping Segment(ray(0), c) f # CASE 4
+      end
+    elseif rc == 0
+      if rd > 0
+        return @IT Overlapping seg f # CASE 4
+      else
+        return @IT CornerTouching a f # CASE 3
+      end
+    else # rc < 0
+      if rd > 0
+        return @IT Overlapping (Segment(ray(0), d)) f # CASE 4
+      elseif rd == 0
+        return @IT CornerTouching a f # CASE 3
+      else
+        return @IT NotIntersecting nothing f
+      end
+    end
+    # in same plane, not parallel
+  else
+    λ₁ = mayberound(λ₁, zero(λ₁))
+    λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
+    if λ₁ < 0 || (λ₂ < 0 || λ₂ > l₂)
+      return @IT NotIntersecting nothing f
+    elseif λ₁ == 0
+      if λ₂ == 0 || λ₂ == l₂
+        return @IT CornerTouching a f # CASE 3
+      else
+        return @IT EdgeTouching a f # CASE 2
+      end
+    else
+      if λ₂ == 0 || λ₂ == l₂
+        return @IT EdgeTouching (λ₂ < l₂ / 2 ? c : d) f # CASE 2
+      else
+        return @IT Crossing ray(λ₁ / l₁) f # CASE 1, equal to seg(λ₂/l₂)
+      end
+    end
+  end
 end
 
 # The intersection type can be one of six types:
@@ -175,32 +175,32 @@ end
 # 3. overlap of line and segment (Overlapping -> Segment)
 # 4. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment, line::Line)
-	a, b = line(0), line(1)
-	c, d = seg(0), seg(1)
+  a, b = line(0), line(1)
+  c, d = seg(0), seg(1)
 
-	# normalize points to gain parameter λ₂ corresponding to arc lengths
-	l₂ = ustrip(length(seg))
-	d₀ = c + 1 / l₂ * (d - c)
+  # normalize points to gain parameter λ₂ corresponding to arc lengths
+  l₂ = ustrip(length(seg))
+  d₀ = c + 1 / l₂ * (d - c)
 
-	_, λ₂, r, rₐ = intersectparameters(a, b, c, d₀)
+  _, λ₂, r, rₐ = intersectparameters(a, b, c, d₀)
 
-	# not in same plane or parallel
-	if r ≠ rₐ
-		return @IT NotIntersecting nothing f # CASE 4
-	# collinear
-	elseif r == rₐ == 1
-		return @IT Overlapping seg f # CASE 3
-	# in same plane, not parallel
-	else
-		λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
-		if λ₂ > 0 && λ₂ < l₂
-			return @IT Crossing seg(λ₂ / l₂) f # CASE 1, equal to line(λ₁)
-		elseif λ₂ == 0 || λ₂ == l₂
-			return @IT Touching ((λ₂ == 0) ? c : d) f # CASE 2
-		else
-			return @IT NotIntersecting nothing f # CASE 4
-		end
-	end
+  # not in same plane or parallel
+  if r ≠ rₐ
+    return @IT NotIntersecting nothing f # CASE 4
+  # collinear
+  elseif r == rₐ == 1
+    return @IT Overlapping seg f # CASE 3
+  # in same plane, not parallel
+  else
+    λ₂ = mayberound(mayberound(λ₂, zero(λ₂)), l₂)
+    if λ₂ > 0 && λ₂ < l₂
+      return @IT Crossing seg(λ₂ / l₂) f # CASE 1, equal to line(λ₁)
+    elseif λ₂ == 0 || λ₂ == l₂
+      return @IT Touching ((λ₂ == 0) ? c : d) f # CASE 2
+    else
+      return @IT NotIntersecting nothing f # CASE 4
+    end
+  end
 end
 
 # intersection between a segment and a polygon
@@ -210,264 +210,259 @@ end
 # 4. the segment is degenerate and is outside the polygon (NotIntersecting -> Nothing)
 # 5. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
+  a, b = vertices(seg)
+  segbbox = boundingbox(seg)
+  polybbox = boundingbox(poly)
 
-	a, b = vertices(seg)
-	segbbox = boundingbox(seg)
-	polybbox = boundingbox(poly)
+  # check for degenerate segments
+  if a ≈ b
+    if a ∈ poly
+      return @IT Touching a f # Case 3
+    else
+      return @IT NotIntersecting nothing f # Case 4
+    end
+  end
 
-	# check for degenerate segments
-	if a ≈ b
-		if a ∈ poly
-			return @IT Touching a f # Case 3
-		else
-			return @IT NotIntersecting nothing f # Case 4
-		end
-	end
+  # assess obvious no intersection case beforehand
+  if !intersects(segbbox, polybbox)
+    return @IT NotIntersecting nothing f # Case 5
+  end
 
-	# assess obvious no intersection case beforehand
-	if !intersects(segbbox, polybbox)
-		return @IT NotIntersecting nothing f # Case 5
-	end
+  # segment endpoints as scalars + segment vector
+  segλs = [0.0, 1.0];
+  v = b-a;
 
-	# segment endpoints as scalars + segment vector
-	segλs = [0.0, 1.0];
-	v = b-a;
+  # Extract the first Cartesian coordinate
+  x(p) = flat(coords(p)).x
+  y(p) = flat(coords(p)).y
 
-	# Extract the first Cartesian coordinate
-	x(p) = flat(coords(p)).x
-	y(p) = flat(coords(p)).y
+  # Choose the polygon's longest bounding-box axis
+  polymin, polymax = extrema(polybbox)
+  xspan = x(polymax) - x(polymin)
+  yspan = y(polymax) - y(polymin)
+  axiscoord = xspan ≥ yspan ? x : y
 
-	# Choose the polygon's longest bounding-box axis
-	polymin, polymax = extrema(polybbox)
-	xspan = x(polymax) - x(polymin)
-	yspan = y(polymax) - y(polymin)
-	axiscoord = xspan ≥ yspan ? x : y
+  # Segment range along the chosen axis
+  segmin, segmax = extrema(segbbox)
+  segstart = axiscoord(segmin)
+  segstop = axiscoord(segmax)
 
-	# Segment range along the chosen axis
-	segmin, segmax = extrema(segbbox)
-	segstart = axiscoord(segmin)
-	segstop = axiscoord(segmax)
+  # assess intersections
+  boundarypoints = Point[]
+  for ring in rings(poly)
+    ringbbox = boundingbox(ring)
+    # check for obvious no intersection case beforehand
+    intersects(segbbox, ringbbox) || continue
+    edges = collect(segments(ring))
+    boxes = boundingbox.(edges)
+    # Edge ranges
+    starts = map(boxes) do box
+      pmin, _ = extrema(box)
+      axiscoord(pmin)
+    end
+    stops = map(boxes) do box
+      _, pmax = extrema(box)
+      axiscoord(pmax)
+    end
 
-	# assess intersections
-	boundarypoints = Point[]
-	for ring in rings(poly)
-		ringbbox = boundingbox(ring)
-		# check for obvious no intersection case beforehand
-		intersects(segbbox, ringbbox) || continue
-		edges = collect(segments(ring))
-		boxes = boundingbox.(edges)
-		# Edge ranges
-		starts = map(boxes) do box
-			pmin, _ = extrema(box)
-			axiscoord(pmin)
-		end
-		stops = map(boxes) do box
-			_, pmax = extrema(box)
-			axiscoord(pmax)
-		end
+    # Sort by minimum coordinate
+    inds = sortperm(starts)
+    edges = edges[inds]
+    boxes = boxes[inds]
+    starts = starts[inds]
+    stops = stops[inds]
+    for i in eachindex(edges)
+      # Edge ends before the segment begins. Later edges may still overlap, so skip only this edge
+      stops[i] < segstart && continue
 
-		# Sort by minimum coordinate
-		inds = sortperm(starts)
-		edges = edges[inds]
-		boxes = boxes[inds]
-		starts = starts[inds]
-		stops = stops[inds]
-		for i in eachindex(edges)
-			# Edge ends before the segment begins. Later edges may still overlap, so skip only this edge.
-			stops[i] < segstart && continue
+      # Edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right
+      starts[i] > segstop && break
 
-			# Edge starts after the segment ends. Since edges are sorted by the selected axis minimum, all later edges are also too far right.
-			starts[i] > segstop && break
+      # The selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
+      intersects(segbbox, boxes[i]) || continue
 
-			# The selected axis ranges overlap, but the full bounding boxes may still be separated along the other axis
-			intersects(segbbox, boxes[i]) || continue
+      edge = edges[i]
+      intersection(seg, edge) do I
+        itype = type(I)
+        # no intersection
+        if itype == NotIntersecting
+          return
+        elseif itype == Overlapping
+          # Overlapping segments
+          seg = get(I)
+          c, d = vertices(seg)
+          λc = ustrip((c-a) ⋅ v / (v ⋅ v))
+          λd = ustrip((d-a) ⋅ v / (v ⋅ v))
+          push!(segλs, λc, λd)
+        else
+          # Crossing, EdgeTouching, CornerTouching, etc.
+          p = get(I)
+          push!(boundarypoints, p)
+          λ = ustrip((p-a) ⋅ v / (v ⋅ v))
+          push!(segλs, λ)
+        end
+      end
+    end
+  end
 
-			edge = edges[i]
-			intersection(seg, edge) do I
-				itype = type(I)
-				# no intersection
-				if itype == NotIntersecting
-					return
-				elseif itype == Overlapping
-					# Overlapping segments
-					seg = get(I)
-					c, d = vertices(seg)
-					λc = ustrip((c-a) ⋅ v / (v ⋅ v))
-					λd = ustrip((d-a) ⋅ v / (v ⋅ v))
-					push!(segλs, λc, λd)
-				else
-					# Crossing, EdgeTouching, CornerTouching, etc.
-					p = get(I)
-					push!(boundarypoints, p)
-					λ = ustrip((p-a) ⋅ v / (v ⋅ v))
-					push!(segλs, λ)
-				end
-			end
-		end
-	end
+  # Define collection of intersected segment pieces
+  sort!(segλs);
+  pieces = Segment[]
+  for (λ₁, λ₂) in zip(segλs[1:(end - 1)], segλs[2:end])
+    λ₁ ≈ λ₂ && continue
+    λmid = (λ₁ + λ₂) / 2
+    if seg(λmid) ∈ poly
+      push!(pieces, Segment(seg(λ₁), seg(λ₂)))
+    end
+  end
 
-	# Define collection of intersected segment pieces
-	sort!(segλs);
-	pieces = Segment[]
-	for (λ₁, λ₂) in zip(segλs[1:(end-1)], segλs[2:end])
-		λ₁ ≈ λ₂ && continue
-		λmid = (λ₁ + λ₂) / 2
-		if seg(λmid) ∈ poly
-			push!(
-				pieces,
-				Segment(seg(λ₁), seg(λ₂)),
-			)
-		end
-	end
-
-	# classifying intersections
-	if !isempty(pieces) # Positive-length intersection
-		geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces)
-		return @IT Overlapping geometry f # Case 1
-	elseif !isempty(boundarypoints) # no segments, but some intersection
-		geometry = length(boundarypoints) == 1 ? only(boundarypoints) : Multi(boundarypoints)
-		return @IT Touching geometry f # Case 2
-	else
-		return @IT NotIntersecting nothing f # Case 5 
-	end
-
+  # classifying intersections
+  if !isempty(pieces) # Positive-length intersection
+    geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces)
+    return @IT Overlapping geometry f # Case 1
+  elseif !isempty(boundarypoints) # no segments, but some intersection
+    geometry = length(boundarypoints) == 1 ? only(boundarypoints) : Multi(boundarypoints)
+    return @IT Touching geometry f # Case 2
+  else
+    return @IT NotIntersecting nothing f # Case 5 
+  end
 end
 
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.
 # (https://www.sciencedirect.com/science/article/pii/S0925772109001448?via%3Dihub)
 function intersection(f, seg::Segment{𝔼{3}}, tri::Triangle{𝔼{3}})
-	Q1, Q2 = vertices(seg)
-	V1, V2, V3 = vertices(tri)
+  Q1, Q2 = vertices(seg)
+  V1, V2, V3 = vertices(tri)
 
-	# according to theorem 1, the algorithm only works
-	# when Q1 is not coplanar with the triangle, we need
-	# to swap Q1 with Q2 in that case
-	if iscoplanar(Q1, V1, V2, V3)
-		(Q1, Q2) = (Q2, Q1)
-	end
+  # according to theorem 1, the algorithm only works
+  # when Q1 is not coplanar with the triangle, we need
+  # to swap Q1 with Q2 in that case
+  if iscoplanar(Q1, V1, V2, V3)
+    (Q1, Q2) = (Q2, Q1)
+  end
 
-	A = Q1 - V3
-	B = V1 - V3
-	C = V2 - V3
+  A = Q1 - V3
+  B = V1 - V3
+  C = V2 - V3
 
-	W₁ = B × C
-	w = A ⋅ W₁
+  W₁ = B × C
+  w = A ⋅ W₁
 
-	D = Q2 - V3
-	s = D ⋅ W₁
+  D = Q2 - V3
+  s = D ⋅ W₁
 
-	if w > atol(w)
-		# rejection 2
-		if s > atol(s)
-			return @IT NotIntersecting nothing f
-		end
+  if w > atol(w)
+    # rejection 2
+    if s > atol(s)
+      return @IT NotIntersecting nothing f
+    end
 
-		W₂ = A × D
-		t = W₂ ⋅ C
+    W₂ = A × D
+    t = W₂ ⋅ C
 
-		# rejection 3
-		if t < -atol(t)
-			return @IT NotIntersecting nothing f
-		end
+    # rejection 3
+    if t < -atol(t)
+      return @IT NotIntersecting nothing f
+    end
 
-		u = -(W₂ ⋅ B)
+    u = -(W₂ ⋅ B)
 
-		# rejection 4
-		if u < -atol(u)
-			return @IT NotIntersecting nothing f
-		end
+    # rejection 4
+    if u < -atol(u)
+      return @IT NotIntersecting nothing f
+    end
 
-		# rejection 5
-		if w < (s + t + u)
-			return @IT NotIntersecting nothing f
-		end
-	elseif w < -atol(w)
-		# rejection 2
-		if s < -atol(s)
-			return @IT NotIntersecting nothing f
-		end
+    # rejection 5
+    if w < (s + t + u)
+      return @IT NotIntersecting nothing f
+    end
+  elseif w < -atol(w)
+    # rejection 2
+    if s < -atol(s)
+      return @IT NotIntersecting nothing f
+    end
 
-		W₂ = A × D
-		t = W₂ ⋅ C
+    W₂ = A × D
+    t = W₂ ⋅ C
 
-		# rejection 3
-		if t > atol(t)
-			return @IT NotIntersecting nothing f
-		end
+    # rejection 3
+    if t > atol(t)
+      return @IT NotIntersecting nothing f
+    end
 
-		u = -(W₂ ⋅ B)
+    u = -(W₂ ⋅ B)
 
-		# rejection 4
-		if u > atol(u)
-			return @IT NotIntersecting nothing f
-		end
+    # rejection 4
+    if u > atol(u)
+      return @IT NotIntersecting nothing f
+    end
 
-		# rejection 5
-		if w > (s + t + u)
-			return @IT NotIntersecting nothing f
-		end
-	else # w ≈ 0
-		if s > atol(s)
-			W₂ = D × A
-			t = W₂ ⋅ C
+    # rejection 5
+    if w > (s + t + u)
+      return @IT NotIntersecting nothing f
+    end
+  else # w ≈ 0
+    if s > atol(s)
+      W₂ = D × A
+      t = W₂ ⋅ C
 
-			# rejection 3
-			if t < -atol(t)
-				return @IT NotIntersecting nothing f
-			end
+      # rejection 3
+      if t < -atol(t)
+        return @IT NotIntersecting nothing f
+      end
 
-			u = -(W₂ ⋅ B)
+      u = -(W₂ ⋅ B)
 
-			# rejection 4
-			if u < -atol(u)
-				return @IT NotIntersecting nothing f
-			end
+      # rejection 4
+      if u < -atol(u)
+        return @IT NotIntersecting nothing f
+      end
 
-			# rejection 5
-			if -s < (t + u)
-				return @IT NotIntersecting nothing f
-			end
-		elseif s < -atol(s)
-			W₂ = D × A
-			t = W₂ ⋅ C
+      # rejection 5
+      if -s < (t + u)
+        return @IT NotIntersecting nothing f
+      end
+    elseif s < -atol(s)
+      W₂ = D × A
+      t = W₂ ⋅ C
 
-			# rejection 3
-			if t > atol(t)
-				return @IT NotIntersecting nothing f
-			end
+      # rejection 3
+      if t > atol(t)
+        return @IT NotIntersecting nothing f
+      end
 
-			u = -(W₂ ⋅ B)
+      u = -(W₂ ⋅ B)
 
-			# rejection 4
-			if u > atol(u)
-				return @IT NotIntersecting nothing f
-			end
+      # rejection 4
+      if u > atol(u)
+        return @IT NotIntersecting nothing f
+      end
 
-			# rejection 5
-			if -s > (t + u)
-				return @IT NotIntersecting nothing f
-			end
-		else # s ≈ 0
-			# rejection 1, coplanar segment
-			return @IT NotIntersecting nothing f
-		end
-	end
+      # rejection 5
+      if -s > (t + u)
+        return @IT NotIntersecting nothing f
+      end
+    else # s ≈ 0
+      # rejection 1, coplanar segment
+      return @IT NotIntersecting nothing f
+    end
+  end
 
-	λ = w / (w - s)
-	λ = clamp(λ, zero(λ), one(λ))
+  λ = w / (w - s)
+  λ = clamp(λ, zero(λ), one(λ))
 
-	p = Segment(Q1, Q2)(λ)
+  p = Segment(Q1, Q2)(λ)
 
-	return @IT Intersecting p f
+  return @IT Intersecting p f
 end
 
 # sorts four numbers using a sorting network 
 # and returns the 2nd and 3rd
 function _sort4vals(a, b, c, d)
-	a > c && ((a, c) = (c, a))
-	b > d && ((b, d) = (d, b))
-	a > b && ((a, b) = (b, a))
-	c > d && ((c, d) = (d, c))
-	b > c && ((b, c) = (c, b))
-	b, c
+  a > c && ((a, c) = (c, a))
+  b > d && ((b, d) = (d, b))
+  a > b && ((a, b) = (b, a))
+  c > d && ((c, d) = (d, c))
+  b > c && ((b, c) = (c, b))
+  b, c
 end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -214,9 +214,9 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   intersects(sbox, pbox) || return @IT NotIntersecting nothing f
 
   # collect and classify boundary events, which are of the
-  # form (point, iscrossing, enteringmode). The enteringmode
-  # is +1 if the segment is entering the polygon, -1 if it is
-  # leaving the polygon, and 0 if it is neither (e.g. crossing)
+  # form (point, iscrossing, endtype). The endtype is +1 if
+  # the segment is entering the polygon, -1 if it is leaving
+  # the polygon, and 0 if it is neither (e.g. crossing)
   a, b = vertices(seg)
   λ(p) = (p - a) ⋅ (b - a)
   events = [(a, false, Int8(0)), (b, false, Int8(0))]
@@ -254,7 +254,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
       # merge coincident events
       events[i] = (eᵢ[1], eᵢ[2] || eⱼ[2], eᵢ[3] + eⱼ[3])
     else
-      # eᵢ is fully merged, connect it with the next event
+      # event is fully merged, connect it with the next event
       depth += eᵢ[3]
       piece = Segment(eᵢ[1], eⱼ[1])
       if depth > 0 

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -219,7 +219,7 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # leaving the polygon, and 0 if it is neither (e.g. crossing)
   a, b = vertices(seg)
   λ(p) = (p - a) ⋅ (b - a)
-  events = [(a, false, 0), (b, false, 0)]
+  events = [(a, false, Int8(0)), (b, false, Int8(0))]
   for ring in rings(poly)
     intersects(sbox, boundingbox(ring)) || continue
     for edge in segments(ring)
@@ -232,11 +232,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
         if λ(d) < λ(c)
           c, d = d, c
         end
-        push!(events, (c, false, 1))
-        push!(events, (d, false, -1))
+        push!(events, (c, false, Int8(+1)))
+        push!(events, (d, false, Int8(-1)))
       else
         p = get(I)
-        push!(events, (p, true, 0))
+        push!(events, (p, true, Int8(0)))
       end
     end
   end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -203,9 +203,84 @@ function intersection(f, seg::Segment, line::Line)
   end
 end
 
+# intersection between a segment and a polygon
+# 1. overlap of line and polygon (Overlapping -> Segment)
+# 2. intersect at one an point, exactly (Touching -> Point)
+# 3. the segment is degenerate and is inside the polygon (Touching -> Point)
+# 4. the segment is degenerate and is outside the polygon (NotIntersecting -> Nothing)
+# 5. do not overlap nor intersect (NotIntersecting -> Nothing)
+function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
+
+  a, b = vertices(seg)
+
+  # check for degenerate segments
+  if a ≈ b
+    if a ∈ poly
+      return @IT Touching a f # Case 3
+    else
+      return @IT NotIntersecting nothing f # Case 4
+    end
+  end
+
+  # segment endpoints as scalars + segment vector
+  segλs = [0.0, 1.0]; v = b-a;
+
+  # assess intersections with the edges
+  boundarypoints = Point[]
+  for ring in rings(poly)
+    for edge in segments(ring)
+      I = intersection(seg, edge)
+      itype = type(I)
+      # no intersection
+      if itype == NotIntersecting
+        continue
+      end
+      # some intersection
+      geom = get(I)
+      if geom isa Point # crosses or touches 
+        push!(boundarypoints, geom)
+        λ = ustrip((geom-a) ⋅ v / (v ⋅ v))
+        push!(segλs, λ)
+      elseif geom isa Segment # overlaps
+        c, d = vertices(geom)
+        λc = ustrip((c-a) ⋅ v / (v ⋅ v))
+        λd = ustrip((d-a) ⋅ v / (v ⋅ v))
+        push!(segλs, λc, λd)
+      else
+        @error "Unexpected Segment × Polygon edge intersection geometry: " * "$(typeof(geometry))"
+      end
+    end
+  end
+
+  # Define collection of intersected segment pieces
+  sort!(segλs); pieces = Segment[]
+  for (λ₁, λ₂) in zip(segλs[1:(end - 1)], segλs[2:end])
+    λ₁ ≈ λ₂ && continue
+    λmid = (λ₁ + λ₂) / 2
+    if seg(λmid) ∈ poly
+      push!(
+        pieces,
+        Segment(seg(λ₁), seg(λ₂))
+      )
+    end
+  end
+
+  # classifying intersections
+  if !isempty(pieces) # Positive-length intersection
+    geometry = length(pieces) == 1 ? only(pieces) : Multi(pieces) 
+    return @IT Overlapping geometry f # Case 1
+  elseif !isempty(boundarypoints) # no segments, but some intersection
+    geometry = length(boundarypoints) == 1 ? only(pieces) : first(pieces) # it gotta be a single point!
+    return @IT Touching geometry f # Case 2
+  else
+    return @IT NotIntersecting nothing f # Case 5 
+  end 
+
+end
+
 # Algorithm 4 of Jiménez, J., Segura, R. and Feito, F. 2009.
 # (https://www.sciencedirect.com/science/article/pii/S0925772109001448?via%3Dihub)
-function intersection(f, seg::Segment, tri::Triangle)
+function intersection(f, seg::Segment{𝔼{3}}, tri::Triangle{𝔼{3}})
   Q1, Q2 = vertices(seg)
   V1, V2, V3 = vertices(tri)
 

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -478,7 +478,7 @@ end
   @test intersection(s, p) |> type == CornerTouching
   @test intersection(p, s) |> type == CornerTouching
   s = Segment(cart(-1, 2), cart(0, 2))
-  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p ≈ p ∩ s ≈ cart(0, 2)
   @test intersection(s, p) |> type == Touching
   @test intersection(p, s) |> type == Touching
@@ -488,7 +488,7 @@ end
   @test intersection(s, p) |> type == Touching
   @test intersection(p, s) |> type == Touching
   s = Segment(cart(2, 2), cart(2, 2))
-  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p ≈ p ∩ s ≈ cart(2, 2)
   @test intersection(s, p) |> type == Touching
   @test intersection(p, s) |> type == Touching
@@ -499,6 +499,11 @@ end
   @test intersection(p, s) |> type == NotIntersecting
   s = Segment(cart(-1, 5), cart(5, 5))
   p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  @test s ∩ p === p ∩ s === nothing
+  @test intersection(s, p) |> type == NotIntersecting
+  @test intersection(p, s) |> type == NotIntersecting
+  s = Segment(cart(3, 3), cart(3, 5))
+  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p === p ∩ s === nothing
   @test intersection(s, p) |> type == NotIntersecting
   @test intersection(p, s) |> type == NotIntersecting

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -238,6 +238,69 @@ end
   @test intersection(s₁₀, s₃) |> type == NotIntersecting
   @test intersection(s₃, s₁₀) |> type == NotIntersecting
 
+  # segments and polygons in 2D
+  poly = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
+
+  # CASE 1: Overlapping, segment inside polygon
+  s = Segment(cart(1, 2), cart(3, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ s
+  @test intersection(s, poly) |> type == Overlapping
+  @test intersection(poly, s) |> type == Overlapping
+
+  # CASE 1: Overlapping, segment crosses polygon
+  s = Segment(cart(-1, 2), cart(5, 2))
+  expected = Segment(cart(0, 2), cart(4, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ expected
+  @test intersection(s, poly) |> type == Overlapping
+  @test intersection(poly, s) |> type == Overlapping
+
+  # CASE 1: Overlapping, segment lies on polygon boundary
+  s = Segment(cart(-1, 0), cart(5, 0))
+  expected = Segment(cart(0, 0), cart(4, 0))
+  @test s ∩ poly ≈ poly ∩ s ≈ expected
+  @test intersection(s, poly) |> type == Overlapping
+  @test intersection(poly, s) |> type == Overlapping
+
+  # CASE 2: Touching polygon edge
+  s = Segment(cart(-1, 2), cart(0, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 2)
+  @test intersection(s, poly) |> type == Touching
+  @test intersection(poly, s) |> type == Touching
+
+  # CASE 2: Touching polygon corner
+  s = Segment(cart(-1, -1), cart(0, 0))
+  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 0)
+  @test intersection(s, poly) |> type == Touching
+  @test intersection(poly, s) |> type == Touching
+
+  # CASE 3: Degenerate segment inside polygon
+  s = Segment(cart(2, 2), cart(2, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ cart(2, 2)
+  @test intersection(s, poly) |> type == Touching
+  @test intersection(poly, s) |> type == Touching
+
+  # CASE 4: Degenerate segment outside polygon
+  s = Segment(cart(5, 5), cart(5, 5))
+  @test s ∩ poly === poly ∩ s === nothing
+  @test intersection(s, poly) |> type == NotIntersecting
+  @test intersection(poly, s) |> type == NotIntersecting
+
+  # CASE 4: Segment outside polygon
+  s = Segment(cart(-1, 5), cart(5, 5))
+  @test s ∩ poly === poly ∩ s === nothing
+  @test intersection(s, poly) |> type == NotIntersecting
+  @test intersection(poly, s) |> type == NotIntersecting
+
+  # concave polygon with disconnected intersection pieces
+  poly = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
+
+  s = Segment(cart(-1, 4), cart(7, 4))
+  expected = Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
+
+  @test s ∩ poly ≈ poly ∩ s ≈ expected
+  @test intersection(s, poly) |> type == Overlapping
+  @test intersection(poly, s) |> type == Overlapping
+
   # segments in 3D
   s1 = Segment(cart(0.0, 0.0, 0.0), cart(1.0, 0.0, 0.0))
   s2 = Segment(cart(0.5, 1.0, 0.0), cart(0.5, -1.0, 0.0))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -456,57 +456,46 @@ end
   p = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
   @test s ∩ p ≈ p ∩ s ≈ s
   @test intersection(s, p) |> type == Intersecting
-  @test intersection(p, s) |> type == Intersecting
   s = Segment(cart(-1, 2), cart(5, 2))
   p = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
   @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 2), cart(4, 2))
   @test intersection(s, p) |> type == Intersecting
-  @test intersection(p, s) |> type == Intersecting
   s = Segment(cart(-1, 4), cart(7, 4))
   p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p ≈ p ∩ s ≈ Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
   @test intersection(s, p) |> type == Intersecting
-  @test intersection(p, s) |> type == Intersecting
   s = Segment(cart(-1, 0), cart(5, 0))
   p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 0), cart(5, 0))
   @test intersection(s, p) |> type == EdgeTouching
-  @test intersection(p, s) |> type == EdgeTouching
   s = Segment(cart(-1.0, 1.0), cart(1.0, -1.0))
   p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
   @test s ∩ p ≈ p ∩ s ≈ cart(0, 0)
   @test intersection(s, p) |> type == CornerTouching
-  @test intersection(p, s) |> type == CornerTouching
   s = Segment(cart(-1, 2), cart(0, 2))
   p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p ≈ p ∩ s ≈ cart(0, 2)
   @test intersection(s, p) |> type == Touching
-  @test intersection(p, s) |> type == Touching
   s = Segment(cart(-1, -1), cart(0, 0))
   p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
   @test s ∩ p ≈ p ∩ s ≈ cart(0, 0)
   @test intersection(s, p) |> type == CornerTouching
-  @test intersection(p, s) |> type == CornerTouching
   s = Segment(cart(2, 2), cart(2, 2))
   p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p ≈ p ∩ s ≈ cart(2, 2)
   @test intersection(s, p) |> type == CornerTouching
-  @test intersection(p, s) |> type == CornerTouching
   s = Segment(cart(5, 5), cart(5, 5))
   p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
   @test s ∩ p === p ∩ s === nothing
   @test intersection(s, p) |> type == NotIntersecting
-  @test intersection(p, s) |> type == NotIntersecting
   s = Segment(cart(-1, 5), cart(5, 5))
   p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
   @test s ∩ p === p ∩ s === nothing
   @test intersection(s, p) |> type == NotIntersecting
-  @test intersection(p, s) |> type == NotIntersecting
   s = Segment(cart(3, 3), cart(3, 5))
   p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p === p ∩ s === nothing
   @test intersection(s, p) |> type == NotIntersecting
-  @test intersection(p, s) |> type == NotIntersecting
 
   # type stability tests
   s₁ = Segment(cart(-1, 4), cart(7, 4))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -238,6 +238,74 @@ end
   @test intersection(s₁₀, s₃) |> type == NotIntersecting
   @test intersection(s₃, s₁₀) |> type == NotIntersecting
 
+  # segments and polygons in 2D
+  poly = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
+
+  # CASE 1: Intersecting, segment inside polygon
+  s = Segment(cart(1, 2), cart(3, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ s
+  @test intersection(s, poly) |> type == Intersecting
+  @test intersection(poly, s) |> type == Intersecting
+
+  # CASE 1: Intersecting, segment crosses polygon
+  s = Segment(cart(-1, 2), cart(5, 2))
+  expected = Segment(cart(0, 2), cart(4, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ expected
+  @test intersection(s, poly) |> type == Intersecting
+  @test intersection(poly, s) |> type == Intersecting
+
+  # CASE 1: concave polygon with disconnected intersection pieces
+  poly = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
+  s = Segment(cart(-1, 4), cart(7, 4))
+  expected = Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
+  @test s ∩ poly ≈ poly ∩ s ≈ expected
+  @test intersection(s, poly) |> type == Intersecting
+  @test intersection(poly, s) |> type == Intersecting
+
+  # CASE 2: EdgeTouching, segment lies on polygon boundary
+  s = Segment(cart(-1, 0), cart(5, 0))
+  expected = Segment(cart(0, 0), cart(4, 0))
+  @test s ∩ poly ≈ poly ∩ s ≈ expected
+  @test intersection(s, poly) |> type == EdgeTouching
+  @test intersection(poly, s) |> type == EdgeTouching
+
+  # CASE 3: CornerTouching polygon edge
+  poly = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  s = Segment(cart(-1.0, 1.0), cart(1.0, -1.0))
+  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 0)
+  @test intersection(s, poly) |> type == CornerTouching
+  @test intersection(poly, s) |> type == CornerTouching
+
+  # CASE 4: Touching polygon edge
+  s = Segment(cart(-1, 2), cart(0, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 2)
+  @test intersection(s, poly) |> type == Touching
+  @test intersection(poly, s) |> type == Touching
+
+  # CASE 4: Touching polygon corner
+  s = Segment(cart(-1, -1), cart(0, 0))
+  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 0)
+  @test intersection(s, poly) |> type == Touching
+  @test intersection(poly, s) |> type == Touching
+
+  # CASE 5: Degenerate segment inside polygon
+  s = Segment(cart(2, 2), cart(2, 2))
+  @test s ∩ poly ≈ poly ∩ s ≈ cart(2, 2)
+  @test intersection(s, poly) |> type == Touching
+  @test intersection(poly, s) |> type == Touching
+
+  # CASE 6: Degenerate segment outside polygon
+  s = Segment(cart(5, 5), cart(5, 5))
+  @test s ∩ poly === poly ∩ s === nothing
+  @test intersection(s, poly) |> type == NotIntersecting
+  @test intersection(poly, s) |> type == NotIntersecting
+
+  # CASE 6: Segment outside polygon
+  s = Segment(cart(-1, 5), cart(5, 5))
+  @test s ∩ poly === poly ∩ s === nothing
+  @test intersection(s, poly) |> type == NotIntersecting
+  @test intersection(poly, s) |> type == NotIntersecting
+
   # segments in 3D
   s1 = Segment(cart(0.0, 0.0, 0.0), cart(1.0, 0.0, 0.0))
   s2 = Segment(cart(0.5, 1.0, 0.0), cart(0.5, -1.0, 0.0))
@@ -450,65 +518,6 @@ end
   @test intersection(s₁, s₁) |> type == CornerTouching
   @test intersection(s₂, s₂) |> type == CornerTouching
   @test intersection(s₃, s₃) |> type == CornerTouching
-
-  # segments and polygons in 2D
-  p = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
-
-  # segment inside polygon
-  s = Segment(cart(1, 2), cart(3, 2))
-  @test s ∩ p ≈ p ∩ s ≈ s
-  @test intersection(s, p) |> type == Overlapping
-  @test intersection(p, s) |> type == Overlapping
-
-  # segment crosses polygon
-  s = Segment(cart(-1, 2), cart(5, 2))
-  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 2), cart(4, 2))
-  @test intersection(s, p) |> type == Overlapping
-  @test intersection(p, s) |> type == Overlapping
-
-  # segment lies on polygon boundary
-  s = Segment(cart(-1, 0), cart(5, 0))
-  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 0), cart(4, 0))
-  @test intersection(s, p) |> type == Overlapping
-  @test intersection(p, s) |> type == Overlapping
-
-  # touching polygon edge
-  s = Segment(cart(-1, 2), cart(0, 2))
-  @test s ∩ p ≈ p ∩ s ≈ cart(0, 2)
-  @test intersection(s, p) |> type == Touching
-  @test intersection(p, s) |> type == Touching
-
-  # touching polygon corner
-  s = Segment(cart(-1, -1), cart(0, 0))
-  @test s ∩ p ≈ p ∩ s ≈ cart(0, 0)
-  @test intersection(s, p) |> type == Touching
-  @test intersection(p, s) |> type == Touching
-
-  # degenerate segment inside polygon
-  s = Segment(cart(2, 2), cart(2, 2))
-  @test s ∩ p ≈ p ∩ s ≈ cart(2, 2)
-  @test intersection(s, p) |> type == Touching
-  @test intersection(p, s) |> type == Touching
-
-  # degenerate segment outside polygon
-  s = Segment(cart(5, 5), cart(5, 5))
-  @test s ∩ p === p ∩ s === nothing
-  @test intersection(s, p) |> type == NotIntersecting
-  @test intersection(p, s) |> type == NotIntersecting
-
-  # segment outside polygon
-  s = Segment(cart(-1, 5), cart(5, 5))
-  @test s ∩ p === p ∩ s === nothing
-  @test intersection(s, p) |> type == NotIntersecting
-  @test intersection(p, s) |> type == NotIntersecting
-
-  # concave polygon with disconnected intersection pieces
-  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
-
-  s = Segment(cart(-1, 4), cart(7, 4))
-  @test s ∩ p ≈ p ∩ s ≈ Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
-  @test intersection(s, p) |> type == Overlapping
-  @test intersection(p, s) |> type == Overlapping
 
   # utils
   @test Meshes._sort4vals(2.5, 1.4, 1.1, 2.0) == (1.4, 2.0)

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -238,69 +238,6 @@ end
   @test intersection(s₁₀, s₃) |> type == NotIntersecting
   @test intersection(s₃, s₁₀) |> type == NotIntersecting
 
-  # segments and polygons in 2D
-  poly = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
-
-  # CASE 1: Overlapping, segment inside polygon
-  s = Segment(cart(1, 2), cart(3, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ s
-  @test intersection(s, poly) |> type == Overlapping
-  @test intersection(poly, s) |> type == Overlapping
-
-  # CASE 1: Overlapping, segment crosses polygon
-  s = Segment(cart(-1, 2), cart(5, 2))
-  expected = Segment(cart(0, 2), cart(4, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ expected
-  @test intersection(s, poly) |> type == Overlapping
-  @test intersection(poly, s) |> type == Overlapping
-
-  # CASE 1: Overlapping, segment lies on polygon boundary
-  s = Segment(cart(-1, 0), cart(5, 0))
-  expected = Segment(cart(0, 0), cart(4, 0))
-  @test s ∩ poly ≈ poly ∩ s ≈ expected
-  @test intersection(s, poly) |> type == Overlapping
-  @test intersection(poly, s) |> type == Overlapping
-
-  # CASE 2: Touching polygon edge
-  s = Segment(cart(-1, 2), cart(0, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 2)
-  @test intersection(s, poly) |> type == Touching
-  @test intersection(poly, s) |> type == Touching
-
-  # CASE 2: Touching polygon corner
-  s = Segment(cart(-1, -1), cart(0, 0))
-  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 0)
-  @test intersection(s, poly) |> type == Touching
-  @test intersection(poly, s) |> type == Touching
-
-  # CASE 3: Degenerate segment inside polygon
-  s = Segment(cart(2, 2), cart(2, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ cart(2, 2)
-  @test intersection(s, poly) |> type == Touching
-  @test intersection(poly, s) |> type == Touching
-
-  # CASE 4: Degenerate segment outside polygon
-  s = Segment(cart(5, 5), cart(5, 5))
-  @test s ∩ poly === poly ∩ s === nothing
-  @test intersection(s, poly) |> type == NotIntersecting
-  @test intersection(poly, s) |> type == NotIntersecting
-
-  # CASE 4: Segment outside polygon
-  s = Segment(cart(-1, 5), cart(5, 5))
-  @test s ∩ poly === poly ∩ s === nothing
-  @test intersection(s, poly) |> type == NotIntersecting
-  @test intersection(poly, s) |> type == NotIntersecting
-
-  # concave polygon with disconnected intersection pieces
-  poly = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
-
-  s = Segment(cart(-1, 4), cart(7, 4))
-  expected = Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
-
-  @test s ∩ poly ≈ poly ∩ s ≈ expected
-  @test intersection(s, poly) |> type == Overlapping
-  @test intersection(poly, s) |> type == Overlapping
-
   # segments in 3D
   s1 = Segment(cart(0.0, 0.0, 0.0), cart(1.0, 0.0, 0.0))
   s2 = Segment(cart(0.5, 1.0, 0.0), cart(0.5, -1.0, 0.0))
@@ -513,6 +450,65 @@ end
   @test intersection(s₁, s₁) |> type == CornerTouching
   @test intersection(s₂, s₂) |> type == CornerTouching
   @test intersection(s₃, s₃) |> type == CornerTouching
+
+  # segments and polygons in 2D
+  p = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
+
+  # segment inside polygon
+  s = Segment(cart(1, 2), cart(3, 2))
+  @test s ∩ p ≈ p ∩ s ≈ s
+  @test intersection(s, p) |> type == Overlapping
+  @test intersection(p, s) |> type == Overlapping
+
+  # segment crosses polygon
+  s = Segment(cart(-1, 2), cart(5, 2))
+  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 2), cart(4, 2))
+  @test intersection(s, p) |> type == Overlapping
+  @test intersection(p, s) |> type == Overlapping
+
+  # segment lies on polygon boundary
+  s = Segment(cart(-1, 0), cart(5, 0))
+  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 0), cart(4, 0))
+  @test intersection(s, p) |> type == Overlapping
+  @test intersection(p, s) |> type == Overlapping
+
+  # touching polygon edge
+  s = Segment(cart(-1, 2), cart(0, 2))
+  @test s ∩ p ≈ p ∩ s ≈ cart(0, 2)
+  @test intersection(s, p) |> type == Touching
+  @test intersection(p, s) |> type == Touching
+
+  # touching polygon corner
+  s = Segment(cart(-1, -1), cart(0, 0))
+  @test s ∩ p ≈ p ∩ s ≈ cart(0, 0)
+  @test intersection(s, p) |> type == Touching
+  @test intersection(p, s) |> type == Touching
+
+  # degenerate segment inside polygon
+  s = Segment(cart(2, 2), cart(2, 2))
+  @test s ∩ p ≈ p ∩ s ≈ cart(2, 2)
+  @test intersection(s, p) |> type == Touching
+  @test intersection(p, s) |> type == Touching
+
+  # degenerate segment outside polygon
+  s = Segment(cart(5, 5), cart(5, 5))
+  @test s ∩ p === p ∩ s === nothing
+  @test intersection(s, p) |> type == NotIntersecting
+  @test intersection(p, s) |> type == NotIntersecting
+
+  # segment outside polygon
+  s = Segment(cart(-1, 5), cart(5, 5))
+  @test s ∩ p === p ∩ s === nothing
+  @test intersection(s, p) |> type == NotIntersecting
+  @test intersection(p, s) |> type == NotIntersecting
+
+  # concave polygon with disconnected intersection pieces
+  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
+
+  s = Segment(cart(-1, 4), cart(7, 4))
+  @test s ∩ p ≈ p ∩ s ≈ Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
+  @test intersection(s, p) |> type == Overlapping
+  @test intersection(p, s) |> type == Overlapping
 
   # utils
   @test Meshes._sort4vals(2.5, 1.4, 1.1, 2.0) == (1.4, 2.0)

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -508,6 +508,17 @@ end
   @test intersection(s, p) |> type == NotIntersecting
   @test intersection(p, s) |> type == NotIntersecting
 
+  # type stability tests
+  s₁ = Segment(cart(-1, 4), cart(7, 4))
+  s₂ = Segment(cart(-1, 0), cart(5, 0))
+  s₃ = Segment(cart(-1.0, 1.0), cart(1.0, -1.0))
+  s₄ = Segment(cart(-1, 2), cart(0, 2))
+  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
+  @inferred someornone(s₁, p)
+  @inferred someornone(s₂, p)
+  @inferred someornone(s₃, p)
+  @inferred someornone(s₄, p)
+
   # utils
   @test Meshes._sort4vals(2.5, 1.4, 1.1, 2.0) == (1.4, 2.0)
   @test Meshes._sort4vals(2.0, 1.1, 1.4, 2.5) == (1.4, 2.0)

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -485,13 +485,13 @@ end
   s = Segment(cart(-1, -1), cart(0, 0))
   p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
   @test s ∩ p ≈ p ∩ s ≈ cart(0, 0)
-  @test intersection(s, p) |> type == Touching
-  @test intersection(p, s) |> type == Touching
+  @test intersection(s, p) |> type == CornerTouching
+  @test intersection(p, s) |> type == CornerTouching
   s = Segment(cart(2, 2), cart(2, 2))
   p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
   @test s ∩ p ≈ p ∩ s ≈ cart(2, 2)
-  @test intersection(s, p) |> type == Touching
-  @test intersection(p, s) |> type == Touching
+  @test intersection(s, p) |> type == CornerTouching
+  @test intersection(p, s) |> type == CornerTouching
   s = Segment(cart(5, 5), cart(5, 5))
   p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
   @test s ∩ p === p ∩ s === nothing

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -469,7 +469,7 @@ end
   @test intersection(p, s) |> type == Intersecting
   s = Segment(cart(-1, 0), cart(5, 0))
   p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
-  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 0), cart(4, 0))
+  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 0), cart(5, 0))
   @test intersection(s, p) |> type == EdgeTouching
   @test intersection(p, s) |> type == EdgeTouching
   s = Segment(cart(-1.0, 1.0), cart(1.0, -1.0))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -238,73 +238,32 @@ end
   @test intersection(s₁₀, s₃) |> type == NotIntersecting
   @test intersection(s₃, s₁₀) |> type == NotIntersecting
 
-  # segments and polygons in 2D
-  poly = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
-
-  # CASE 1: Intersecting, segment inside polygon
-  s = Segment(cart(1, 2), cart(3, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ s
-  @test intersection(s, poly) |> type == Intersecting
-  @test intersection(poly, s) |> type == Intersecting
-
-  # CASE 1: Intersecting, segment crosses polygon
-  s = Segment(cart(-1, 2), cart(5, 2))
-  expected = Segment(cart(0, 2), cart(4, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ expected
-  @test intersection(s, poly) |> type == Intersecting
-  @test intersection(poly, s) |> type == Intersecting
-
-  # CASE 1: concave polygon with disconnected intersection pieces
-  poly = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
-  s = Segment(cart(-1, 4), cart(7, 4))
-  expected = Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
-  @test s ∩ poly ≈ poly ∩ s ≈ expected
-  @test intersection(s, poly) |> type == Intersecting
-  @test intersection(poly, s) |> type == Intersecting
-
-  # CASE 2: EdgeTouching, segment lies on polygon boundary
-  s = Segment(cart(-1, 0), cart(5, 0))
-  expected = Segment(cart(0, 0), cart(4, 0))
-  @test s ∩ poly ≈ poly ∩ s ≈ expected
-  @test intersection(s, poly) |> type == EdgeTouching
-  @test intersection(poly, s) |> type == EdgeTouching
-
-  # CASE 3: CornerTouching polygon edge
-  poly = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
-  s = Segment(cart(-1.0, 1.0), cart(1.0, -1.0))
-  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 0)
-  @test intersection(s, poly) |> type == CornerTouching
-  @test intersection(poly, s) |> type == CornerTouching
-
-  # CASE 4: Touching polygon edge
-  s = Segment(cart(-1, 2), cart(0, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 2)
-  @test intersection(s, poly) |> type == Touching
-  @test intersection(poly, s) |> type == Touching
-
-  # CASE 4: Touching polygon corner
-  s = Segment(cart(-1, -1), cart(0, 0))
-  @test s ∩ poly ≈ poly ∩ s ≈ cart(0, 0)
-  @test intersection(s, poly) |> type == Touching
-  @test intersection(poly, s) |> type == Touching
-
-  # CASE 5: Degenerate segment inside polygon
-  s = Segment(cart(2, 2), cart(2, 2))
-  @test s ∩ poly ≈ poly ∩ s ≈ cart(2, 2)
-  @test intersection(s, poly) |> type == Touching
-  @test intersection(poly, s) |> type == Touching
-
-  # CASE 6: Degenerate segment outside polygon
-  s = Segment(cart(5, 5), cart(5, 5))
-  @test s ∩ poly === poly ∩ s === nothing
-  @test intersection(s, poly) |> type == NotIntersecting
-  @test intersection(poly, s) |> type == NotIntersecting
-
-  # CASE 6: Segment outside polygon
-  s = Segment(cart(-1, 5), cart(5, 5))
-  @test s ∩ poly === poly ∩ s === nothing
-  @test intersection(s, poly) |> type == NotIntersecting
-  @test intersection(poly, s) |> type == NotIntersecting
+  # degenerate segments
+  A = cart(0.0, 0.0)
+  B = cart(0.5, 0.0)
+  C = cart(1.0, 0.0)
+  s₀ = Segment(A, C)
+  s₁ = Segment(A, A)
+  s₂ = Segment(B, B)
+  s₃ = Segment(C, C)
+  @test s₀ ∩ s₁ ≈ s₁ ∩ s₀ ≈ A
+  @test s₀ ∩ s₂ ≈ s₂ ∩ s₀ ≈ B
+  @test s₀ ∩ s₃ ≈ s₃ ∩ s₀ ≈ C
+  @test intersection(s₀, s₁) |> type == CornerTouching
+  @test intersection(s₀, s₂) |> type == EdgeTouching
+  @test intersection(s₀, s₃) |> type == CornerTouching
+  @test s₁ ∩ s₂ === s₂ ∩ s₁ === nothing
+  @test s₁ ∩ s₃ === s₃ ∩ s₁ === nothing
+  @test s₂ ∩ s₃ === s₃ ∩ s₂ === nothing
+  @test intersection(s₁, s₂) |> type == NotIntersecting
+  @test intersection(s₁, s₃) |> type == NotIntersecting
+  @test intersection(s₂, s₃) |> type == NotIntersecting
+  @test s₁ ∩ s₁ ≈ A
+  @test s₂ ∩ s₂ ≈ B
+  @test s₃ ∩ s₃ ≈ C
+  @test intersection(s₁, s₁) |> type == CornerTouching
+  @test intersection(s₂, s₂) |> type == CornerTouching
+  @test intersection(s₃, s₃) |> type == CornerTouching
 
   # segments in 3D
   s1 = Segment(cart(0.0, 0.0, 0.0), cart(1.0, 0.0, 0.0))
@@ -492,32 +451,57 @@ end
   @test intersection(l₁, s₇) |> type == NotIntersecting # CASE 4
   @test l₁ ∩ s₇ === s₇ ∩ l₁ === nothing
 
-  # degenerate segments
-  A = cart(0.0, 0.0)
-  B = cart(0.5, 0.0)
-  C = cart(1.0, 0.0)
-  s₀ = Segment(A, C)
-  s₁ = Segment(A, A)
-  s₂ = Segment(B, B)
-  s₃ = Segment(C, C)
-  @test s₀ ∩ s₁ ≈ s₁ ∩ s₀ ≈ A
-  @test s₀ ∩ s₂ ≈ s₂ ∩ s₀ ≈ B
-  @test s₀ ∩ s₃ ≈ s₃ ∩ s₀ ≈ C
-  @test intersection(s₀, s₁) |> type == CornerTouching
-  @test intersection(s₀, s₂) |> type == EdgeTouching
-  @test intersection(s₀, s₃) |> type == CornerTouching
-  @test s₁ ∩ s₂ === s₂ ∩ s₁ === nothing
-  @test s₁ ∩ s₃ === s₃ ∩ s₁ === nothing
-  @test s₂ ∩ s₃ === s₃ ∩ s₂ === nothing
-  @test intersection(s₁, s₂) |> type == NotIntersecting
-  @test intersection(s₁, s₃) |> type == NotIntersecting
-  @test intersection(s₂, s₃) |> type == NotIntersecting
-  @test s₁ ∩ s₁ ≈ A
-  @test s₂ ∩ s₂ ≈ B
-  @test s₃ ∩ s₃ ≈ C
-  @test intersection(s₁, s₁) |> type == CornerTouching
-  @test intersection(s₂, s₂) |> type == CornerTouching
-  @test intersection(s₃, s₃) |> type == CornerTouching
+  # segments and polygons in 2D
+  s = Segment(cart(1, 2), cart(3, 2))
+  p = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
+  @test s ∩ p ≈ p ∩ s ≈ s
+  @test intersection(s, p) |> type == Intersecting
+  @test intersection(p, s) |> type == Intersecting
+  s = Segment(cart(-1, 2), cart(5, 2))
+  p = PolyArea([cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4)])
+  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 2), cart(4, 2))
+  @test intersection(s, p) |> type == Intersecting
+  @test intersection(p, s) |> type == Intersecting
+  s = Segment(cart(-1, 4), cart(7, 4))
+  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
+  @test s ∩ p ≈ p ∩ s ≈ Multi([Segment(cart(0, 4), cart(2, 4)), Segment(cart(4, 4), cart(6, 4))])
+  @test intersection(s, p) |> type == Intersecting
+  @test intersection(p, s) |> type == Intersecting
+  s = Segment(cart(-1, 0), cart(5, 0))
+  p = PolyArea([cart(0, 0), cart(6, 0), cart(6, 6), cart(4, 6), cart(4, 2), cart(2, 2), cart(2, 6), cart(0, 6)])
+  @test s ∩ p ≈ p ∩ s ≈ Segment(cart(0, 0), cart(4, 0))
+  @test intersection(s, p) |> type == EdgeTouching
+  @test intersection(p, s) |> type == EdgeTouching
+  s = Segment(cart(-1.0, 1.0), cart(1.0, -1.0))
+  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  @test s ∩ p ≈ p ∩ s ≈ cart(0, 0)
+  @test intersection(s, p) |> type == CornerTouching
+  @test intersection(p, s) |> type == CornerTouching
+  s = Segment(cart(-1, 2), cart(0, 2))
+  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  @test s ∩ p ≈ p ∩ s ≈ cart(0, 2)
+  @test intersection(s, p) |> type == Touching
+  @test intersection(p, s) |> type == Touching
+  s = Segment(cart(-1, -1), cart(0, 0))
+  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  @test s ∩ p ≈ p ∩ s ≈ cart(0, 0)
+  @test intersection(s, p) |> type == Touching
+  @test intersection(p, s) |> type == Touching
+  s = Segment(cart(2, 2), cart(2, 2))
+  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  @test s ∩ p ≈ p ∩ s ≈ cart(2, 2)
+  @test intersection(s, p) |> type == Touching
+  @test intersection(p, s) |> type == Touching
+  s = Segment(cart(5, 5), cart(5, 5))
+  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  @test s ∩ p === p ∩ s === nothing
+  @test intersection(s, p) |> type == NotIntersecting
+  @test intersection(p, s) |> type == NotIntersecting
+  s = Segment(cart(-1, 5), cart(5, 5))
+  p = PolyArea([cart(0.0, 0.0), cart(1.0, 0.0), cart(1.0, 1.0), cart(0.0, 1.0)])
+  @test s ∩ p === p ∩ s === nothing
+  @test intersection(s, p) |> type == NotIntersecting
+  @test intersection(p, s) |> type == NotIntersecting
 
   # utils
   @test Meshes._sort4vals(2.5, 1.4, 1.1, 2.0) == (1.4, 2.0)


### PR DESCRIPTION
I recently noticed that `intersection` does not implement a method for `Chain`–`Polygon` intersections. Currently, when no matching method is found, the function falls back to swapping the argument order. However, because there is also no `Polygon`–`Chain` method, it repeatedly swaps the arguments back and forth, resulting in a stack overflow. It follows a reproducible example:
```julia
using Meshes

rope = Rope([
    Point(0,0),
    Point(2,0)
])

poly = PolyArea([
    Point(1,-1),
    Point(3,-1),
    Point(3,1),
    Point(1,1)
])

intersection(rope, poly)
```

While working on a fix, I realized that the first step was to implement `Segment`–`Polygon` intersections, since `Chain`–`Polygon` intersections can naturally be built on top of them. This PR covers that first step.

I implemented this method by leveraging as much as I could on the previously implemented `Segment`-`Segment` intersection. This may not be the most efficient way to go about it, but it was the most immediate one to me right now.

**Result**: For my simple tests, the method is working just fine, but I have not stress tested it. When this PR gets completed, I hope to start working on the `Chain`-`Polygon` part. 