### PR TITLE
Fix simplexification of tapered Wedge

### DIFF
--- a/src/discretization/manual.jl
+++ b/src/discretization/manual.jl
@@ -80,5 +80,5 @@ function _manualconnec(::Pyramid)
 end
 
 function _manualconnec(::Wedge)
-  [connect((1, 2, 3, 4), Tetrahedron), connect((4, 5, 6, 2), Tetrahedron), connect((4, 5, 6, 3), Tetrahedron)]
+  [connect((1, 2, 3, 4), Tetrahedron), connect((2, 3, 4, 5), Tetrahedron), connect((3, 4, 5, 6), Tetrahedron)]
 end

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -349,6 +349,13 @@ end
   @test eltype(mesh) <: Tetrahedron
   @test measure(mesh) ≈ measure(tetra)
 
+  wedge = Wedge(cart(0, 0, 0), cart(1, 0, 0), cart(0, 1, 0), cart(0, 0, 1), cart(0.5, 0, 1), cart(0, 0.5, 1))
+  mesh = discretize(wedge, ManualSimplexification())
+  @test nvertices(mesh) == 6
+  @test nelements(mesh) == 3
+  @test eltype(mesh) <: Tetrahedron
+  @test measure(mesh) ≈ T(7 / 24) * u"m^3"
+
   box = Box(cart(0, 0, 0), cart(1, 1, 1))
   hexa = Hexahedron(
     cart(0, 0, 0),


### PR DESCRIPTION
`_manualconnec(::Wedge)` uses `(4, 5, 6)` twice, which tiles a right prism but not a tapered one:

```julia
julia> w = Wedge(Point(0, 0, 0), Point(1, 0, 0), Point(0, 1, 0), Point(0, 0, 1), Point(0.5, 0, 1), Point(0, 0.5, 1));

julia> measure(w)
0.24999999999999997 m³
```

should be 7/24. The error reaches 14.29% mid taper and vanishes at both ends, so `Cylinder` never hit it. The staircase decomposition is exact at every taper.

Side effect, the volume of a discretized `Ball` is now exactly independent of the radial count, 4.17396339 at nr = 1, 2, 4 and 8, where before it drifted from 4.17587 to 4.17442.
