### PR TITLE
Fix cartesianrange for geodesic grids

### DIFF
--- a/src/indices.jl
+++ b/src/indices.jl
@@ -151,64 +151,60 @@ function _euclideanrange(grid::OrthoRectilinearGrid, box::Box)
 end
 
 function _geodesicrange(grid::Grid, box::Box)
-  nlon, nlat = vsize(grid)
+  n₁, n₂ = vsize(grid)
+
+  # the latitude may be stored in the first or in the second axis
+  v₁ = convert(LatLon, coords(vertex(grid, (1, 1))))
+  v₂ = convert(LatLon, coords(vertex(grid, (2, 1))))
+  latfirst = abs(v₂.lat - v₁.lat) > abs(v₂.lon - v₁.lon)
+
+  nlat, nlon = latfirst ? (n₁, n₂) : (n₂, n₁)
+  latcoord(i) = convert(LatLon, coords(vertex(grid, latfirst ? (i, 1) : (1, i)))).lat
+  loncoord(j) = convert(LatLon, coords(vertex(grid, latfirst ? (1, j) : (j, 1)))).lon
 
   boxmin = convert(LatLon, coords(minimum(box)))
   boxmax = convert(LatLon, coords(maximum(box)))
 
-  a = convert(LatLon, coords(vertex(grid, (1, 1))))
-  b = convert(LatLon, coords(vertex(grid, (nlon, 1))))
-  c = convert(LatLon, coords(vertex(grid, (1, nlat))))
-
-  swaplon = a.lon > b.lon
-  swaplat = a.lat > c.lat
-
-  loninds = swaplon ? (nlon:-1:1) : (1:1:nlon)
+  # vertex indices in increasing latitude and longitude
+  swaplat = latcoord(1) > latcoord(nlat)
+  swaplon = loncoord(1) > loncoord(nlon)
   latinds = swaplat ? (nlat:-1:1) : (1:1:nlat)
+  loninds = swaplon ? (nlon:-1:1) : (1:1:nlon)
 
-  gridlonₛ, gridlonₑ = swaplon ? (b.lon, a.lon) : (a.lon, b.lon)
-  gridlatₛ, gridlatₑ = swaplat ? (c.lat, a.lat) : (a.lat, c.lat)
+  latmin = max(boxmin.lat, latcoord(first(latinds)))
+  latmax = min(boxmax.lat, latcoord(last(latinds)))
+  lonmin = max(boxmin.lon, loncoord(first(loninds)))
+  lonmax = min(boxmax.lon, loncoord(last(loninds)))
 
-  lonmin = max(boxmin.lon, gridlonₛ)
-  latmin = max(boxmin.lat, gridlatₛ)
-  lonmax = min(boxmax.lon, gridlonₑ)
-  latmax = min(boxmax.lat, gridlatₑ)
+  latₛ, latₑ = _axisrange(latcoord, latinds, latmin, latmax)
+  lonₛ, lonₑ = _axisrange(loncoord, loninds, lonmin, lonmax)
 
-  iₛ = findlast(loninds) do i
-    p = vertex(grid, (i, 1))
-    c = convert(LatLon, coords(p))
-    c.lon ≤ lonmin
+  # map back to element indices of the grid
+  i₁, i₂ = swaplat ? (nlat - latₑ, nlat - latₛ) : (latₛ, latₑ)
+  j₁, j₂ = swaplon ? (nlon - lonₑ, nlon - lonₛ) : (lonₛ, lonₑ)
+
+  if latfirst
+    CartesianIndex(i₁, j₁):CartesianIndex(i₂, j₂)
+  else
+    CartesianIndex(j₁, i₁):CartesianIndex(j₂, i₂)
   end
