### PR TITLE
Add intersection for Box{🌐}

### DIFF
--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -35,10 +35,9 @@ function intersection(f, box₁::Box, box₂::Box)
 end
 
 function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
-  # corners in a common LatLon CRS
-  C = manifoldcrs(box₁)
-  cs = (convert(C, coords(p)) for p in (extrema(box₁)..., extrema(box₂)...))
-  m₁, M₁, m₂, M₂ = promote(cs...)
+  # corners in a common CRS
+  m₁, M₁ = coords.(extrema(box₁))
+  m₂, M₂ = coords.(extrema(box₂ |> Proj(crs(box₁))))
 
   # intersect coordinate ranges
   latₛ, latₑ = max(m₁.lat, m₂.lat), min(M₁.lat, M₂.lat)

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -36,8 +36,9 @@ end
 
 function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   # corners in a common CRS
-  m₁, M₁ = coords.(extrema(box₁))
-  m₂, M₂ = coords.(extrema(box₂ |> Proj(crs(box₁))))
+  crs = manifoldcrs(box₁)
+  m₁, M₁ = coords.(extrema(box₁ |> Proj(crs)))
+  m₂, M₂ = coords.(extrema(box₂ |> Proj(crs)))
 
   # intersect coordinate ranges
   latₛ, latₑ = max(m₁.lat, m₂.lat), min(M₁.lat, M₂.lat)

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -53,15 +53,15 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   isempty(lonranges) && return @IT NotIntersecting nothing f
 
   # classify intersection
-  latpoint = isapproxzero(latₑ - latₛ)
-  lonpoints = all(r -> isapproxzero(last(r) - first(r)), lonranges)
-  corner = latpoint && lonpoints
-  overlap = !latpoint && !lonpoints
+  singlelat = isapproxequal(latₛ, latₑ)
+  singlelon = all(lon -> isapproxequal(lon[1], lon[2]), lonranges)
+  iscorner = singlelat && singlelon
+  overlaps = !singlelat && !singlelon
 
   # construct geometry
   geoms = map(lonranges) do (lonₛ, lonₑ)
     u = withcrs(box₁, (latₛ, lonₛ))
-    if corner
+    if iscorner
       u
     else
       v = withcrs(box₁, (latₑ, lonₑ))
@@ -70,9 +70,9 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   end
   geom = length(geoms) == 1 ? only(geoms) : Multi(geoms)
 
-  if overlap
+  if overlaps
     return @IT Overlapping geom f
-  elseif corner
+  elseif iscorner
     return @IT CornerTouching geom f
   else
     return @IT Touching geom f

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -49,17 +49,17 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   latₛ > latₑ && return @IT NotIntersecting nothing f
 
   # check longitude coordinate
-  lons = _lonintersects(min₁.lon, max₁.lon, min₂.lon, max₂.lon)
-  isempty(lons) && return @IT NotIntersecting nothing f
+  lonranges = _lonintersects(min₁.lon, max₁.lon, min₂.lon, max₂.lon)
+  isempty(lonranges) && return @IT NotIntersecting nothing f
 
-  # classify
+  # classify intersection
   latpoint = isapproxzero(latₑ - latₛ)
-  lonpoints = all(r -> isapproxzero(last(r) - first(r)), lons)
+  lonpoints = all(r -> isapproxzero(last(r) - first(r)), lonranges)
   corner = latpoint && lonpoints
   overlap = !latpoint && !lonpoints
 
   # construct geometry
-  geoms = map(lons) do (lonₛ, lonₑ)
+  geoms = map(lonranges) do (lonₛ, lonₑ)
     u = withcrs(box₁, (latₛ, lonₛ))
     if corner
       u
@@ -79,17 +79,17 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   end
 end
 
-function _lonintersects(lo₁, hi₁, lo₂, hi₂)
-  ranges₁ = _lonranges(lo₁, hi₁)
-  ranges₂ = _lonranges(lo₂, hi₂)
-  ranges = Tuple{typeof(lo₁),typeof(lo₁)}[]
+function _lonintersects(minlon₁::T, maxlon₁::T, minlon₂::T, maxlon₂::T) where {T}
+  ranges₁ = _lonranges(minlon₁, maxlon₁)
+  ranges₂ = _lonranges(minlon₂, maxlon₂)
+  ranges = Tuple{T,T}[]
   for (a, b) in ranges₁, (c, d) in ranges₂
     lo, hi = max(a, c), min(b, d)
     lo ≤ hi && push!(ranges, (lo, hi))
   end
 
   # -180° and 180° represent the same meridian
