### PR TITLE
Normal calculation for any Ngon

### DIFF
--- a/src/geometries/polytopes/ngon.jl
+++ b/src/geometries/polytopes/ngon.jl
@@ -65,6 +65,23 @@ angles(ngon::Ngon) = angles(boundary(ngon))
 
 innerangles(ngon::Ngon) = innerangles(boundary(ngon))
 
+# Normal calculation using Newell's algorithm
+# https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml
+function normal(ngon::Ngon)
+  assertion(embeddim(ngon) == 3, "ngon must be 3-dimensional")
+  v = CircularVector(ngon.vertices)
+  nx = ny = nz = 0.0
+  for i in eachindex(v)
+    x₁, y₁, z₁ = ustrip.(to(v[i + 1]))
+    x₂, y₂, z₂ = ustrip.(to(v[i]))
+    nx += (z₂ + z₁) * (y₂ - y₁)
+    ny += (x₂ + x₁) * (z₂ - z₁)
+    nz += (y₂ + y₁) * (x₂ - x₁)
+  end
+  lt = unit(lentype(ngon))
+  unormalize(Vec(nx*lt, ny*lt, nz*lt))
+end
+
 # ----------
 # TRIANGLES
 # ----------

--- a/src/geometries/polytopes/ngon.jl
+++ b/src/geometries/polytopes/ngon.jl
@@ -65,21 +65,7 @@ angles(ngon::Ngon) = angles(boundary(ngon))
 
 innerangles(ngon::Ngon) = innerangles(boundary(ngon))
 
-# normal of n-gon using Newell's algorithm
-# https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml
-function normal(ngon::Ngon)
-  assertion(embeddim(ngon) == 3, "ngon must be embedded in ℝ³")
-  v = CircularVector(ngon.vertices)
-  n = sum(eachindex(v)) do i
-    x₁, y₁, z₁ = ustrip.(to(v[i]))
-    x₂, y₂, z₂ = ustrip.(to(v[i + 1]))
-    nx = (z₁ + z₂) * (y₁ - y₂)
-    ny = (x₁ + x₂) * (z₁ - z₂)
-    nz = (y₁ + y₂) * (x₁ - x₂)
-    Vec(nx, ny, nz)
-  end
-  unormalize(n)
-end
+normal(ngon::Ngon) = newellnormal(vertices(ngon))
 
 # ----------
 # TRIANGLES

--- a/src/geometries/polytopes/ngon.jl
+++ b/src/geometries/polytopes/ngon.jl
@@ -65,21 +65,20 @@ angles(ngon::Ngon) = angles(boundary(ngon))
 
 innerangles(ngon::Ngon) = innerangles(boundary(ngon))
 
-# Normal calculation using Newell's algorithm
+# normal of n-gon using Newell's algorithm
 # https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml
 function normal(ngon::Ngon)
   assertion(embeddim(ngon) == 3, "ngon must be 3-dimensional")
   v = CircularVector(ngon.vertices)
-  nx = ny = nz = 0.0
-  for i in eachindex(v)
-    x₁, y₁, z₁ = ustrip.(to(v[i + 1]))
-    x₂, y₂, z₂ = ustrip.(to(v[i]))
-    nx += (z₂ + z₁) * (y₂ - y₁)
-    ny += (x₂ + x₁) * (z₂ - z₁)
-    nz += (y₂ + y₁) * (x₂ - x₁)
+  n = sum(eachindex(v)) do i
+    x₁, y₁, z₁ = ustrip.(to(v[i]))
+    x₂, y₂, z₂ = ustrip.(to(v[i + 1]))
+    nx = (z₁ + z₂) * (y₁ - y₂)
+    ny = (x₁ + x₂) * (z₁ - z₂)
+    nz = (y₁ + y₂) * (x₁ - x₂)
+    Vec(nx, ny, nz)
   end
-  lt = unit(lentype(ngon))
-  unormalize(Vec(nx*lt, ny*lt, nz*lt))
+  unormalize(n)
 end
 
 # ----------

