### PR TITLE
Add centroid definition for Ellipsoid

### DIFF
--- a/src/centroid.jl
+++ b/src/centroid.jl
@@ -19,6 +19,8 @@ centroid(b::Ball) = center(b)
 
 centroid(s::Sphere) = center(s)
 
+centroid(e::Ellipsoid) = center(e)
+
 centroid(d::Disk) = center(d)
 
 centroid(c::Circle) = center(c)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -730,7 +730,11 @@ end
   @test Meshes.lentype(e) == ℳ
   @test radii(e) == (T(3) * u"m", T(2) * u"m", T(1) * u"m")
   @test center(e) == cart(0, 0, 0)
+  @test centroid(e) == cart(0, 0, 0)
   @test perimeter(e) == zero(ℳ)
+
+  e = Ellipsoid((T(3), T(2), T(1)), cart(1, 2, 3))
+  @test centroid(e) == cart(1, 2, 3)
 
   e = Ellipsoid((T(3), T(2), T(1)))
   equaltest(e)


### PR DESCRIPTION
Closes #1391.

Both warnings come from the `Scale` test item in test/transforms.jl, at `@test centroid(r) ≈ f(centroid(g))` with `g = Ellipsoid(T.((1, 2, 3)))`. Ellipsoid had no centroid definition, so it went through the generic integral.

That was also inaccurate away from the origin:

```julia
julia> centroid(Ellipsoid((3.0, 2.0, 1.0), Point(1.0, 2.0, 3.0)))
Point(x: 1.0023394395953535 m, y: 2.004678969276033 m, z: 3.0070184557365867 m)
```

An ellipsoid is symmetric about its center, so the centroid is the center.