-  Δ = oftype(lo₁, 180u"°")
+  Δ = oftype(minlon₁, 180u"°")
   if _containsantimeridian(ranges₁, Δ) && _containsantimeridian(ranges₂, Δ) && !_containsantimeridian(ranges, Δ)
     push!(ranges, (Δ, Δ))
   end

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -33,3 +33,77 @@ function intersection(f, box₁::Box, box₂::Box)
     return @IT NotIntersecting nothing f
   end
 end
+
+function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
+  # corners in a common LatLon CRS
+  C = manifoldcrs(box₁)
+  cs = (convert(C, coords(p)) for p in (extrema(box₁)..., extrema(box₂)...))
+  m₁, M₁, m₂, M₂ = promote(cs...)
+
+  # intersect coordinate ranges
+  latₛ, latₑ = max(m₁.lat, m₂.lat), min(M₁.lat, M₂.lat)
+  latₛ > latₑ && return @IT NotIntersecting nothing f
+
+  lons = _lonintersections(m₁.lon, M₁.lon, m₂.lon, M₂.lon)
+  isempty(lons) && return @IT NotIntersecting nothing f
+
+  # classify
+  latpoint = isapproxzero(latₑ - latₛ)
+  lonpoints = all(r -> isapproxzero(last(r) - first(r)), lons)
+  corner = latpoint && lonpoints
+  overlap = !latpoint && !lonpoints
+
+  # construct geometry
+  geoms = map(lons) do (lonₛ, lonₑ)
+    u = withcrs(box₁, (latₛ, lonₛ))
+    if corner
+      u
+    else
+      v = withcrs(box₁, (latₑ, lonₑ))
+      Box(u, v)
+    end
+  end
+  geom = length(geoms) == 1 ? only(geoms) : Multi(geoms)
+
+  if overlap
+    return @IT Overlapping geom f
+  elseif corner
+    return @IT CornerTouching geom f
+  else
+    return @IT Touching geom f
+  end
+end
+
+# longitude intervals in the canonical [-180°, 180°] range
+function _lonintervals(lo, hi)
+  Δ = oftype(lo, 180u"°")
+  lo ≤ hi ? [(lo, hi)] : [(-Δ, hi), (lo, Δ)]
+end
+
+function _lonintersections(lo₁, hi₁, lo₂, hi₂)
+  intervals₁ = _lonintervals(lo₁, hi₁)
+  intervals₂ = _lonintervals(lo₂, hi₂)
+  ranges = Tuple{typeof(lo₁),typeof(lo₁)}[]
+  for (a, b) in intervals₁, (c, d) in intervals₂
+    lo, hi = max(a, c), min(b, d)
+    lo ≤ hi && push!(ranges, (lo, hi))
+  end
+
+  # -180° and 180° represent the same meridian
+  Δ = oftype(lo₁, 180u"°")
+  if _containsantimeridian(intervals₁, Δ) && _containsantimeridian(intervals₂, Δ) &&
+     !_containsantimeridian(ranges, Δ)
+    push!(ranges, (Δ, Δ))
+  end
+
+  # pieces meeting at the antimeridian form a single wrapped interval
+  if length(ranges) == 2
+    if first(ranges)[1] == -Δ && last(ranges)[2] == Δ
+      lo, hi = last(ranges)[1], first(ranges)[2]
+      return lo == Δ && hi == -Δ ? [(Δ, Δ)] : [(lo, hi)]
+    end
+  end
+  ranges
+end
+
+_containsantimeridian(ranges, Δ) = any(r -> first(r) == -Δ || last(r) == Δ, ranges)

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -64,7 +64,7 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
     v = withcrs(box₁, (latₑ, lonₑ))
     iscorner ? u : Box(u, v)
   end
-  geom = length(geoms) == 1 ? only(geoms) : Multi(geoms)
+  geom = maybemulti(geoms)
 
   if overlaps
     return @IT Overlapping geom f

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -9,12 +9,12 @@
 # 4. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, box₁::Box, box₂::Box)
   # retrieve corner points
-  m1, M1 = to.(extrema(box₁))
-  m2, M2 = to.(extrema(box₂))
+  m₁, M₁ = to.(extrema(box₁))
+  m₂, M₂ = to.(extrema(box₂))
 
   # relevant vertices
-  u = withcrs(box₁, max.(promote(m1, m2)...))
-  v = withcrs(box₁, min.(promote(M1, M2)...))
+  u = withcrs(box₁, max.(promote(m₁, m₂)...))
+  v = withcrs(box₁, min.(promote(M₁, M₂)...))
 
   # auxiliary variables
   δ = v - u
@@ -44,11 +44,12 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   m₁, M₁ = coords.(extrema(box₁ |> Proj(crs)))
   m₂, M₂ = coords.(extrema(box₂ |> Proj(crs)))
 