-  iₑ = findfirst(loninds) do i
-    p = vertex(grid, (i, 1))
-    c = convert(LatLon, coords(p))
-    c.lon ≥ lonmax
-  end
-
-  jₛ = findlast(latinds) do i
-    p = vertex(grid, (1, i))
-    c = convert(LatLon, coords(p))
-    c.lat ≤ latmin
-  end
-  jₑ = findfirst(latinds) do i
-    p = vertex(grid, (1, i))
-    c = convert(LatLon, coords(p))
-    c.lat ≥ latmax
-  end
-
-  if iₛ == iₑ || jₛ == jₑ
-    throw(ArgumentError("the passed limits are not valid for the grid"))
-  end
-
-  iₛ, iₑ = swaplon ? (iₑ, iₛ) : (iₛ, iₑ)
-  jₛ, jₑ = swaplat ? (jₑ, jₛ) : (jₛ, jₑ)
-
-  CartesianIndex(loninds[iₛ], latinds[jₛ]):CartesianIndex(loninds[iₑ] - 1, latinds[jₑ] - 1)
 end
 
 # -----------------
 # HELPER FUNCTIONS
 # -----------------
+
+# range of elements along an axis that intersect the interval [cmin, cmax],
+# where `inds` lists the vertex indices in increasing coordinate order
+function _axisrange(coord, inds, cmin, cmax)
+  n = length(inds)
+  sₚ = findfirst(p -> coord(inds[p]) ≥ cmin, 1:n)
+  eₚ = findlast(p -> coord(inds[p]) ≤ cmax, 1:n)
+  if isnothing(sₚ) || isnothing(eₚ) || eₚ < sₚ - 1
+    throw(ArgumentError("the passed limits are not valid for the grid"))
+  end
+  clamp(sₚ - 1, 1, n - 1), clamp(eₚ, 1, n - 1)
+end
 
 function _fill!(mask, grid, val, triangle)
   v = vertices(triangle)

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -151,64 +151,58 @@ function _euclideanrange(grid::OrthoRectilinearGrid, box::Box)
 end
 
 function _geodesicrange(grid::Grid, box::Box)
-  nlon, nlat = vsize(grid)
+  nlat, nlon = vsize(grid)
 
   boxmin = convert(LatLon, coords(minimum(box)))
   boxmax = convert(LatLon, coords(maximum(box)))
 
   a = convert(LatLon, coords(vertex(grid, (1, 1))))
-  b = convert(LatLon, coords(vertex(grid, (nlon, 1))))
-  c = convert(LatLon, coords(vertex(grid, (1, nlat))))
+  b = convert(LatLon, coords(vertex(grid, (nlat, 1))))
+  c = convert(LatLon, coords(vertex(grid, (1, nlon))))
 
-  swaplon = a.lon > b.lon
-  swaplat = a.lat > c.lat
-
-  loninds = swaplon ? (nlon:-1:1) : (1:1:nlon)
+  # vertex indices in increasing latitude and longitude
+  swaplat = a.lat > b.lat
+  swaplon = a.lon > c.lon
   latinds = swaplat ? (nlat:-1:1) : (1:1:nlat)
+  loninds = swaplon ? (nlon:-1:1) : (1:1:nlon)
 
-  gridlonₛ, gridlonₑ = swaplon ? (b.lon, a.lon) : (a.lon, b.lon)
-  gridlatₛ, gridlatₑ = swaplat ? (c.lat, a.lat) : (a.lat, c.lat)
+  gridlatₛ, gridlatₑ = swaplat ? (b.lat, a.lat) : (a.lat, b.lat)
+  gridlonₛ, gridlonₑ = swaplon ? (c.lon, a.lon) : (a.lon, c.lon)
 
-  lonmin = max(boxmin.lon, gridlonₛ)
   latmin = max(boxmin.lat, gridlatₛ)
-  lonmax = min(boxmax.lon, gridlonₑ)
   latmax = min(boxmax.lat, gridlatₑ)
+  lonmin = max(boxmin.lon, gridlonₛ)
+  lonmax = min(boxmax.lon, gridlonₑ)
 
