### PR TITLE
Fix bridge between rings that share a vertex

### DIFF
--- a/src/transforms/bridge.jl
+++ b/src/transforms/bridge.jl
@@ -77,8 +77,12 @@ function bridge(rings, rinds, δ)
     A = outer[omax]
     B = inner[imax]
 
+    # the rings may share the vertex, in which case the segment A--B
+    # degenerates and the bridge is oriented towards the hole instead
+    shared = A == B
+
     # direction and normal to segment A--B
-    v = B - A
+    v = shared ? (coordmean(inner) - A) : (B - A)
     u = Vec(-v[2], v[1])
     n = norm(u)
 
@@ -90,18 +94,23 @@ function bridge(rings, rinds, δ)
     B′ = B + (δ / 2n) * u
     B′′ = B - (δ / 2n) * u
 
+    # a bridge of zero length needs a single pair of split points
+    head = shared ? [A′] : [A′, B′]
+    tail = shared ? [A′′] : [B′′, A′′]
+    sinds = circshift(iinds, -imax + 1)
+    hinds = shared ? sinds[2:end] : [sinds; iinds[imax]]
+
     # insert hole at closest vertex
     outer = [
       outer[begin:(omax - 1)]
-      [A′, B′]
+      head
       circshift(inner, -imax + 1)[2:end]
-      [B′′, A′′]
+      tail
       outer[(omax + 1):end]
     ]
     oinds = [
       oinds[begin:omax]
-      circshift(iinds, -imax + 1)
-      [iinds[imax]]
+      hinds
       oinds[omax:end]
     ]
   end

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -315,6 +315,15 @@ end
   @test nelements(mesh) == 1
   @test vertices(mesh) == [cart(0, 0), cart(0, 0), cart(0, 0)]
   @test mesh[1] == Triangle(cart(0, 0), cart(0, 0), cart(0, 0))
+
+  # https://github.com/JuliaGeometry/Meshes.jl/issues/629
+  outer = Ring(cart.([(0, 0), (0, 3), (2, 3), (2, 2), (3, 2), (3, 0)]))
+  inner = Ring(cart.([(1, 1), (1, 2), (2, 2), (2, 1)]))
+  poly = PolyArea(outer, inner)
+  mesh = discretize(poly)
+  @test all(v -> !any(isnan, to(v)), vertices(mesh))
+  @test Set(vertices(poly)) ⊆ Set(vertices(mesh))
+  @test sum(measure, mesh) ≈ measure(poly)
 end
 
 @testitem "ManualSimplexification" setup = [Setup] begin


### PR DESCRIPTION
Closes #629.

When the outer ring and a hole share a vertex the segment A--B has zero length, so the offset becomes Inf times zero and the mesh comes out with NaN vertices. The bridge is now oriented towards the hole, and since it has zero length a single pair of split points is enough, otherwise the coincident points come back as zero area triangles.

Also tried the Repair(10) route from the thread. It clears the NaN but moves the outer ring by 10atol, so the original vertices no longer appear in the mesh. This way every input point survives.

Checked against measure(poly) over a sweep of hole sizes, corners and scales, 64 cases, no NaN and no area mismatch. One zero area triangle is left at the pinch, that vertex has to appear twice in the bridged ring.