-  # intersect coordinate ranges
+  # check latitude coordinate
   latₛ, latₑ = max(m₁.lat, m₂.lat), min(M₁.lat, M₂.lat)
   latₛ > latₑ && return @IT NotIntersecting nothing f
 
-  lons = _lonintersections(m₁.lon, M₁.lon, m₂.lon, M₂.lon)
+  # check longitude coordinate
+  lons = _lonintersects(m₁.lon, M₁.lon, m₂.lon, M₂.lon)
   isempty(lons) && return @IT NotIntersecting nothing f
 
   # classify
@@ -78,13 +79,7 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   end
 end
 
-# longitude intervals in the canonical [-180°, 180°] range
-function _lonintervals(lo, hi)
-  Δ = oftype(lo, 180u"°")
-  lo ≤ hi ? [(lo, hi)] : [(-Δ, hi), (lo, Δ)]
-end
-
-function _lonintersections(lo₁, hi₁, lo₂, hi₂)
+function _lonintersects(lo₁, hi₁, lo₂, hi₂)
   intervals₁ = _lonintervals(lo₁, hi₁)
   intervals₂ = _lonintervals(lo₂, hi₂)
   ranges = Tuple{typeof(lo₁),typeof(lo₁)}[]
@@ -105,6 +100,12 @@ function _lonintersections(lo₁, hi₁, lo₂, hi₂)
     return lo == Δ && hi == -Δ ? [(Δ, Δ)] : [(lo, hi)]
   end
   ranges
+end
+
+# longitude intervals in the canonical [-180°, 180°] range
+function _lonintervals(lo, hi)
+  Δ = oftype(lo, 180u"°")
+  lo ≤ hi ? [(lo, hi)] : [(-Δ, hi), (lo, Δ)]
 end
 
 _containsantimeridian(ranges, Δ) = any(r -> first(r) == -Δ || last(r) == Δ, ranges)

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -3,7 +3,6 @@
 # ------------------------------------------------------------------
 
 # The intersection type can be one of four types:
-#
 # 1. overlap with non-zero measure (Overlapping -> Box)
 # 2. intersect at corner point (CornerTouching -> Point)
 # 3. intersect at one of the facets (Touching -> Box)
@@ -34,6 +33,11 @@ function intersection(f, box₁::Box, box₂::Box)
   end
 end
 
+# The intersection type can be one of four types:
+# 1. overlap with non-zero measure (Overlapping -> Box)
+# 2. intersect at corner point (CornerTouching -> Point)
+# 3. intersect at one of the facets (Touching -> Box)
+# 4. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   # corners in a common CRS
   crs = manifoldcrs(box₁)

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -61,12 +61,8 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   # construct geometry
   geoms = map(lonranges) do (lonₛ, lonₑ)
     u = withcrs(box₁, (latₛ, lonₛ))
-    if iscorner
-      u
-    else
-      v = withcrs(box₁, (latₑ, lonₑ))
-      Box(u, v)
-    end
+    v = withcrs(box₁, (latₑ, lonₑ))
+    iscorner ? u : Box(u, v)
   end
   geom = length(geoms) == 1 ? only(geoms) : Multi(geoms)
 

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 # The intersection type can be one of four types:
-# 
+#
 # 1. overlap with non-zero measure (Overlapping -> Box)
 # 2. intersect at corner point (CornerTouching -> Point)
 # 3. intersect at one of the facets (Touching -> Box)
@@ -91,17 +91,14 @@ function _lonintersections(lo₁, hi₁, lo₂, hi₂)
 
   # -180° and 180° represent the same meridian
   Δ = oftype(lo₁, 180u"°")
-  if _containsantimeridian(intervals₁, Δ) && _containsantimeridian(intervals₂, Δ) &&
-     !_containsantimeridian(ranges, Δ)
+  if _containsantimeridian(intervals₁, Δ) && _containsantimeridian(intervals₂, Δ) && !_containsantimeridian(ranges, Δ)
     push!(ranges, (Δ, Δ))
   end
 
   # pieces meeting at the antimeridian form a single wrapped interval
-  if length(ranges) == 2
-    if first(ranges)[1] == -Δ && last(ranges)[2] == Δ
-      lo, hi = last(ranges)[1], first(ranges)[2]
-      return lo == Δ && hi == -Δ ? [(Δ, Δ)] : [(lo, hi)]
-    end
+  if length(ranges) ≥ 2 && first(ranges)[1] == -Δ && last(ranges)[2] == Δ
+    lo, hi = last(ranges)[1], first(ranges)[2]
+    return lo == Δ && hi == -Δ ? [(Δ, Δ)] : [(lo, hi)]
   end
   ranges
 end

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -76,32 +76,32 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
 end
 
 function _lonintersects(minlon₁::T, maxlon₁::T, minlon₂::T, maxlon₂::T) where {T}