-  iₛ = findlast(loninds) do i
-    p = vertex(grid, (i, 1))
-    c = convert(LatLon, coords(p))
-    c.lon ≤ lonmin
+  latₛ, latₑ = _axisrange(latinds, latmin, latmax) do i
+    convert(LatLon, coords(vertex(grid, (i, 1)))).lat
   end
-  iₑ = findfirst(loninds) do i
-    p = vertex(grid, (i, 1))
-    c = convert(LatLon, coords(p))
-    c.lon ≥ lonmax
+  lonₛ, lonₑ = _axisrange(loninds, lonmin, lonmax) do j
+    convert(LatLon, coords(vertex(grid, (1, j)))).lon
   end
 
-  jₛ = findlast(latinds) do i
-    p = vertex(grid, (1, i))
-    c = convert(LatLon, coords(p))
-    c.lat ≤ latmin
-  end
-  jₑ = findfirst(latinds) do i
-    p = vertex(grid, (1, i))
-    c = convert(LatLon, coords(p))
-    c.lat ≥ latmax
-  end
+  # map back to element indices of the grid
+  i₁, i₂ = swaplat ? (nlat - latₑ, nlat - latₛ) : (latₛ, latₑ)
+  j₁, j₂ = swaplon ? (nlon - lonₑ, nlon - lonₛ) : (lonₛ, lonₑ)
 
-  if iₛ == iₑ || jₛ == jₑ
-    throw(ArgumentError("the passed limits are not valid for the grid"))
-  end
-
-  iₛ, iₑ = swaplon ? (iₑ, iₛ) : (iₛ, iₑ)
-  jₛ, jₑ = swaplat ? (jₑ, jₛ) : (jₛ, jₑ)
-
-  CartesianIndex(loninds[iₛ], latinds[jₛ]):CartesianIndex(loninds[iₑ] - 1, latinds[jₑ] - 1)
+  CartesianIndex(i₁, j₁):CartesianIndex(i₂, j₂)
 end
 
 # -----------------
 # HELPER FUNCTIONS
 # -----------------
+
+# range of elements along an axis that intersect the interval [cmin, cmax],
+# where `inds` lists the vertex indices in increasing coordinate order
+function _axisrange(coord, inds, cmin, cmax)
+  n = length(inds)
+  sₚ = findfirst(p -> coord(inds[p]) ≥ cmin, 1:n)
+  eₚ = findlast(p -> coord(inds[p]) ≤ cmax, 1:n)
+  if isnothing(sₚ) || isnothing(eₚ) || eₚ < sₚ - 1
+    throw(ArgumentError("the passed limits are not valid for the grid"))
+  end
+  clamp(sₚ - 1, 1, n - 1), clamp(eₚ, 1, n - 1)
+end
 
 function _fill!(mask, grid, val, triangle)
   v = vertices(triangle)

--- a/test/indices.jl
+++ b/test/indices.jl
@@ -224,3 +224,41 @@
   @test indices(tmesh, tri) == indices(mesh, inverse(trans)(tri))
   @test indices(mesh, ttri) == unique(mapreduce(g -> indices(mesh, g), vcat, discretize(ttri)))
 end