--- a/src/geometries/polytopes/ngon.jl
+++ b/src/geometries/polytopes/ngon.jl
@@ -68,7 +68,7 @@ innerangles(ngon::Ngon) = innerangles(boundary(ngon))
 # normal of n-gon using Newell's algorithm
 # https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml
 function normal(ngon::Ngon)
-  assertion(embeddim(ngon) == 3, "ngon must be 3-dimensional")
+  assertion(embeddim(ngon) == 3, "ngon must be embedded in ℝ³")
   v = CircularVector(ngon.vertices)
   n = sum(eachindex(v)) do i
     x₁, y₁, z₁ = ustrip.(to(v[i]))
@@ -86,7 +86,7 @@ end
 # ----------
 
 function normal(t::Triangle)
-  assertion(embeddim(t) == 3, "triangle must be 3-dimensional")
+  assertion(embeddim(t) == 3, "triangle must be embedded in ℝ³")
   A, B, C = t.vertices
   unormalize(ucross((B - A), (C - A)))
 end

--- a/src/geometries/polytopes/polyarea.jl
+++ b/src/geometries/polytopes/polyarea.jl
@@ -54,6 +54,8 @@ nvertices(p::PolyArea) = mapreduce(nvertices, +, p.rings)
 
 rings(p::PolyArea) = p.rings
 
+normal(p::PolyArea) = newellnormal(vertices(first(p.rings)))
+
 function Base.unique!(p::PolyArea)
   foreach(unique!, p.rings)
   inds = findall(r -> nvertices(r) ≤ 2, p.rings)

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -55,3 +55,25 @@ function svdbasis(p::AbstractVector{<:Point})
   n = Vec(zero(ℒ), zero(ℒ), oneunit(ℒ))
   isnegative((u × v) ⋅ n) ? (v, u) : (u, v)
 end