-  ranges₁ = _lonranges(minlon₁, maxlon₁)
-  ranges₂ = _lonranges(minlon₂, maxlon₂)
-  ranges = Tuple{T,T}[]
-  for (a, b) in ranges₁, (c, d) in ranges₂
-    lo, hi = max(a, c), min(b, d)
-    lo ≤ hi && push!(ranges, (lo, hi))
-  end
-
   # -180° and 180° represent the same meridian
-  Δ = oftype(minlon₁, 180u"°")
-  if _containsantimeridian(ranges₁, Δ) && _containsantimeridian(ranges₂, Δ) && !_containsantimeridian(ranges, Δ)
-    push!(ranges, (Δ, Δ))
+  πdeg = oftype(T, 180u"°")
+
+  # convert range to one or two non-decreasing ranges,
+  # depending on whether it crosses the antimeridian
+  ranges₁ = minlon₁ ≤ maxlon₁ ? ((minlon₁, maxlon₁),) : ((-πdeg, maxlon₁), (minlon₁, πdeg))
+  ranges₂ = minlon₂ ≤ maxlon₂ ? ((minlon₂, maxlon₂),) : ((-πdeg, maxlon₂), (minlon₂, πdeg))
+
+  # compute the intersection of the two sets of ranges
+  ranges = Tuple{T,T}[]
+  for (a₁, b₁) in ranges₁, (a₂, b₂) in ranges₂
+    a, b = max(a₁, a₂), min(b₁, b₂)
+    a ≤ b && push!(ranges, (a, b))
   end
 
-  # pieces meeting at the antimeridian form a single wrapped interval
-  if length(ranges) ≥ 2 && first(ranges)[1] == -Δ && last(ranges)[2] == Δ
-    lo, hi = last(ranges)[1], first(ranges)[2]
-    return lo == Δ && hi == -Δ ? [(Δ, Δ)] : [(lo, hi)]
+  # check if the intersection contains the antimeridian
+  _hasπdeg(ranges) = any(lon -> lon[1] == -πdeg || lon[2] == πdeg, ranges)
+  if _hasπdeg(ranges₁) && _hasπdeg(ranges₂) && !_hasπdeg(ranges)
+    push!(ranges, (πdeg, πdeg))
   end
+
+  # ranges meeting at the antimeridian form a single wrapped interval
+  if length(ranges) ≥ 2 && first(ranges)[1] == -πdeg && last(ranges)[2] == πdeg
+    a, b = last(ranges)[1], first(ranges)[2]
+    return a == πdeg && b == -πdeg ? [(πdeg, πdeg)] : [(a, b)]
+  end
+
   ranges
 end
-
-# longitude intervals in the canonical [-180°, 180°] range
-function _lonranges(lo, hi)
-  Δ = oftype(lo, 180u"°")
-  lo ≤ hi ? ((lo, hi),) : ((-Δ, hi), (lo, Δ))
-end
-
-_containsantimeridian(ranges, Δ) = any(r -> first(r) == -Δ || last(r) == Δ, ranges)

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -77,7 +77,7 @@ end
 
 function _lonintersects(minlon₁::T, maxlon₁::T, minlon₂::T, maxlon₂::T) where {T}
   # -180° and 180° represent the same meridian
-  πdeg = oftype(T, 180u"°")
+  πdeg = T(180u"°")
 
   # convert range to one or two non-decreasing ranges,
   # depending on whether it crosses the antimeridian

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -9,12 +9,12 @@
 # 4. do not overlap nor intersect (NotIntersecting -> Nothing)
 function intersection(f, box₁::Box, box₂::Box)
   # retrieve corner points
-  m₁, M₁ = to.(extrema(box₁))
-  m₂, M₂ = to.(extrema(box₂))
+  min₁, max₁ = to.(extrema(box₁))
+  min₂, max₂ = to.(extrema(box₂))
 
   # relevant vertices
-  u = withcrs(box₁, max.(promote(m₁, m₂)...))
-  v = withcrs(box₁, min.(promote(M₁, M₂)...))
+  u = withcrs(box₁, max.(promote(min₁, min₂)...))
+  v = withcrs(box₁, min.(promote(max₁, max₂)...))
 
   # auxiliary variables
   δ = v - u
@@ -41,15 +41,15 @@ end
 function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
   # corners in a common CRS
   crs = manifoldcrs(box₁)
