### PR TITLE
Implement discretize for Ball{𝔼{3}}

### DIFF
--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -45,6 +45,8 @@ discretize(box::Box) = discretize(box, RegularDiscretization(1))
 
 discretize(ball::Ball{𝔼{2}}) = discretize(ball, RegularDiscretization(2, 50))
 
+discretize(ball::Ball{𝔼{3}}) = discretize(ball, RegularDiscretization(2, 50, 50))
+
 discretize(disk::Disk) = discretize(disk, RegularDiscretization(50))
 
 discretize(sphere::Sphere{𝔼{3}}) = discretize(sphere, RegularDiscretization(50))

--- a/src/discretization/manual.jl
+++ b/src/discretization/manual.jl
@@ -61,6 +61,10 @@ function _manualconnec(::Quadrangle)
   [connect((1, 2, 3), Triangle), connect((1, 3, 4), Triangle)]
 end
 
+function _manualconnec(::Tetrahedron)
+  [connect((1, 2, 3, 4), Tetrahedron)]
+end
+
 function _manualconnec(::Hexahedron)
   [
     connect((1, 5, 6, 8), Tetrahedron),

--- a/src/discretization/regular.jl
+++ b/src/discretization/regular.jl
@@ -66,6 +66,8 @@ appendtopo(g, tg) = tg
 
 appendtopo(::Ball{𝔼{2}}, tg) = _appendcenter(tg)
 
+appendtopo(::Ball{𝔼{3}}, tg) = _appendcenteraxis(tg)
+
 appendtopo(::Disk, tg) = _appendcenter(tg)
 
 appendtopo(::Sphere{𝔼{3}}, tg) = _appendpoles(tg, 2, true)
@@ -103,6 +105,57 @@ function _appendcenter(tg)
   push!(tris, connect((c, u, v)))
 
   SimpleTopology([quads; tris])
+end
+
+function _appendcenteraxis(tg)
+  # auxiliary variables
+  nr, nt, np = size(tg)
+  it, nvert = nt + 1, nvertices(tg)
+
+  # center and points along the polar axis
+  c = nvert + 1
+  north(i) = nvert + 1 + i
+  south(i) = nvert + 1 + (nr + 1) + i
+
+  # wrap periodic azimuthal index
+  wrap(k) = k > np ? 1 : k
+
+  # connect hexahedra in the interior
+  hexas = collect(elements(tg))
+
+  # connect polar axis with wedges
+  winds = NTuple{6,Int}[]
+  for i in 1:nr, k in 1:np
+    l = wrap(k + 1)
+    u1, v1 = cart2corner(tg, i, 1, k), cart2corner(tg, i, 1, l)
+    u2, v2 = cart2corner(tg, i + 1, 1, k), cart2corner(tg, i + 1, 1, l)
+    push!(winds, (north(i), u1, v1, north(i + 1), u2, v2))
+    u1, v1 = cart2corner(tg, i, it, k), cart2corner(tg, i, it, l)
+    u2, v2 = cart2corner(tg, i + 1, it, k), cart2corner(tg, i + 1, it, l)
+    push!(winds, (south(i), v1, u1, south(i + 1), v2, u2))
+  end
+  wedges = [connect(ind, Wedge) for ind in winds]
+
+  # connect center with pyramids
+  pinds = NTuple{5,Int}[]
+  for j in 1:nt, k in 1:np
+    l = wrap(k + 1)
+    u1, v1 = cart2corner(tg, 1, j, k), cart2corner(tg, 1, j, l)
+    u2, v2 = cart2corner(tg, 1, j + 1, k), cart2corner(tg, 1, j + 1, l)
+    push!(pinds, (u1, v1, v2, u2, c))
+  end
+  pyramids = [connect(ind, Pyramid) for ind in pinds]
+
+  # connect center and poles with tetrahedra
+  tinds = NTuple{4,Int}[]
+  for k in 1:np
+    l = wrap(k + 1)
+    push!(tinds, (c, north(1), cart2corner(tg, 1, 1, k), cart2corner(tg, 1, 1, l)))
+    push!(tinds, (c, south(1), cart2corner(tg, 1, it, l), cart2corner(tg, 1, it, k)))
+  end
+  tetras = [connect(ind, Tetrahedron) for ind in tinds]
+
+  SimpleTopology([hexas; wedges; pyramids; tetras])
 end
 
 function _appendaxis(tg)

--- a/src/discretization/regular.jl
+++ b/src/discretization/regular.jl
@@ -163,32 +163,31 @@ function _appendaxis(tg)
   _, ny, nz = size(tg)
 
   # number of grid vertices
-  nvert = nvertices(tg)
+  nv = nvertices(tg)
 
   # connect hexahedra in the volume
   hexas = collect(elements(tg))
 
   # connect axis with wedges
-  inds = NTuple{6,Int}[]
+  wedges = Connectivity{Wedge,6}[]
   for k in 1:nz
     for j in 1:(ny - 1)
-      a1 = nvert + k
+      a1 = nv + k
       b1 = cart2corner(tg, 1, j, k)
       c1 = cart2corner(tg, 1, j + 1, k)
-      a2 = nvert + k + 1
+      a2 = nv + k + 1
       b2 = cart2corner(tg, 1, j, k + 1)
       c2 = cart2corner(tg, 1, j + 1, k + 1)
-      push!(inds, (a1, b1, c1, a2, b2, c2))
+      push!(wedges, connect((a1, b1, c1, a2, b2, c2), Wedge))
     end
-    a1 = nvert + k
+    a1 = nv + k
     b1 = cart2corner(tg, 1, ny, k)
     c1 = cart2corner(tg, 1, 1, k)
-    a2 = nvert + k + 1
+    a2 = nv + k + 1
     b2 = cart2corner(tg, 1, ny, k + 1)
     c2 = cart2corner(tg, 1, 1, k + 1)
-    push!(inds, (a1, b1, c1, a2, b2, c2))
+    push!(wedges, connect((a1, b1, c1, a2, b2, c2), Wedge))
   end
-  wedges = [connect(ind, Wedge) for ind in inds]
 
   SimpleTopology([hexas; wedges])
 end

--- a/src/discretization/regular.jl
+++ b/src/discretization/regular.jl
@@ -110,12 +110,13 @@ end
 function _appendcenteraxis(tg)
   # auxiliary variables
   nr, nt, np = size(tg)
-  it, nvert = nt + 1, nvertices(tg)
+  nv = nvertices(tg)
+  it = nt + 1
 
   # center and points along the polar axis
-  c = nvert + 1
-  north(i) = nvert + 1 + i
-  south(i) = nvert + 1 + (nr + 1) + i
+  c = nv + 1
+  north(i) = nv + 1 + i
+  south(i) = nv + 1 + (nr + 1) + i
 
   # wrap periodic azimuthal index
   wrap(k) = k > np ? 1 : k
@@ -124,36 +125,35 @@ function _appendcenteraxis(tg)
   hexas = collect(elements(tg))
 
   # connect polar axis with wedges
-  winds = NTuple{6,Int}[]
+  wedges = Connectivity{Wedge,6}[]
   for i in 1:nr, k in 1:np
     l = wrap(k + 1)
     u1, v1 = cart2corner(tg, i, 1, k), cart2corner(tg, i, 1, l)
     u2, v2 = cart2corner(tg, i + 1, 1, k), cart2corner(tg, i + 1, 1, l)
-    push!(winds, (north(i), u1, v1, north(i + 1), u2, v2))
+    push!(wedges, connect((north(i), u1, v1, north(i + 1), u2, v2), Wedge))
     u1, v1 = cart2corner(tg, i, it, k), cart2corner(tg, i, it, l)
     u2, v2 = cart2corner(tg, i + 1, it, k), cart2corner(tg, i + 1, it, l)
-    push!(winds, (south(i), v1, u1, south(i + 1), v2, u2))
+    push!(wedges, connect((south(i), v1, u1, south(i + 1), v2, u2), Wedge))
   end
-  wedges = [connect(ind, Wedge) for ind in winds]
 
   # connect center with pyramids
-  pinds = NTuple{5,Int}[]
+  pyramids = Connectivity{Pyramid,5}[]
   for j in 1:nt, k in 1:np
     l = wrap(k + 1)
     u1, v1 = cart2corner(tg, 1, j, k), cart2corner(tg, 1, j, l)
     u2, v2 = cart2corner(tg, 1, j + 1, k), cart2corner(tg, 1, j + 1, l)
-    push!(pinds, (u1, v1, v2, u2, c))
+    push!(pyramids, connect((u1, v1, v2, u2, c), Pyramid))
   end
-  pyramids = [connect(ind, Pyramid) for ind in pinds]
 
   # connect center and poles with tetrahedra
-  tinds = NTuple{4,Int}[]
+  tetras = Connectivity{Tetrahedron,4}[]
   for k in 1:np
     l = wrap(k + 1)
-    push!(tinds, (c, north(1), cart2corner(tg, 1, 1, k), cart2corner(tg, 1, 1, l)))
-    push!(tinds, (c, south(1), cart2corner(tg, 1, it, l), cart2corner(tg, 1, it, k)))
+    u1, v1 = cart2corner(tg, 1, 1, k), cart2corner(tg, 1, 1, l)
+    u2, v2 = cart2corner(tg, 1, it, k), cart2corner(tg, 1, it, l)
+    push!(tetras, connect((c, north(1), u1, v1), Tetrahedron))
+    push!(tetras, connect((c, south(1), v2, u2), Tetrahedron))
   end
-  tetras = [connect(ind, Tetrahedron) for ind in tinds]
 
   SimpleTopology([hexas; wedges; pyramids; tetras])
 end

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -53,6 +53,14 @@ firstoffset(b::Ball) = (n -> inv(n), firstoffset(boundary(b))...)
 lastoffset(b::Ball) = (n -> zero(n), lastoffset(boundary(b))...)
 extrapoints(b::Ball, sz) = (center(b),)
 
+function extrapoints(b::Ball{𝔼{3}}, sz)
+  T = numtype(lentype(b))
+  n = sz[1]
+  δₛ, δₑ = first(firstoffset(b)), first(lastoffset(b))
+  rs = range(T(δₛ(n)), stop=T(1 - δₑ(n)), length=n)
+  (center(b), (b(r, 0, 0) for r in rs)..., (b(r, 1, 0) for r in rs)...)
+end
+
 _firstoffset(::Sphere, ::Val{3}) = (n -> inv(n + 1), n -> zero(n))
 _lastoffset(::Sphere, ::Val{3}) = (n -> inv(n + 1), n -> inv(n))
 _extrapoints(s::Sphere, ::Val{3}, sz) = (s(0, 0), s(1, 0))

--- a/src/sampling/regular.jl
+++ b/src/sampling/regular.jl
@@ -41,29 +41,13 @@ firstoffset(g::Geometry) = _firstoffset(g, Val(embeddim(g)))
 lastoffset(g::Geometry) = _lastoffset(g, Val(embeddim(g)))
 extrapoints(g::Geometry, sz) = _extrapoints(g, Val(embeddim(g)), sz)
 
-_firstoffset(g::Geometry, ::Val) = ntuple(i -> (n -> zero(n)), paramdim(g))
-_lastoffset(g::Geometry, ::Val) = ntuple(i -> (n -> isperiodic(g)[i] ? inv(n) : zero(n)), paramdim(g))
-_extrapoints(::Geometry, ::Val, sz) = ()
-
 firstoffset(d::Disk) = (n -> inv(n), firstoffset(boundary(d))...)
 lastoffset(d::Disk) = (n -> zero(n), lastoffset(boundary(d))...)
 extrapoints(d::Disk, sz) = (center(d),)
 
 firstoffset(b::Ball) = (n -> inv(n), firstoffset(boundary(b))...)
 lastoffset(b::Ball) = (n -> zero(n), lastoffset(boundary(b))...)
-extrapoints(b::Ball, sz) = (center(b),)
-
-function extrapoints(b::Ball{𝔼{3}}, sz)
-  T = numtype(lentype(b))
-  n = sz[1]
-  δₛ, δₑ = first(firstoffset(b)), first(lastoffset(b))
-  rs = range(T(δₛ(n)), stop=T(1 - δₑ(n)), length=n)
-  (center(b), (b(r, 0, 0) for r in rs)..., (b(r, 1, 0) for r in rs)...)
-end
-
-_firstoffset(::Sphere, ::Val{3}) = (n -> inv(n + 1), n -> zero(n))
-_lastoffset(::Sphere, ::Val{3}) = (n -> inv(n + 1), n -> inv(n))
-_extrapoints(s::Sphere, ::Val{3}, sz) = (s(0, 0), s(1, 0))
+extrapoints(b::Ball, sz) = _extrapoints(b, Val(embeddim(b)), sz)
 
 firstoffset(::Ellipsoid) = (n -> inv(n + 1), n -> zero(n))
 lastoffset(::Ellipsoid) = (n -> inv(n + 1), n -> inv(n))
@@ -94,6 +78,29 @@ extrapoints(c::FrustumSurface, sz) = (bottom(c)(0, 0), top(c)(0, 0))
 firstoffset(::ParaboloidSurface) = (n -> inv(n), n -> zero(n))
 lastoffset(::ParaboloidSurface) = (n -> zero(n), n -> inv(n))
 extrapoints(p::ParaboloidSurface, sz) = (apex(p),)
+
+# -------------------
+# DIMENSION-SPECIFIC
+# -------------------
+
+_firstoffset(g::Geometry, ::Val) = ntuple(i -> (n -> zero(n)), paramdim(g))
+_lastoffset(g::Geometry, ::Val) = ntuple(i -> (n -> isperiodic(g)[i] ? inv(n) : zero(n)), paramdim(g))
+_extrapoints(::Geometry, ::Val, sz) = ()
+
+_extrapoints(b::Ball, ::Val{2}, sz) = (center(b),)
+function _extrapoints(b::Ball, ::Val{3}, sz)
+  T = numtype(lentype(b))
+  δₛ = firstoffset(b)
+  δₑ = lastoffset(b)
+  tₛ = T(0 + δₛ[1](sz[1]))
+  tₑ = T(1 - δₑ[1](sz[1]))
+  rs = range(tₛ, stop=tₑ, length=sz[1])
+  (center(b), (b(r, 0, 0) for r in rs)..., (b(r, 1, 0) for r in rs)...)
+end
+
+_firstoffset(::Sphere, ::Val{3}) = (n -> inv(n + 1), n -> zero(n))
+_lastoffset(::Sphere, ::Val{3}) = (n -> inv(n + 1), n -> inv(n))
+_extrapoints(s::Sphere, ::Val{3}, sz) = (s(0, 0), s(1, 0))
 
 # --------------
 # SPECIAL CASES

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -342,6 +342,13 @@ end
   @test nelements(mesh) == 2
   @test eltype(mesh) <: Triangle
 
+  tetra = Tetrahedron(cart(0, 0, 0), cart(1, 0, 0), cart(0, 1, 0), cart(0, 0, 1))
+  mesh = discretize(tetra, ManualSimplexification())
+  @test nvertices(mesh) == 4
+  @test nelements(mesh) == 1
+  @test eltype(mesh) <: Tetrahedron
+  @test measure(mesh) ≈ measure(tetra)
+
   box = Box(cart(0, 0, 0), cart(1, 1, 1))
   hexa = Hexahedron(
     cart(0, 0, 0),
@@ -426,6 +433,14 @@ end
   @test nelements(mesh) == 10 * 10 + 10
   @test eltype(mesh) <: Ngon
   @test nvertices.(mesh) ⊆ [3, 4]
+
+  ball = Ball(cart(0, 0, 0), T(1))
+  mesh = discretize(ball, RegularDiscretization(10))
+  @test nvertices(mesh) == 11 * 11 * 10 + 2 * 11 + 1
+  @test nelements(mesh) == 10 * 10 * 10 + 2 * 10 * 10 + 10 * 10 + 2 * 10
+  @test eltype(mesh) <: Polyhedron
+  @test nvertices.(mesh) ⊆ [4, 5, 6, 8]
+  @test measure(mesh) ≈ measure(simplexify(mesh))
 
   disk = Disk(Plane(cart(0, 0, 0), vector(0, 0, 1)), T(1))
   mesh = discretize(disk, RegularDiscretization(10))
@@ -557,6 +572,11 @@ end
   @test !(eltype(mesh) <: Triangle)
   @test !(eltype(mesh) <: Quadrangle)
   @test nelements(mesh) == 150
+
+  ball = Ball(cart(0, 0, 0), T(1))
+  mesh = discretize(ball)
+  @test !(eltype(mesh) <: Hexahedron)
+  @test nelements(mesh) == 7800
 
   sphere = Sphere(cart(0, 0, 0), T(1))
   mesh = discretize(sphere)


### PR DESCRIPTION
Part of #1410.

Added the `discretize` method with `RegularDiscretization(2, 50, 50)`.

`extrapoints(b::Ball, sz)` was only adding the centre, so the poles from the boundary sphere got dropped, and with no `appendtopo` the centre was sampled but never referenced.

`_appendcenteraxis` closes both, so the volume no longer depends on the radial count, 4.17587 at nr=1 and 4.17442 at nr=8, where before it went 4.01 to 4.18.

The ball uses tetrahedra at the centre and the poles, and `_manualconnec(::Tetrahedron)` was missing, so `simplexify` needed that too.