+
+@testitem "CartesianRange" setup = [Setup] begin
+  # the range on a geodesic grid matches the range
+  # on the corresponding Euclidean grid
+  # https://github.com/JuliaGeometry/Meshes.jl/issues/1304
+  ggrid = RegularGrid(latlon(0, 0), latlon(10, 10), dims=(10, 10))
+  egrid = cartgrid(10, 10)
+  for (lo, up) in [((2, 2), (4, 4)), ((0, 0), (10, 10)), ((1, 1), (3, 3))]
+    gbox = Box(latlon(lo...), latlon(up...))
+    ebox = Box(cart(lo...), cart(up...))
+    @test Meshes.cartesianrange(ggrid, gbox) == Meshes.cartesianrange(egrid, ebox)
+  end
+
+  # grids with decreasing latitude and longitude
+  C = typeof(LatLon(T(0), T(0)))
+  lats = T.(0:10)
+  lons = T.(0:10)
+  agrid = RectilinearGrid{🌐,C}(lats, lons)
+  dgrid = RectilinearGrid{🌐,C}(reverse(lats), reverse(lons))
+  box = Box(latlon(2, 2), latlon(4, 4))
+  ebox = Box(cart(2, 2), cart(4, 4))
+  nelems = length(Meshes.cartesianrange(egrid, ebox))
+  @test length(Meshes.cartesianrange(agrid, box)) == nelems
+  @test length(Meshes.cartesianrange(dgrid, box)) == nelems
+
+  # grids may store the longitude in the first axis
+  X = [T(j - 1) for i in 1:11, j in 1:11]
+  Y = [T(i - 1) for i in 1:11, j in 1:11]
+  lonfirst = StructuredGrid{🌐,C}(X, Y)
+  abox = Box(latlon(2, 5), latlon(4, 8))
+  rlat = Meshes.cartesianrange(agrid, abox)
+  rlon = Meshes.cartesianrange(lonfirst, abox)
+  @test rlat.indices == reverse(rlon.indices)
+
+  # the Slice transform relies on the range
+  sliced = ggrid |> Slice(lat=(T(2) * u"°", T(4) * u"°"), lon=(T(2) * u"°", T(4) * u"°"))
+  @test size(sliced) == (4, 4)
+end

--- a/test/indices.jl
+++ b/test/indices.jl
@@ -224,3 +224,32 @@
   @test indices(tmesh, tri) == indices(mesh, inverse(trans)(tri))
   @test indices(mesh, ttri) == unique(mapreduce(g -> indices(mesh, g), vcat, discretize(ttri)))
 end
+
+@testitem "CartesianRange" setup = [Setup] begin
+  # the range on a geodesic grid matches the range
+  # on the corresponding Euclidean grid
+  # https://github.com/JuliaGeometry/Meshes.jl/issues/1304
+  ggrid = RegularGrid(latlon(0, 0), latlon(10, 10), dims=(10, 10))
+  egrid = cartgrid(10, 10)
+  for (lo, up) in [((2, 2), (4, 4)), ((0, 0), (10, 10)), ((1, 1), (3, 3))]
+    gbox = Box(latlon(lo...), latlon(up...))
+    ebox = Box(cart(lo...), cart(up...))
+    @test Meshes.cartesianrange(ggrid, gbox) == Meshes.cartesianrange(egrid, ebox)
+  end
+
+  # grids with decreasing latitude and longitude
+  C = typeof(LatLon(T(0), T(0)))
+  lats = T.(0:10)
+  lons = T.(0:10)
+  agrid = RectilinearGrid{🌐,C}(lats, lons)
+  dgrid = RectilinearGrid{🌐,C}(reverse(lats), reverse(lons))
+  box = Box(latlon(2, 2), latlon(4, 4))
+  ebox = Box(cart(2, 2), cart(4, 4))
+  nelems = length(Meshes.cartesianrange(egrid, ebox))
+  @test length(Meshes.cartesianrange(agrid, box)) == nelems
+  @test length(Meshes.cartesianrange(dgrid, box)) == nelems
+
+  # the Slice transform relies on the range
+  sliced = ggrid |> Slice(lat=(T(2) * u"°", T(4) * u"°"), lon=(T(2) * u"°", T(4) * u"°"))
+  @test size(sliced) == (4, 4)
+end


### PR DESCRIPTION
Closes #1304.

`_geodesicrange` was reading the first grid dimension as longitude, but `LatLon` grids are ordered (lat, lon), so every query returned an empty range. On main this makes `Slice` throw for any geodesic grid.

Also aligned the boundary handling with `_euclideanrange`, which keeps elements that touch the box.

Checked against the Euclidean range on the same grid in (lat, lon) space, 1100 random boxes across regular and rectilinear grids including the decreasing axis case, no mismatches. Added tests, this path had none.