-  m₁, M₁ = coords.(extrema(box₁ |> Proj(crs)))
-  m₂, M₂ = coords.(extrema(box₂ |> Proj(crs)))
+  min₁, max₁ = coords.(extrema(box₁ |> Proj(crs)))
+  min₂, max₂ = coords.(extrema(box₂ |> Proj(crs)))
 
   # check latitude coordinate
-  latₛ, latₑ = max(m₁.lat, m₂.lat), min(M₁.lat, M₂.lat)
+  latₛ, latₑ = max(min₁.lat, min₂.lat), min(max₁.lat, max₂.lat)
   latₛ > latₑ && return @IT NotIntersecting nothing f
 
   # check longitude coordinate
-  lons = _lonintersects(m₁.lon, M₁.lon, m₂.lon, M₂.lon)
+  lons = _lonintersects(min₁.lon, max₁.lon, min₂.lon, max₂.lon)
   isempty(lons) && return @IT NotIntersecting nothing f
 
   # classify

--- a/src/intersections/boxes.jl
+++ b/src/intersections/boxes.jl
@@ -80,17 +80,17 @@ function intersection(f, box₁::Box{🌐}, box₂::Box{🌐})
 end
 
 function _lonintersects(lo₁, hi₁, lo₂, hi₂)
-  intervals₁ = _lonintervals(lo₁, hi₁)
-  intervals₂ = _lonintervals(lo₂, hi₂)
+  ranges₁ = _lonranges(lo₁, hi₁)
+  ranges₂ = _lonranges(lo₂, hi₂)
   ranges = Tuple{typeof(lo₁),typeof(lo₁)}[]
-  for (a, b) in intervals₁, (c, d) in intervals₂
+  for (a, b) in ranges₁, (c, d) in ranges₂
     lo, hi = max(a, c), min(b, d)
     lo ≤ hi && push!(ranges, (lo, hi))
   end
 
   # -180° and 180° represent the same meridian
   Δ = oftype(lo₁, 180u"°")
-  if _containsantimeridian(intervals₁, Δ) && _containsantimeridian(intervals₂, Δ) && !_containsantimeridian(ranges, Δ)
+  if _containsantimeridian(ranges₁, Δ) && _containsantimeridian(ranges₂, Δ) && !_containsantimeridian(ranges, Δ)
     push!(ranges, (Δ, Δ))
   end
 
@@ -103,9 +103,9 @@ function _lonintersects(lo₁, hi₁, lo₂, hi₂)
 end
 
 # longitude intervals in the canonical [-180°, 180°] range
-function _lonintervals(lo, hi)
+function _lonranges(lo, hi)
   Δ = oftype(lo, 180u"°")
-  lo ≤ hi ? [(lo, hi)] : [(-Δ, hi), (lo, Δ)]
+  lo ≤ hi ? ((lo, hi),) : ((-Δ, hi), (lo, Δ))
 end
 
 _containsantimeridian(ranges, Δ) = any(r -> first(r) == -Δ || last(r) == Δ, ranges)

--- a/src/predicates/in.jl
+++ b/src/predicates/in.jl
@@ -44,9 +44,7 @@ function Base.in(p::Point{🌐}, b::Box{🌐})
   latlonₗ.lat ≤ latlonₚ.lat ≤ latlonᵣ.lat && inlonrange(latlonₗ.lon, latlonₚ.lon, latlonᵣ.lon)
 end
 
-function inlonrange(lonₗ, lonₚ, lonᵣ)
-  lonₗ ≤ lonᵣ ? lonₗ ≤ lonₚ ≤ lonᵣ : lonₗ ≤ lonₚ || lonₚ ≤ lonᵣ
-end
+inlonrange(lonₗ, lonₚ, lonᵣ) = lonₗ ≤ lonᵣ ? lonₗ ≤ lonₚ ≤ lonᵣ : lonₗ ≤ lonₚ || lonₚ ≤ lonᵣ
 
 function Base.in(p::Point, b::Ball)
   c = center(b)

--- a/src/predicates/in.jl
+++ b/src/predicates/in.jl
@@ -45,11 +45,7 @@ function Base.in(p::Point{🌐}, b::Box{🌐})
 end
 
 function inlonrange(lonₗ, lonₚ, lonᵣ)
-  if isnegative(lonₗ) && isnonnegative(lonᵣ)
-    lonₚ ≤ lonₗ || (isnonnegative(lonₚ) && lonₚ ≤ lonᵣ)
-  else
-    lonₗ ≤ lonₚ ≤ lonᵣ
-  end
+  lonₗ ≤ lonᵣ ? lonₗ ≤ lonₚ ≤ lonᵣ : lonₗ ≤ lonₚ || lonₚ ≤ lonᵣ
 end
 
 function Base.in(p::Point, b::Ball)

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1078,6 +1078,7 @@ end
 
   b1 = Box(latlon(-10, -150), latlon(10, 150))
   b2 = Box(latlon(-5, 30), latlon(5, -30))