+
+"""
+    newellnormal(points)
+
+Return the normal vector of a polygon defined
+by a list of 3D `points` using Newell's method.
+
+See <https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml>.
+"""
+function newellnormal(p::AbstractVector{<:Point})
+  assertion(embeddim(first(p)) == 3, "points must be embedded in ℝ³")
+  v = CircularVector(p)
+  n = sum(eachindex(v)) do i
+    x₁, y₁, z₁ = ustrip.(to(v[i]))
+    x₂, y₂, z₂ = ustrip.(to(v[i + 1]))
+    nx = (z₁ + z₂) * (y₁ - y₂)
+    ny = (x₁ + x₂) * (z₁ - z₂)
+    nz = (y₁ + y₂) * (x₁ - x₂)
+    Vec(nx, ny, nz)
+  end
+  unormalize(n)
+end

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -64,12 +64,12 @@ by a list of 3D `points` using Newell's method.
 
 See <https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml>.
 """
-function newellnormal(p::AbstractVector{<:Point})
+newellnormal(p::AbstractVector{<:Point}) = newellnormal(CircularVector(p))
+function newellnormal(p::CircularVector{<:Point})
   assertion(embeddim(first(p)) == 3, "points must be embedded in ℝ³")
-  v = CircularVector(p)
-  n = sum(eachindex(v)) do i
-    x₁, y₁, z₁ = ustrip.(to(v[i]))
-    x₂, y₂, z₂ = ustrip.(to(v[i + 1]))
+  n = sum(eachindex(p)) do i
+    x₁, y₁, z₁ = ustrip.(to(p[i]))
+    x₂, y₂, z₂ = ustrip.(to(p[i + 1]))
     nx = (z₁ + z₂) * (y₁ - y₂)
     ny = (x₁ + x₂) * (z₁ - z₂)
     nz = (y₁ + y₂) * (x₁ - x₂)

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -316,13 +316,6 @@ end
   @test_throws ArgumentError Ngon(cart(0, 0), cart(1, 1))
   @test_throws ArgumentError Ngon{2}(cart(0, 0), cart(1, 1))
 
-  q = Quadrangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
-  @test isapprox(normal(q), vector(1, 0, 0))
-  @test isapprox(norm(normal(q)), oneunit(ℳ))
-  q = Quadrangle(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
-  @test isapprox(normal(q), vector(0, -0.7071067811865475, 0.7071067811865475))
-  @test isapprox(norm(normal(q)), oneunit(ℳ))
-
   # ---------
   # TRIANGLE
   # ---------
@@ -504,6 +497,14 @@ end
   # centroid
   q = Quadrangle(latlon(0, 0), latlon(0, 45), latlon(45, 45), latlon(45, 0))
   @test centroid(q) == latlon(22.5, 22.5)
+
+  # normal
+  q = Quadrangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
+  @test isapprox(normal(q), vector(1, 0, 0))
+  @test isapprox(norm(normal(q)), oneunit(ℳ))
+  q = Quadrangle(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
+  @test isapprox(normal(q), vector(0, -0.7071067811865475, 0.7071067811865475))
+  @test isapprox(norm(normal(q)), oneunit(ℳ))
 
   q = Quadrangle(cart(0, 0), cart(1, 0), cart(1, 1), cart(0, 1))
   @test sprint(show, q) == "Quadrangle((x: 0.0 m, y: 0.0 m), ..., (x: 0.0 m, y: 1.0 m))"

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -413,7 +413,6 @@ end
   t = Triangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 0, 1))
   @test isapprox(normal(t), vector(1, 0, 0))
   @test isapprox(norm(normal(t)), oneunit(ℳ))
-  @test (@allocated normal(t)) == 0
   t = Triangle(cart(0, 0, 0), cart(2, 0, 0), cart(0, 2, 2))
   @test isapprox(normal(t), vector(0, -0.7071067811865475, 0.7071067811865475))
   @test isapprox(norm(normal(t)), oneunit(ℳ))
@@ -506,7 +505,6 @@ end
   q = Quadrangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
   @test isapprox(normal(q), vector(1, 0, 0))
   @test isapprox(norm(normal(q)), oneunit(ℳ))
-  @test (@allocated normal(q)) == 0
   q = Quadrangle(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
   @test isapprox(normal(q), vector(0, -0.7071067811865475, 0.7071067811865475))
   @test isapprox(norm(normal(q)), oneunit(ℳ))
@@ -656,7 +654,6 @@ end
   poly = PolyArea(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
   @test isapprox(normal(poly), vector(1, 0, 0))
   @test isapprox(norm(normal(poly)), oneunit(ℳ))
-  @test (@allocated normal(poly)) == 0
   poly = PolyArea(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
   @test isapprox(normal(poly), vector(0, -0.7071067811865475, 0.7071067811865475))
   @test isapprox(norm(normal(poly)), oneunit(ℳ))

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -413,6 +413,7 @@ end
   t = Triangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 0, 1))
   @test isapprox(normal(t), vector(1, 0, 0))
   @test isapprox(norm(normal(t)), oneunit(ℳ))
+  @test (@allocated normal(t)) == 0
   t = Triangle(cart(0, 0, 0), cart(2, 0, 0), cart(0, 2, 2))
   @test isapprox(normal(t), vector(0, -0.7071067811865475, 0.7071067811865475))
   @test isapprox(norm(normal(t)), oneunit(ℳ))
@@ -505,6 +506,7 @@ end
   q = Quadrangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
   @test isapprox(normal(q), vector(1, 0, 0))
   @test isapprox(norm(normal(q)), oneunit(ℳ))
+  @test (@allocated normal(q)) == 0
   q = Quadrangle(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
   @test isapprox(normal(q), vector(0, -0.7071067811865475, 0.7071067811865475))
   @test isapprox(norm(normal(q)), oneunit(ℳ))
@@ -654,6 +656,7 @@ end
   poly = PolyArea(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
   @test isapprox(normal(poly), vector(1, 0, 0))
   @test isapprox(norm(normal(poly)), oneunit(ℳ))
+  @test (@allocated normal(poly)) == 0
   poly = PolyArea(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
   @test isapprox(normal(poly), vector(0, -0.7071067811865475, 0.7071067811865475))
   @test isapprox(norm(normal(poly)), oneunit(ℳ))

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -392,11 +392,6 @@ end
   @test t(T(1.0), T(0.0)) == cart(0, 1, 0)
   @test t(T(0.0), T(1.0)) == cart(0, 0, 1)
   @test t(T(0.5), T(0.5)) == cart(0, 0.5, 0.5)
-  @test isapprox(normal(t), vector(1, 0, 0))
-  @test isapprox(norm(normal(t)), oneunit(ℳ))
-  t = Triangle(cart(0, 0, 0), cart(2, 0, 0), cart(0, 2, 2))
-  @test isapprox(normal(t), vector(0, -0.7071067811865475, 0.7071067811865475))
-  @test isapprox(norm(normal(t)), oneunit(ℳ))
 
   # CRS propagation
   t = Triangle(merc(0, 0), merc(1, 0), merc(0, 1))
@@ -413,6 +408,14 @@ end
   # centroid
   t = Triangle(latlon(0, 0), latlon(0, 45), latlon(45, 0))
   @test centroid(t) == latlon(15, 15)
+
+  # normal
+  t = Triangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 0, 1))
+  @test isapprox(normal(t), vector(1, 0, 0))
+  @test isapprox(norm(normal(t)), oneunit(ℳ))
+  t = Triangle(cart(0, 0, 0), cart(2, 0, 0), cart(0, 2, 2))
+  @test isapprox(normal(t), vector(0, -0.7071067811865475, 0.7071067811865475))
+  @test isapprox(norm(normal(t)), oneunit(ℳ))
 
   t = Triangle(cart(0, 0), cart(1, 0), cart(0, 1))
   @test sprint(show, t) == "Triangle((x: 0.0 m, y: 0.0 m), (x: 1.0 m, y: 0.0 m), (x: 0.0 m, y: 1.0 m))"
@@ -646,6 +649,14 @@ end
   # centroid
   poly = PolyArea(cart.([(0, 0), (1, 0), (1, 1), (0, 1)]))
   @test centroid(poly) ≈ cart(0.5, 0.5)
+
+  # normal
+  poly = PolyArea(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
+  @test isapprox(normal(poly), vector(1, 0, 0))
+  @test isapprox(norm(normal(poly)), oneunit(ℳ))
+  poly = PolyArea(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
+  @test isapprox(normal(poly), vector(0, -0.7071067811865475, 0.7071067811865475))
+  @test isapprox(norm(normal(poly)), oneunit(ℳ))
 
   # https://github.com/JuliaGeometry/Meshes.jl/issues/1385
   poly = PolyArea(

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -316,6 +316,13 @@ end
   @test_throws ArgumentError Ngon(cart(0, 0), cart(1, 1))
   @test_throws ArgumentError Ngon{2}(cart(0, 0), cart(1, 1))
 
+  q = Quadrangle(cart(0, 0, 0), cart(0, 1, 0), cart(0, 1, 1), cart(0, 0, 1))
+  @test isapprox(normal(q), vector(1, 0, 0))
+  @test isapprox(norm(normal(q)), oneunit(ℳ))
+  q = Quadrangle(cart(0, 0, 0), cart(2, 0, 0), cart(2, 2, 2), cart(0, 2, 2))
+  @test isapprox(normal(q), vector(0, -0.7071067811865475, 0.7071067811865475))
+  @test isapprox(norm(normal(q)), oneunit(ℳ))
+
   # ---------
   # TRIANGLE
   # ---------


### PR DESCRIPTION
Generalize `normal` for any Ngon using Newell's algorithm (end of https://people.eecs.berkeley.edu/~ug/slide/pipeline/assignments/backfacecull.shtml, see also https://wikis.khronos.org/opengl/Calculating_a_Surface_Normal#Newell's_Method)

This is the first step to address issue https://github.com/JuliaGeometry/Meshes.jl/issues/535, replacing PR #1403 