### PR TITLE
Fix centroid of unbounded geometries

### DIFF
--- a/src/centroid.jl
+++ b/src/centroid.jl
@@ -12,7 +12,11 @@ centroid(g::Geometry) = withcrs(g, integral(to, g) / measure(g))
 
 centroid(p::Point) = p
 
-centroid(p::Plane) = center(p)
+centroid(::Ray) = throw(ArgumentError("centroid is not defined for unbounded geometries"))
+
+centroid(::Line) = throw(ArgumentError("centroid is not defined for unbounded geometries"))
+
+centroid(::Plane) = throw(ArgumentError("centroid is not defined for unbounded geometries"))
 
 centroid(b::Box) = center(b)
 

--- a/src/geometries/primitives/plane.jl
+++ b/src/geometries/primitives/plane.jl
@@ -40,8 +40,6 @@ paramdim(::Type{<:Plane}) = 2
 
 normal(p::Plane) = unormalize(ucross(p.u, p.v))
 
-center(p::Plane) = p(0, 0)
-
 ==(p₁::Plane, p₂::Plane) =
   p₁(0, 0) ∈ p₂ && p₁(1, 0) ∈ p₂ && p₁(0, 1) ∈ p₂ && p₂(0, 0) ∈ p₁ && p₂(1, 0) ∈ p₁ && p₂(0, 1) ∈ p₁
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -195,6 +195,7 @@ end
   @test measure(r) == typemax(ℳ)
   @test length(r) == typemax(ℳ)
   @test perimeter(r) == zero(ℳ)
+  @test_throws ArgumentError centroid(r)
 
   r = Ray(cart(0, 0), vector(1, 1))
   equaltest(r)
@@ -253,6 +254,7 @@ end
   @test measure(l) == typemax(ℳ)
   @test length(l) == typemax(ℳ)
   @test perimeter(l) == zero(ℳ)
+  @test_throws ArgumentError centroid(l)
 
   l = Line(cart(0, 0), cart(1, 1))
   equaltest(l)
@@ -304,6 +306,7 @@ end
   @test Meshes.lentype(p) == ℳ
   @test measure(p) == typemax(ℳ)^2
   @test area(p) == typemax(ℳ)^2
+  @test_throws ArgumentError centroid(p)
   @test p(T(0), T(0)) == cart(0, 0, 0)
   @test normal(p) == Vec(0, 0, 1)
   @test perimeter(p) == zero(ℳ)
@@ -1108,7 +1111,7 @@ end
   @test paramdim(c) == 3
   @test crs(c) <: Cartesian{NoDatum}
   @test Meshes.lentype(c) == ℳ
-  @test c(T(0), T(0), T(0)) ≈ centroid(p)
+  @test c(T(0), T(0), T(0)) ≈ p(0, 0)
   @test c(T(0), T(0), T(1)) ≈ a
   @test c(T(1.0), T(0.25), T(0.0)) ≈ cart(0, 2, 0)
 


### PR DESCRIPTION
Closes #1411.

Went with an error rather than returning some point, since Line equality is geometric:

```julia
julia> l1, l2 = Line(Point(0.0, 0.0), Point(1.0, 1.0)), Line(Point(5.0, 5.0), Point(9.0, 9.0));

julia> l1 == l2
true

julia> l1(0), l2(0)
(Point(x: 0.0 m, y: 0.0 m), Point(x: 5.0 m, y: 5.0 m))
```

so any point we pick makes two equal lines differ. Before #1387 both were hitting a MethodError anyway.

Nothing depended on `centroid(::Plane)`. `Stretch` has its own `_origin(p::Plane) = p(0, 0)`, `TransformedGeometry` goes through `isparametrized`, and `supportfun` and `gjkprepare` need `boundarypoints` which errors on a plane. Only the Cone test used it, and `p(0, 0)` works there.

Just removing the method is not enough though, it falls back to the generic integral and returns NaN, so Plane throws too. `Ray`, `Line` and `Plane` are the only geometries with `typemax` measure.

Removed `center(p::Plane)` as well.