+  @test intersection(b1, b2) |> type == Overlapping
   @test b1 ∩ b2 == b2 ∩ b1 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
 
   # Ray-Box intersection

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1035,6 +1035,46 @@ end
   b2 = Box(merc(0.5, 0.5), merc(2, 2))
   @test crs(b1 ∩ b2) === crs(b1)
 
+  # LatLon boxes
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
+  b2 = Box(latlon(-5, 175), latlon(5, -175))
+  @test intersection(b1, b2) |> type == Overlapping
+  @test b1 ∩ b2 == Box(latlon(-5, 175), latlon(5, -175))
+  @test b2 ∩ b1 == b1 ∩ b2
+
+  b2 = Box(latlon(-5, 160), latlon(5, 175))
+  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 175))
+  b2 = Box(latlon(-5, -175), latlon(5, -160))
+  @test b1 ∩ b2 == Box(latlon(-5, -175), latlon(5, -170))
+
+  b2 = Box(latlon(-5, -160), latlon(5, 160))
+  @test intersection(b1, b2) |> type == NotIntersecting
+  @test isnothing(b1 ∩ b2)
+
+  b2 = Box(latlon(-5, 160), latlon(5, 170))
+  @test intersection(b1, b2) |> type == Touching
+  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 170))
+
+  b2 = Box(latlon(10, 160), latlon(20, 170))
+  @test intersection(b1, b2) |> type == CornerTouching
+  @test b1 ∩ b2 == latlon(10, 170)
+
+  b1 = Box(latlon(-10, 170), latlon(10, 180))
+  b2 = Box(latlon(-5, -180), latlon(5, -170))
+  @test intersection(b1, b2) |> type == Touching
+  @test b1 ∩ b2 == Box(latlon(-5, 180), latlon(5, 180))
+
+  b1 = Box(latlon(-10, 180), latlon(10, -180))
+  b2 = Box(latlon(10, 180), latlon(20, -180))
+  @test intersection(b1, b2) |> type == CornerTouching
+  @test b1 ∩ b2 == latlon(10, 180)
+
+  b1 = Box(latlon(-10, -150), latlon(10, 150))
+  b2 = Box(latlon(-5, 30), latlon(5, -30))
+  @test b1 ∩ b2 == Multi([
+    Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))
+  ])
+
   # Ray-Box intersection
   b = Box(cart(0, 0, 0), cart(1, 1, 1))
 

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1071,9 +1071,7 @@ end
 
   b1 = Box(latlon(-10, -150), latlon(10, 150))
   b2 = Box(latlon(-5, 30), latlon(5, -30))
-  @test b1 ∩ b2 == Multi([
-    Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))
-  ])
+  @test b1 ∩ b2 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
 
   # Ray-Box intersection
   b = Box(cart(0, 0, 0), cart(1, 1, 1))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1039,39 +1039,46 @@ end
   b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, 175), latlon(5, -175))
   @test intersection(b1, b2) |> type == Overlapping
-  @test b1 ∩ b2 == Box(latlon(-5, 175), latlon(5, -175))
-  @test b2 ∩ b1 == b1 ∩ b2
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 175), latlon(5, -175))
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, 160), latlon(5, 175))
-  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 175))
-  b2 = Box(latlon(-5, -175), latlon(5, -160))
-  @test b1 ∩ b2 == Box(latlon(-5, -175), latlon(5, -170))
+  @test intersection(b1, b2) |> type == Overlapping
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 170), latlon(5, 175))
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
+  b2 = Box(latlon(-5, -175), latlon(5, -160))
+  @test intersection(b1, b2) |> type == Overlapping
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, -175), latlon(5, -170))
+
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, -160), latlon(5, 160))
   @test intersection(b1, b2) |> type == NotIntersecting
-  @test isnothing(b1 ∩ b2)
+  @test b1 ∩ b2 === b2 ∩ b1 === nothing
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, 160), latlon(5, 170))
   @test intersection(b1, b2) |> type == Touching
-  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 170))
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 170), latlon(5, 170))
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(10, 160), latlon(20, 170))
   @test intersection(b1, b2) |> type == CornerTouching
-  @test b1 ∩ b2 == latlon(10, 170)
+  @test b1 ∩ b2 == b2 ∩ b1 == latlon(10, 170)
 
   b1 = Box(latlon(-10, 170), latlon(10, 180))
   b2 = Box(latlon(-5, -180), latlon(5, -170))
   @test intersection(b1, b2) |> type == Touching
