### PR TITLE
Generalize normal calculation and add normals option to viz

### DIFF
--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -35,3 +35,25 @@ grid = CartesianGrid(10, 10, 10)
 
 viz(grid, showsegments = true, segmentcolor = :teal)
 ```
+
+### Normals
+
+By default, Makie will compute per-vertex normals, resulting in a smoothed
+representation of e.g. a discretized sphere:
+
+```@example viz
+sphere = Sphere((0.,0.,0.), 1.)
+mesh = discretize(sphere, RegularDiscretization(10,10))
+viz(mesh)
+```
+
+If this smoothing is not desired, the `normals` keyword can be used to set the
+normals that will be used by Makie when rendering. If the number of normals
+equals the number of mesh elements then per-face normals are assumed, if it
+matches the number of vertices they are used as per-vertex normals.
+
+```@example viz
+sphere = Sphere((0.,0.,0.), 1.)
+mesh = discretize(sphere, RegularDiscretization(10,10))
+viz(mesh; normals=normal.(mesh))
+```

--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -44,6 +44,8 @@ Makie.@recipe Viz (object,) begin
   pointcolor = :gray30
   "size of points"
   pointsize = 4
+  "mesh normals, either per-face or per-vertex (decided based on length)"
+  normals = nothing
 end
 
 # choose between 2D and 3D axis

--- a/ext/mesh.jl
+++ b/ext/mesh.jl
@@ -52,83 +52,101 @@ end
 
 function vizmesh!(plot, ::Type, ::Val{2}, edim::Val)
   # compute triangle mesh and colors
-  Makie.map!(plot, [:object, :colorant], [:tmesh, :tcolors]) do mesh, colorant
+  Makie.map!(plot, [:object, :colorant], [:tmesh]) do mesh, colorant
     # relevant settings
     nvert = nvertices(mesh)
     nelem = nelements(mesh)
     verts = map(asmakie, eachvertex(mesh))
     elems = elements(topology(mesh))
 
-    # decide whether or not to reverse connectivity list
-    rev = crs(mesh) <: LatLon && orientation(first(mesh)) == CW ? reverse : identity
+    if colorant isa AbstractVector
+      facecolors = false
+      colors = Makie.RGBAf.(colorant) # GB.Mesh needs RGBA(f) type
+      ncolor = length(colorant)
+      if ncolor == nelem # element coloring
+        facecolors = true
+      elseif ncolor != nvert
+        throw(ArgumentError("provided $ncolor colors but the mesh has
+                             $nvert vertices and $nelem elements."))
+      end
+    else
+      facecolors = false
+      colors = fill(Makie.RGBAf(colorant), nvert)
+    end
+
+    normals_in = plot.normals[]
+    normals = nothing
+    nnormals = isnothing(normals_in) ? 0 : length(normals_in)
+    facenormals = nnormals == nelem
+    if nnormals != 0 && nnormals != nelem && nnormals != nvert
+        throw(ArgumentError("provided $nnormals normals but the mesh has
+                             $nvert vertices and $nelem elements."))
+    end
+
+    # decide whether or not to reverse connectivity list and normals
+    rev = identity
+    normalsign = 1.0
+    if crs(mesh) <: LatLon && orientation(first(mesh)) == CW
+      rev = reverse
+      normalsign = -1.0
+    end
 
     # fan triangulation (assume convexity)
     ntri = sum(e -> nvertices(pltype(e)) - 2, elems)
     tris = Vector{GB.TriangleFace{Int}}(undef, ntri)
     tind = 0
-    for elem in elems
+    # initialize normals data
+    if nnormals != 0
+      if facenormals
+        normals = Vector{Makie.Vec{3, Float32}}(undef, ntri)
+      else
+        # vertex normals can be copied
+        normals = map(asmakie, normals_in) .* normalsign
+      end
+    end
+    if facecolors
+      tcolors = Vector{typeof(first(colors))}(undef, ntri)
+    else # vertex coloring
+      # nothing needs to be done because
+      # this is the default in Makie and
+      # because the triangulation below
+      # does not change the vertices in
+      # the original polygonal mesh
+      tcolors = colors
+    end
+    for (eind, elem) in enumerate(elems)
       I = rev(indices(elem))
       for i in 2:(length(I) - 1)
         tind += 1
         tris[tind] = GB.TriangleFace(I[1], I[i], I[i + 1])
+        if facenormals
+          normals[tind] = normalsign * asmakie(normals_in[eind])
+        end
+        if facecolors
+          tcolors[tind] = colors[eind]
+        end
       end
+    end
+
+    if facenormals
+      normals = GB.FaceView(normals, GB.GLTriangleFace.(eachindex(normals)))
     end
 
     # element vs. vertex coloring
-    if colorant isa AbstractVector
-      ncolor = length(colorant)
-      if ncolor == nelem # element coloring
-        # duplicate vertices and adjust
-        # connectivities to avoid linear
-        # interpolation of colors
-        tind = 0
-        elem4tri = Dict{Int,Int}()
-        sizehint!(elem4tri, ntri)
-        for (eind, e) in enumerate(elems)
-          for _ in 1:(nvertices(pltype(e)) - 2)
-            tind += 1
-            elem4tri[tind] = eind
-          end
-        end
-        nv = 3ntri
-        tverts = [verts[i] for tri in tris for i in tri]
-        telems = [GB.TriangleFace(i, i + 1, i + 2) for i in range(start=1, step=3, length=ntri)]
-        tcolors = map(1:nv) do i
-          t = ceil(Int, i / 3)
-          e = elem4tri[t]
-          colorant[e]
-        end
-      elseif ncolor == nvert # vertex coloring
-        # nothing needs to be done because
-        # this is the default in Makie and
-        # because the triangulation above
-        # does not change the vertices in
-        # the original polygonal mesh
-        tverts = verts
-        telems = tris
-        tcolors = colorant
-      else
-        throw(ArgumentError("provided $ncolor colors but the mesh has
-                             $nvert vertices and $nelem elements."))
-      end
-    else # single color
-      # nothing needs to be done
-      tverts = verts
-      telems = tris
-      tcolors = colorant
+    if facecolors
+      tcolors = GB.FaceView(tcolors, GB.GLTriangleFace.(eachindex(tcolors)))
     end
 
     # triangle mesh
-    tmesh = GB.Mesh(tverts, telems)
-
-    tmesh, tcolors
+    tmesh = GB.mesh(verts, tris; color=tcolors, normal=normals)
+    return (tmesh,)
   end
 
   # enable shading in 3D
   shading = edim == Val(3)
 
   # visualize as triangle mesh
-  Makie.mesh!(plot, plot.tmesh, color=plot.tcolors, shading=shading)
+  Makie.mesh!(plot, plot.tmesh, shading=shading)
 
   if plot.showsegments[]
     vizfacets!(plot)

--- a/src/geometries/polytopes/ngon.jl
+++ b/src/geometries/polytopes/ngon.jl
@@ -65,6 +65,24 @@ angles(ngon::Ngon) = angles(boundary(ngon))
 
 innerangles(ngon::Ngon) = innerangles(boundary(ngon))
 
+# Normal calculation using Newell's algorithm
+# https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml
+function normal(ngon::Ngon{N}) where {N}
+  assertion(embeddim(ngon) == 3, "ngon must be 3-dimensional")
+  verts = ngon.vertices
+  nextverts = circshift(ngon.vertices, 1)
+  nx = ny = nz = 0.0 #zero(lentype(ngon))^2
+  for (p₁,p₂) in zip(verts,nextverts)
+    x₁, y₁, z₁ = ustrip.(to(p₁))
+    x₂, y₂, z₂ = ustrip.(to(p₂))
+    nx += (z₂+z₁) * (y₂-y₁)
+    ny += (x₂+x₁) * (z₂-z₁)
+    nz += (y₂+y₁) * (x₂-x₁)
+  end
+  lt = unit(lentype(ngon))
+  return unormalize(Vec(nx*lt, ny*lt, nz*lt))
+end
+
 # ----------
 # TRIANGLES
 # ----------

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -316,6 +316,13 @@ end
   @test_throws ArgumentError Ngon(cart(0, 0), cart(1, 1))
   @test_throws ArgumentError Ngon{2}(cart(0, 0), cart(1, 1))
 
+  q = Quadrangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
+  @test isapprox(normal(q), vector(1, 0, 0))
+  @test isapprox(norm(normal(q)), oneunit(ℳ))
+  q = Quadrangle(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
+  @test isapprox(normal(q), vector(0, -0.7071067811865475, 0.7071067811865475))
+  @test isapprox(norm(normal(q)), oneunit(ℳ))
+
   # ---------
   # TRIANGLE
   # ---------


### PR DESCRIPTION
Hi,

This is an attempt to address issue #535 in two steps:

1. Generalize `normal` for any `Ngon` using Newell's algorithm (end of https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml, see also https://wikis.khronos.org/opengl/Calculating_a_Surface_Normal#Newell's_Method)
2. Add an option to pass normals to `viz`, either per-face or per-vertex