-  @test b1 ∩ b2 == Box(latlon(-5, 180), latlon(5, 180))
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 180), latlon(5, 180))
 
   b1 = Box(latlon(-10, 180), latlon(10, -180))
   b2 = Box(latlon(10, 180), latlon(20, -180))
   @test intersection(b1, b2) |> type == CornerTouching
-  @test b1 ∩ b2 == latlon(10, 180)
+  @test b1 ∩ b2 == b2 ∩ b1 == latlon(10, 180)
 
   b1 = Box(latlon(-10, -150), latlon(10, 150))
   b2 = Box(latlon(-5, 30), latlon(5, -30))
-  @test b1 ∩ b2 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
+  @test b1 ∩ b2 == b2 ∩ b1 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
 
   # Ray-Box intersection
   b = Box(cart(0, 0, 0), cart(1, 1, 1))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -882,9 +882,7 @@ end
 
   b1 = Box(latlon(-10, -150), latlon(10, 150))
   b2 = Box(latlon(-5, 30), latlon(5, -30))
-  @test b1 ∩ b2 == Multi([
-    Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))
-  ])
+  @test b1 ∩ b2 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
 
   # Ray-Box intersection
   b = Box(cart(0, 0, 0), cart(1, 1, 1))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -889,6 +889,7 @@ end
 
   b1 = Box(latlon(-10, -150), latlon(10, 150))
   b2 = Box(latlon(-5, 30), latlon(5, -30))
+  @test intersection(b1, b2) |> type == Overlapping
   @test b1 ∩ b2 == b2 ∩ b1 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
 
   # Ray-Box intersection

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -850,39 +850,46 @@ end
   b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, 175), latlon(5, -175))
   @test intersection(b1, b2) |> type == Overlapping
-  @test b1 ∩ b2 == Box(latlon(-5, 175), latlon(5, -175))
-  @test b2 ∩ b1 == b1 ∩ b2
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 175), latlon(5, -175))
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, 160), latlon(5, 175))
-  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 175))
-  b2 = Box(latlon(-5, -175), latlon(5, -160))
-  @test b1 ∩ b2 == Box(latlon(-5, -175), latlon(5, -170))
+  @test intersection(b1, b2) |> type == Overlapping
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 170), latlon(5, 175))
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
+  b2 = Box(latlon(-5, -175), latlon(5, -160))
+  @test intersection(b1, b2) |> type == Overlapping
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, -175), latlon(5, -170))
+
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, -160), latlon(5, 160))
   @test intersection(b1, b2) |> type == NotIntersecting
-  @test isnothing(b1 ∩ b2)
+  @test b1 ∩ b2 === b2 ∩ b1 === nothing
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(-5, 160), latlon(5, 170))
   @test intersection(b1, b2) |> type == Touching
-  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 170))
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 170), latlon(5, 170))
 
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
   b2 = Box(latlon(10, 160), latlon(20, 170))
   @test intersection(b1, b2) |> type == CornerTouching
-  @test b1 ∩ b2 == latlon(10, 170)
+  @test b1 ∩ b2 == b2 ∩ b1 == latlon(10, 170)
 
   b1 = Box(latlon(-10, 170), latlon(10, 180))
   b2 = Box(latlon(-5, -180), latlon(5, -170))
   @test intersection(b1, b2) |> type == Touching
-  @test b1 ∩ b2 == Box(latlon(-5, 180), latlon(5, 180))
+  @test b1 ∩ b2 == b2 ∩ b1 == Box(latlon(-5, 180), latlon(5, 180))
 
   b1 = Box(latlon(-10, 180), latlon(10, -180))
   b2 = Box(latlon(10, 180), latlon(20, -180))
   @test intersection(b1, b2) |> type == CornerTouching
-  @test b1 ∩ b2 == latlon(10, 180)
+  @test b1 ∩ b2 == b2 ∩ b1 == latlon(10, 180)
 
   b1 = Box(latlon(-10, -150), latlon(10, 150))
   b2 = Box(latlon(-5, 30), latlon(5, -30))
-  @test b1 ∩ b2 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
+  @test b1 ∩ b2 == b2 ∩ b1 == Multi([Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))])
 
   # Ray-Box intersection
   b = Box(cart(0, 0, 0), cart(1, 1, 1))

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -846,6 +846,46 @@ end
   b2 = Box(merc(0.5, 0.5), merc(2, 2))
   @test crs(b1 ∩ b2) === crs(b1)
 
+  # LatLon boxes
+  b1 = Box(latlon(-10, 170), latlon(10, -170))
+  b2 = Box(latlon(-5, 175), latlon(5, -175))
+  @test intersection(b1, b2) |> type == Overlapping
+  @test b1 ∩ b2 == Box(latlon(-5, 175), latlon(5, -175))
+  @test b2 ∩ b1 == b1 ∩ b2
+
+  b2 = Box(latlon(-5, 160), latlon(5, 175))
+  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 175))
+  b2 = Box(latlon(-5, -175), latlon(5, -160))
+  @test b1 ∩ b2 == Box(latlon(-5, -175), latlon(5, -170))
+
+  b2 = Box(latlon(-5, -160), latlon(5, 160))
+  @test intersection(b1, b2) |> type == NotIntersecting
+  @test isnothing(b1 ∩ b2)
+
+  b2 = Box(latlon(-5, 160), latlon(5, 170))
+  @test intersection(b1, b2) |> type == Touching
+  @test b1 ∩ b2 == Box(latlon(-5, 170), latlon(5, 170))
+
+  b2 = Box(latlon(10, 160), latlon(20, 170))
+  @test intersection(b1, b2) |> type == CornerTouching
+  @test b1 ∩ b2 == latlon(10, 170)
+
+  b1 = Box(latlon(-10, 170), latlon(10, 180))
+  b2 = Box(latlon(-5, -180), latlon(5, -170))
+  @test intersection(b1, b2) |> type == Touching
+  @test b1 ∩ b2 == Box(latlon(-5, 180), latlon(5, 180))
+
+  b1 = Box(latlon(-10, 180), latlon(10, -180))
+  b2 = Box(latlon(10, 180), latlon(20, -180))
+  @test intersection(b1, b2) |> type == CornerTouching
+  @test b1 ∩ b2 == latlon(10, 180)
+
+  b1 = Box(latlon(-10, -150), latlon(10, 150))
+  b2 = Box(latlon(-5, 30), latlon(5, -30))
+  @test b1 ∩ b2 == Multi([
+    Box(latlon(-5, -150), latlon(5, -30)), Box(latlon(-5, 30), latlon(5, 150))
+  ])
+
   # Ray-Box intersection
   b = Box(cart(0, 0, 0), cart(1, 1, 1))
 

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -99,7 +99,7 @@ end
   hole1 = [merc(0.2, 0.2), merc(0.4, 0.2), merc(0.4, 0.4), merc(0.2, 0.4)]
   hole2 = [merc(0.6, 0.2), merc(0.8, 0.2), merc(0.8, 0.4), merc(0.6, 0.4)]
   poly = PolyArea([outer, hole1, hole2])
-  @test all(p ∈ poly for p in outer)
+  @test all(p in poly for p in outer)
   @test merc(0.5, 0.5) ∈ poly
   @test merc(0.2, 0.6) ∈ poly
   @test merc(1.5, 0.5) ∉ poly

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -127,10 +127,15 @@ end
 
   box = Box(latlon(48.0110, -178.5), latlon(48.2511, 2.001))
   @test latlon(48.1, 0) ∈ box
-  @test latlon(48.1, -179.1) ∈ box
+  @test latlon(48.1, -179.1) ∉ box
   @test latlon(48.1, 1.1) ∈ box
-  @test latlon(48.1, -178.1) ∉ box
+  @test latlon(48.1, -178.1) ∈ box
   @test latlon(48.1, 2.1) ∉ box
+
+  box = Box(latlon(-10, 170), latlon(10, -170))
+  @test latlon(0, 175) ∈ box
+  @test latlon(0, -175) ∈ box
+  @test latlon(0, 0) ∉ box
 
   box = Box(latlon(48.0110, -50.5), latlon(48.2511, -45.4))
   @test latlon(48.1, -48) ∈ box

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -99,7 +99,7 @@ end
   hole1 = [merc(0.2, 0.2), merc(0.4, 0.2), merc(0.4, 0.4), merc(0.2, 0.4)]
   hole2 = [merc(0.6, 0.2), merc(0.8, 0.2), merc(0.8, 0.4), merc(0.6, 0.4)]
   poly = PolyArea([outer, hole1, hole2])
-  @test all(p in poly for p in outer)
+  @test all(p ∈ poly for p in outer)
   @test merc(0.5, 0.5) ∈ poly
   @test merc(0.2, 0.6) ∈ poly
   @test merc(1.5, 0.5) ∉ poly


### PR DESCRIPTION
Based on the discussion in https://github.com/JuliaGeometry/Meshes.jl/pull/1369#discussion_r3364791648, this is a smaller, less broad PR: Just providing intersections over LatLon boxes.

The code broadly follows the industry-standard logic in https://s2geometry.io/devguide/basic_types.html, but with some improvements (enabled by the very good design of this library): we return true `Multi` boxes in cases of wrapped overlapping boxes.