### PR TITLE
Add `Chain`-`Polygon` intersection method

### DIFF
--- a/src/intersections/chains.jl
+++ b/src/intersections/chains.jl
@@ -11,11 +11,16 @@ intersection(f, chain₁::Chain, chain₂::Chain) =
 # 3. overlaps at the polygon edges (EdgeTouching)
 # 4. no intersection (NotIntersecting)
 function intersection(f, chain::Chain, poly::Polygon)
-  # assess intersections 
-  pieces = Geometry{manifold(chain), crs(chain)}[]
-  hasintersection = false
+  # retrieve manifold and crs
+  M = manifold(chain)
+  C = crs(chain)
+
+  # collect intersection pieces and
+  # classify final intersection type
   onlytouching = true
   onlyedgetouching = true
+  hasintersection = false
+  pieces = Geometry{M,C}[]
   for seg in segments(chain)
     I = intersection(seg, poly)
     type(I) == NotIntersecting && continue
@@ -29,11 +34,10 @@ function intersection(f, chain::Chain, poly::Polygon)
       push!(pieces, geom)
     end
   end
-
   unique!(pieces)
+
   glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
 
-  # classifying intersections
   if !hasintersection
     return @IT NotIntersecting nothing f
   elseif onlytouching

--- a/src/intersections/chains.jl
+++ b/src/intersections/chains.jl
@@ -10,7 +10,7 @@ intersection(f, chain₁::Chain, chain₂::Chain) =
 # 2. intersect at boundary points (Touching)
 # 3. overlaps at the polygon edges (EdgeTouching)
 # 4. no intersection (NotIntersecting)
-function intersection(f, chain::Chain{𝔼{2}}, poly::Polygon{𝔼{2}})
+function intersection(f, chain::Chain, poly::Polygon)
   # assess intersections 
   pieces = Geometry{𝔼{2},crs(chain)}[]
   hasintersection = false

--- a/src/intersections/chains.jl
+++ b/src/intersections/chains.jl
@@ -36,15 +36,13 @@ function intersection(f, chain::Chain, poly::Polygon)
   end
   unique!(pieces)
 
-  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
-
   if !hasintersection
     return @IT NotIntersecting nothing f
   elseif onlytouching
-    return @IT Touching glue(pieces) f
+    return @IT Touching maybemulti(pieces) f
   elseif onlyedgetouching
-    return @IT EdgeTouching glue(pieces) f
+    return @IT EdgeTouching maybemulti(pieces) f
   else
-    return @IT Intersecting glue(pieces) f
+    return @IT Intersecting maybemulti(pieces) f
   end
 end

--- a/src/intersections/chains.jl
+++ b/src/intersections/chains.jl
@@ -12,7 +12,7 @@ intersection(f, chain₁::Chain, chain₂::Chain) =
 # 4. no intersection (NotIntersecting)
 function intersection(f, chain::Chain, poly::Polygon)
   # assess intersections 
-  pieces = Geometry{𝔼{2},crs(chain)}[]
+  pieces = Geometry{manifold(chain), crs(chain)}[]
   hasintersection = false
   onlytouching = true
   onlyedgetouching = true

--- a/src/intersections/chains.jl
+++ b/src/intersections/chains.jl
@@ -12,7 +12,7 @@ intersection(f, chain₁::Chain, chain₂::Chain) =
 # 4. no intersection (NotIntersecting)
 function intersection(f, chain::Chain{𝔼{2}}, poly::Polygon{𝔼{2}})
   # assess intersections 
-  pieces = Geometry[]
+  pieces = Geometry{𝔼{2},crs(chain)}[]
   hasintersection = false
   onlytouching = true
   onlyedgetouching = true
@@ -31,7 +31,7 @@ function intersection(f, chain::Chain{𝔼{2}}, poly::Polygon{𝔼{2}})
   end
 
   unique!(pieces)
-  glue(pieces) = length(pieces) == 1 ? only(pieces) : GeometrySet(pieces)
+  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
 
   # classifying intersections
   if !hasintersection

--- a/src/intersections/chains.jl
+++ b/src/intersections/chains.jl
@@ -4,3 +4,43 @@
 
 intersection(f, chain₁::Chain, chain₂::Chain) =
   intersection(f, GeometrySet(segments(chain₁)), GeometrySet(segments(chain₂)))
+
+# intersection between a chain and a polygon
+# 1. intersect at inner points (Intersecting)
+# 2. intersect at boundary points (Touching)
+# 3. overlaps at the polygon edges (EdgeTouching)
+# 4. no intersection (NotIntersecting)
+function intersection(f, chain::Chain{𝔼{2}}, poly::Polygon{𝔼{2}})
+  # assess intersections 
+  pieces = Geometry[]
+  hasintersection = false
+  onlytouching = true
+  onlyedgetouching = true
+  for seg in segments(chain)
+    I = intersection(seg, poly)
+    type(I) == NotIntersecting && continue
+    hasintersection = true
+    onlytouching &= (type(I) == Touching) || (type(I) == CornerTouching)
+    onlyedgetouching &= (type(I) == EdgeTouching)
+    geom = get(I)
+    if geom isa Multi
+      append!(pieces, parent(geom))
+    else
+      push!(pieces, geom)
+    end
+  end
+
+  unique!(pieces)
+  glue(pieces) = length(pieces) == 1 ? only(pieces) : GeometrySet(pieces)
+
+  # classifying intersections
+  if !hasintersection
+    return @IT NotIntersecting nothing f
+  elseif onlytouching
+    return @IT Touching glue(pieces) f
+  elseif onlyedgetouching
+    return @IT EdgeTouching glue(pieces) f
+  else
+    return @IT Intersecting glue(pieces) f
+  end
+end

--- a/src/intersections/domains.jl
+++ b/src/intersections/domains.jl
@@ -5,12 +5,10 @@
 function intersection(f, geom::Geometry, pset::PointSet)
   ps = filter(∈(geom), collect(pset))
 
-  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
-
   if isempty(ps)
     return @IT NotIntersecting nothing f
   else
-    return @IT Intersecting glue(ps) f
+    return @IT Intersecting maybemulti(ps) f
   end
 end
 
@@ -31,12 +29,10 @@ function intersection(f, dom₁::Domain, dom₂::Domain)
   # handle intersection at shared facets
   unique!(gs)
 
-  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
-
   # return intersection
   if isempty(gs)
     return @IT NotIntersecting nothing f
   else
-    return @IT Intersecting glue(gs) f
+    return @IT Intersecting maybemulti(gs) f
   end
 end

--- a/src/intersections/domains.jl
+++ b/src/intersections/domains.jl
@@ -4,7 +4,6 @@
 
 function intersection(f, geom::Geometry, pset::PointSet)
   ps = filter(∈(geom), collect(pset))
-
   if isempty(ps)
     return @IT NotIntersecting nothing f
   else

--- a/src/intersections/domains.jl
+++ b/src/intersections/domains.jl
@@ -4,18 +4,25 @@
 
 function intersection(f, geom::Geometry, pset::PointSet)
   ps = filter(∈(geom), collect(pset))
+
+  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
+
   if isempty(ps)
     return @IT NotIntersecting nothing f
   else
-    return @IT Intersecting PointSet(ps) f
+    return @IT Intersecting glue(ps) f
   end
 end
 
 intersection(f, dom::Domain, pset::PointSet) = intersection(f, Multi(collect(dom)), pset)
 
 function intersection(f, dom₁::Domain, dom₂::Domain)
+  # retrieve manifold and crs
+  M = manifold(dom₁)
+  C = crs(dom₁)
+
   # loop over all geometries
-  gs = Geometry[]
+  gs = Geometry{M,C}[]
   for g₁ in dom₁, g₂ in dom₂
     g = g₁ ∩ g₂
     isnothing(g) || push!(gs, g)
@@ -24,10 +31,12 @@ function intersection(f, dom₁::Domain, dom₂::Domain)
   # handle intersection at shared facets
   unique!(gs)
 
+  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
+
   # return intersection
   if isempty(gs)
     return @IT NotIntersecting nothing f
   else
-    return @IT Intersecting GeometrySet(gs) f
+    return @IT Intersecting glue(gs) f
   end
 end

--- a/src/intersections/segments.jl
+++ b/src/intersections/segments.jl
@@ -272,14 +272,11 @@ function intersection(f, seg::Segment{𝔼{2}}, poly::Polygon{𝔼{2}})
   # number of crossing events
   ncrosses = count(e -> e[2], events)
 
-  # glue pieces together into a single geometry
-  glue(pieces) = length(pieces) == 1 ? only(pieces) : Multi(pieces)
-
   # classify intersection
   if inpoly
-    return @IT Intersecting glue(pieces) f
+    return @IT Intersecting maybemulti(pieces) f
   elseif !isempty(pieces)
-    return @IT EdgeTouching glue(pieces) f
+    return @IT EdgeTouching maybemulti(pieces) f
   elseif ncrosses == 1
     i = findfirst(e -> e[2], events)
     p = events[i][1]

--- a/src/utils/basic.jl
+++ b/src/utils/basic.jl
@@ -62,3 +62,10 @@ end
 Return true if `cond`ition is true in the presence of multiple threads.
 """
 isthreaded(cond=true) = cond && Threads.nthreads() > 1
+
+"""
+    maybemulti(geoms)
+
+Return `only(geoms)` or `Multi(geoms)` depending on the length of `geoms`.
+"""
+maybemulti(geoms) = length(geoms) == 1 ? only(geoms) : Multi(geoms)

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1252,3 +1252,82 @@ end
   @test pset ∩ grid == grid ∩ pset == pset
   @test pset ∩ ball == ball ∩ pset == PointSet(cart(0.5, 0.5))
 end
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
+@testitem "Chain-Polygon intersection" setup = [Setup] begin
+  poly = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+
+  # CASE 1: chain crosses polygon
+  c = Rope([cart(-1, 2), cart(2, 2), cart(5, 2)])
+  @test intersection(c, poly) |> type == Intersecting
+  @test c ∩ poly ≈ GeometrySet([Segment(cart(0, 2), cart(2, 2)), Segment(cart(2, 2), cart(4, 2))])
+
+  c = Ring([cart(-1, 1), cart(2, 1), cart(2, 3), cart(-1, 3)])
+  @test intersection(c, poly) |> type == Intersecting
+
+  # CASE 1: one segment inside, others outside
+  c = Rope([cart(-1, 2), cart(1, 2), cart(3, 2), cart(5, 2)])
+  @test intersection(c, poly) |> type == Intersecting
+
+  # CASE 1: chain entirely inside polygon
+  c = Rope([cart(1, 1), cart(2, 2), cart(3, 1)])
+  @test intersection(c, poly) |> type == Intersecting
+  @test c ∩ poly ≈ GeometrySet([Segment(cart(1, 1), cart(2, 2)), Segment(cart(2, 2), cart(3, 1))])
+
+  c = Ring([cart(1, 1), cart(3, 1), cart(3, 3), cart(1, 3)])
+  @test intersection(c, poly) |> type == Intersecting
+
+  # CASE 1: mixed touching and intersecting
+  c = Rope([cart(-1, 0), cart(0, 0), cart(2, 2), cart(5, 2)])
+  @test intersection(c, poly) |> type == Intersecting
+
+  c = Ring([cart(-1, 0), cart(2, 0), cart(2, -2), cart(-1, -2)])
+  @test intersection(c, poly) |> type == Intersecting
+
+  # CASE 2: touches polygon at edge only
+  c = Rope([cart(-2, 2), cart(0, 2), cart(-2, 3)])
+  @test intersection(c, poly) |> type == Touching
+  @test c ∩ poly ≈ cart(0, 2)
+
+  # CASE 2: touches polygon at corner only
+  c = Rope([cart(-2, -1), cart(0, 0), cart(-1, -2)])
+  @test intersection(c, poly) |> type == Touching
+  @test c ∩ poly ≈ cart(0, 0)
+
+  c = Ring([cart(-2, -2), cart(0, 0), cart(-2, 2), cart(-3, 0)])
+  @test intersection(c, poly) |> type == Touching
+  @test c ∩ poly ≈ cart(0, 0)
+
+  # CASE 2: multiple isolated touches
+  c = Rope([cart(-1, 1), cart(0, 1), cart(-1, 2), cart(0, 3), cart(-1, 3)])
+  @test intersection(c, poly) |> type == Touching
+  @test c ∩ poly ≈ GeometrySet([cart(0, 1), cart(0, 3)])
+
+  # CASE 2: mixture of EdgeTouching and CornerTouching
+  # should still collapse to Touching at the Rope-Polygon level
+  c = Rope([cart(-1, 2), cart(0, 2), cart(-1, 1), cart(0, 0), cart(-1, -1)])
+  @test intersection(c, poly) |> type == Touching
+  @test c ∩ poly ≈ GeometrySet([cart(0, 2), cart(0, 0)])
+
+  # CASE 3: chain overlaps polygon boundary
+  c = Rope([cart(-1, 0), cart(2, 0), cart(5, 0)])
+  @test intersection(c, poly) |> type == EdgeTouching
+  @test c ∩ poly ≈ GeometrySet([Segment(cart(0, 0), cart(2, 0)), Segment(cart(2, 0), cart(4, 0))])
+
+  # CASE 4: chain completely outside polygon
+  c = Rope([cart(-3, 1), cart(-2, 2), cart(-1, 3)])
+  @test intersection(c, poly) |> type == NotIntersecting
+  @test isnothing(c ∩ poly)
+
+  c₁ = Ring([cart(-3, -3), cart(-1, -3), cart(-1, -1), cart(-3, -1)])
+  @test intersection(c₁, poly) |> type == NotIntersecting
+  @test isnothing(c₁ ∩ poly)
+
+  # CASE 4: bounding boxes overlap but geometries don't
+  c₂ = Rope([cart(-1, 3.5), cart(1, 5), cart(3, 5)])
+  @test intersection(c₂, poly) |> type == NotIntersecting
+  @test isnothing(c₂ ∩ poly)
+
+  # type stability
+  @inferred someornone(c₁, poly)
+  @inferred someornone(c₂, poly)
+end

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1259,7 +1259,7 @@ end
   # CASE 1: chain crosses polygon
   c = Rope([cart(-1, 2), cart(2, 2), cart(5, 2)])
   @test intersection(c, poly) |> type == Intersecting
-  @test c ∩ poly ≈ GeometrySet([Segment(cart(0, 2), cart(2, 2)), Segment(cart(2, 2), cart(4, 2))])
+  @test c ∩ poly ≈ Multi([Segment(cart(0, 2), cart(2, 2)), Segment(cart(2, 2), cart(4, 2))])
 
   c = Ring([cart(-1, 1), cart(2, 1), cart(2, 3), cart(-1, 3)])
   @test intersection(c, poly) |> type == Intersecting
@@ -1271,7 +1271,7 @@ end
   # CASE 1: chain entirely inside polygon
   c = Rope([cart(1, 1), cart(2, 2), cart(3, 1)])
   @test intersection(c, poly) |> type == Intersecting
-  @test c ∩ poly ≈ GeometrySet([Segment(cart(1, 1), cart(2, 2)), Segment(cart(2, 2), cart(3, 1))])
+  @test c ∩ poly ≈ Multi([Segment(cart(1, 1), cart(2, 2)), Segment(cart(2, 2), cart(3, 1))])
 
   c = Ring([cart(1, 1), cart(3, 1), cart(3, 3), cart(1, 3)])
   @test intersection(c, poly) |> type == Intersecting
@@ -1300,18 +1300,18 @@ end
   # CASE 2: multiple isolated touches
   c = Rope([cart(-1, 1), cart(0, 1), cart(-1, 2), cart(0, 3), cart(-1, 3)])
   @test intersection(c, poly) |> type == Touching
-  @test c ∩ poly ≈ GeometrySet([cart(0, 1), cart(0, 3)])
+  @test c ∩ poly ≈ Multi([cart(0, 1), cart(0, 3)])
 
   # CASE 2: mixture of EdgeTouching and CornerTouching
   # should still collapse to Touching at the Rope-Polygon level
   c = Rope([cart(-1, 2), cart(0, 2), cart(-1, 1), cart(0, 0), cart(-1, -1)])
   @test intersection(c, poly) |> type == Touching
-  @test c ∩ poly ≈ GeometrySet([cart(0, 2), cart(0, 0)])
+  @test c ∩ poly ≈ Multi([cart(0, 2), cart(0, 0)])
 
   # CASE 3: chain overlaps polygon boundary
   c = Rope([cart(-1, 0), cart(2, 0), cart(5, 0)])
   @test intersection(c, poly) |> type == EdgeTouching
-  @test c ∩ poly ≈ GeometrySet([Segment(cart(0, 0), cart(2, 0)), Segment(cart(2, 0), cart(4, 0))])
+  @test c ∩ poly ≈ Multi([Segment(cart(0, 0), cart(2, 0)), Segment(cart(2, 0), cart(4, 0))])
 
   # CASE 4: chain completely outside polygon
   c = Rope([cart(-3, 1), cart(-2, 2), cart(-1, 3)])

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -666,6 +666,100 @@ end
   r = Rope(cart(0, 0), cart(1, 1))
   @test r ∩ r == GeometrySet([Segment(cart(0, 0), cart(1, 1))])
   @inferred someornone(r, r)
+
+  # CASE 1: chain crosses polygon
+  r = Rope([cart(-1, 2), cart(2, 2), cart(5, 2)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Intersecting
+  @test r ∩ p ≈ p ∩ r ≈ Multi([Segment(cart(0, 2), cart(2, 2)), Segment(cart(2, 2), cart(4, 2))])
+
+  r = Ring([cart(-1, 1), cart(2, 1), cart(2, 3), cart(-1, 3)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Intersecting
+
+  # CASE 1: one segment inside, others outside
+  r = Rope([cart(-1, 2), cart(1, 2), cart(3, 2), cart(5, 2)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Intersecting
+
+  # CASE 1: chain entirely inside polygon
+  r = Rope([cart(1, 1), cart(2, 2), cart(3, 1)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Intersecting
+  @test r ∩ p ≈ p ∩ r ≈ Multi([Segment(cart(1, 1), cart(2, 2)), Segment(cart(2, 2), cart(3, 1))])
+
+  r = Ring([cart(1, 1), cart(3, 1), cart(3, 3), cart(1, 3)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Intersecting
+
+  # CASE 1: mixed touching and intersecting
+  r = Rope([cart(-1, 0), cart(0, 0), cart(2, 2), cart(5, 2)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Intersecting
+
+  r = Ring([cart(-1, 0), cart(2, 0), cart(2, -2), cart(-1, -2)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Intersecting
+
+  # CASE 2: touches polygon at edge only
+  r = Rope([cart(-2, 2), cart(0, 2), cart(-2, 3)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Touching
+  @test r ∩ p ≈ p ∩ r ≈ cart(0, 2)
+
+  # CASE 2: touches polygon at corner only
+  r = Rope([cart(-2, -1), cart(0, 0), cart(-1, -2)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Touching
+  @test r ∩ p ≈ p ∩ r ≈ cart(0, 0)
+
+  r = Ring([cart(-2, -2), cart(0, 0), cart(-2, 2), cart(-3, 0)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Touching
+  @test r ∩ p ≈ p ∩ r ≈ cart(0, 0)
+
+  # CASE 2: multiple isolated touches
+  r = Rope([cart(-1, 1), cart(0, 1), cart(-1, 2), cart(0, 3), cart(-1, 3)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Touching
+  @test r ∩ p ≈ p ∩ r ≈ Multi([cart(0, 1), cart(0, 3)])
+
+  # CASE 2: mixture of EdgeTouching and CornerTouching
+  # should still collapse to Touching at the Rope-Polygon level
+  r = Rope([cart(-1, 2), cart(0, 2), cart(-1, 1), cart(0, 0), cart(-1, -1)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == Touching
+  @test r ∩ p ≈ p ∩ r ≈ Multi([cart(0, 2), cart(0, 0)])
+
+  # CASE 3: chain overlaps polygon boundary
+  r = Rope([cart(-1, 0), cart(2, 0), cart(5, 0)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == EdgeTouching
+  @test r ∩ p ≈ p ∩ r ≈ Multi([Segment(cart(0, 0), cart(2, 0)), Segment(cart(2, 0), cart(4, 0))])
+
+  # CASE 4: chain completely outside polygon
+  r = Rope([cart(-3, 1), cart(-2, 2), cart(-1, 3)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == NotIntersecting
+  @test r ∩ p === p ∩ r === nothing
+
+  r = Ring([cart(-3, -3), cart(-1, -3), cart(-1, -1), cart(-3, -1)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == NotIntersecting
+  @test r ∩ p === p ∩ r === nothing
+
+  # CASE 4: bounding boxes overlap but geometries don't
+  r = Rope([cart(-1, 3.5), cart(1, 5), cart(3, 5)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @test intersection(r, p) |> type == NotIntersecting
+  @test r ∩ p === p ∩ r === nothing
+
+  # type stability
+  r₁ = Ring([cart(-3, -3), cart(-1, -3), cart(-1, -1), cart(-3, -1)])
+  r₂ = Rope([cart(-1, 3.5), cart(1, 5), cart(3, 5)])
+  p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  @inferred someornone(r₁, p)
+  @inferred someornone(r₂, p)
 end
 
 @testitem "Plane intersection" setup = [Setup] begin
@@ -1251,83 +1345,4 @@ end
   @test pset ∩ pset == pset
   @test pset ∩ grid == grid ∩ pset == pset
   @test pset ∩ ball == ball ∩ pset == PointSet(cart(0.5, 0.5))
-end
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
-@testitem "Chain-Polygon intersection" setup = [Setup] begin
-  poly = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
-
-  # CASE 1: chain crosses polygon
-  c = Rope([cart(-1, 2), cart(2, 2), cart(5, 2)])
-  @test intersection(c, poly) |> type == Intersecting
-  @test c ∩ poly ≈ Multi([Segment(cart(0, 2), cart(2, 2)), Segment(cart(2, 2), cart(4, 2))])
-
-  c = Ring([cart(-1, 1), cart(2, 1), cart(2, 3), cart(-1, 3)])
-  @test intersection(c, poly) |> type == Intersecting
-
-  # CASE 1: one segment inside, others outside
-  c = Rope([cart(-1, 2), cart(1, 2), cart(3, 2), cart(5, 2)])
-  @test intersection(c, poly) |> type == Intersecting
-
-  # CASE 1: chain entirely inside polygon
-  c = Rope([cart(1, 1), cart(2, 2), cart(3, 1)])
-  @test intersection(c, poly) |> type == Intersecting
-  @test c ∩ poly ≈ Multi([Segment(cart(1, 1), cart(2, 2)), Segment(cart(2, 2), cart(3, 1))])
-
-  c = Ring([cart(1, 1), cart(3, 1), cart(3, 3), cart(1, 3)])
-  @test intersection(c, poly) |> type == Intersecting
-
-  # CASE 1: mixed touching and intersecting
-  c = Rope([cart(-1, 0), cart(0, 0), cart(2, 2), cart(5, 2)])
-  @test intersection(c, poly) |> type == Intersecting
-
-  c = Ring([cart(-1, 0), cart(2, 0), cart(2, -2), cart(-1, -2)])
-  @test intersection(c, poly) |> type == Intersecting
-
-  # CASE 2: touches polygon at edge only
-  c = Rope([cart(-2, 2), cart(0, 2), cart(-2, 3)])
-  @test intersection(c, poly) |> type == Touching
-  @test c ∩ poly ≈ cart(0, 2)
-
-  # CASE 2: touches polygon at corner only
-  c = Rope([cart(-2, -1), cart(0, 0), cart(-1, -2)])
-  @test intersection(c, poly) |> type == Touching
-  @test c ∩ poly ≈ cart(0, 0)
-
-  c = Ring([cart(-2, -2), cart(0, 0), cart(-2, 2), cart(-3, 0)])
-  @test intersection(c, poly) |> type == Touching
-  @test c ∩ poly ≈ cart(0, 0)
-
-  # CASE 2: multiple isolated touches
-  c = Rope([cart(-1, 1), cart(0, 1), cart(-1, 2), cart(0, 3), cart(-1, 3)])
-  @test intersection(c, poly) |> type == Touching
-  @test c ∩ poly ≈ Multi([cart(0, 1), cart(0, 3)])
-
-  # CASE 2: mixture of EdgeTouching and CornerTouching
-  # should still collapse to Touching at the Rope-Polygon level
-  c = Rope([cart(-1, 2), cart(0, 2), cart(-1, 1), cart(0, 0), cart(-1, -1)])
-  @test intersection(c, poly) |> type == Touching
-  @test c ∩ poly ≈ Multi([cart(0, 2), cart(0, 0)])
-
-  # CASE 3: chain overlaps polygon boundary
-  c = Rope([cart(-1, 0), cart(2, 0), cart(5, 0)])
-  @test intersection(c, poly) |> type == EdgeTouching
-  @test c ∩ poly ≈ Multi([Segment(cart(0, 0), cart(2, 0)), Segment(cart(2, 0), cart(4, 0))])
-
-  # CASE 4: chain completely outside polygon
-  c = Rope([cart(-3, 1), cart(-2, 2), cart(-1, 3)])
-  @test intersection(c, poly) |> type == NotIntersecting
-  @test isnothing(c ∩ poly)
-
-  c₁ = Ring([cart(-3, -3), cart(-1, -3), cart(-1, -1), cart(-3, -1)])
-  @test intersection(c₁, poly) |> type == NotIntersecting
-  @test isnothing(c₁ ∩ poly)
-
-  # CASE 4: bounding boxes overlap but geometries don't
-  c₂ = Rope([cart(-1, 3.5), cart(1, 5), cart(3, 5)])
-  @test intersection(c₂, poly) |> type == NotIntersecting
-  @test isnothing(c₂ ∩ poly)
-
-  # type stability
-  @inferred someornone(c₁, poly)
-  @inferred someornone(c₂, poly)
 end

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -667,88 +667,93 @@ end
   @test r ∩ r == Segment(cart(0, 0), cart(1, 1))
   @inferred someornone(r, r)
 
-  # CASE 1: chain crosses polygon
+  # chain crosses polygon
   r = Rope([cart(-1, 2), cart(2, 2), cart(5, 2)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Intersecting
   @test r ∩ p ≈ p ∩ r ≈ Multi([Segment(cart(0, 2), cart(2, 2)), Segment(cart(2, 2), cart(4, 2))])
 
+  # chain crosses polygon
   r = Ring([cart(-1, 1), cart(2, 1), cart(2, 3), cart(-1, 3)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Intersecting
 
-  # CASE 1: one segment inside, others outside
+  # one segment inside, others outside
   r = Rope([cart(-1, 2), cart(1, 2), cart(3, 2), cart(5, 2)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Intersecting
 
-  # CASE 1: chain entirely inside polygon
+  # chain entirely inside polygon
   r = Rope([cart(1, 1), cart(2, 2), cart(3, 1)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Intersecting
   @test r ∩ p ≈ p ∩ r ≈ Multi([Segment(cart(1, 1), cart(2, 2)), Segment(cart(2, 2), cart(3, 1))])
 
+  # chain entirely inside polygon
   r = Ring([cart(1, 1), cart(3, 1), cart(3, 3), cart(1, 3)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Intersecting
 
-  # CASE 1: mixed touching and intersecting
+  # mixed touching and intersecting
   r = Rope([cart(-1, 0), cart(0, 0), cart(2, 2), cart(5, 2)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Intersecting
 
+  # chain touching polygon
   r = Ring([cart(-1, 0), cart(2, 0), cart(2, -2), cart(-1, -2)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Intersecting
 
-  # CASE 2: touches polygon at edge only
+  # chain vertex touches polygon edge
   r = Rope([cart(-2, 2), cart(0, 2), cart(-2, 3)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Touching
   @test r ∩ p ≈ p ∩ r ≈ cart(0, 2)
 
-  # CASE 2: touches polygon at corner only
+  # chain vertex touches polygon vertex
   r = Rope([cart(-2, -1), cart(0, 0), cart(-1, -2)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Touching
   @test r ∩ p ≈ p ∩ r ≈ cart(0, 0)
 
+  # chain vertex touches polygon vertex
   r = Ring([cart(-2, -2), cart(0, 0), cart(-2, 2), cart(-3, 0)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Touching
   @test r ∩ p ≈ p ∩ r ≈ cart(0, 0)
 
-  # CASE 2: multiple isolated touches
+  # multiple isolated touches
   r = Rope([cart(-1, 1), cart(0, 1), cart(-1, 2), cart(0, 3), cart(-1, 3)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Touching
   @test r ∩ p ≈ p ∩ r ≈ Multi([cart(0, 1), cart(0, 3)])
 
-  # CASE 2: mixture of EdgeTouching and CornerTouching
+  # mixture of EdgeTouching and CornerTouching
   # should still collapse to Touching at the Rope-Polygon level
   r = Rope([cart(-1, 2), cart(0, 2), cart(-1, 1), cart(0, 0), cart(-1, -1)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == Touching
   @test r ∩ p ≈ p ∩ r ≈ Multi([cart(0, 2), cart(0, 0)])
 
-  # CASE 3: chain overlaps polygon boundary
+  # chain overlaps polygon boundary
   r = Rope([cart(-1, 0), cart(2, 0), cart(5, 0)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == EdgeTouching
   @test r ∩ p ≈ p ∩ r ≈ Multi([Segment(cart(0, 0), cart(2, 0)), Segment(cart(2, 0), cart(4, 0))])
 
-  # CASE 4: chain completely outside polygon
+  # chain completely outside polygon
   r = Rope([cart(-3, 1), cart(-2, 2), cart(-1, 3)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == NotIntersecting
   @test r ∩ p === p ∩ r === nothing
 
+  # chain completely outside polygon
   r = Ring([cart(-3, -3), cart(-1, -3), cart(-1, -1), cart(-3, -1)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == NotIntersecting
   @test r ∩ p === p ∩ r === nothing
 
-  # CASE 4: bounding boxes overlap but geometries don't
+  # bounding boxes overlap but geometries don't
   r = Rope([cart(-1, 3.5), cart(1, 5), cart(3, 5)])
   p = Quadrangle(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
   @test intersection(r, p) |> type == NotIntersecting

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -664,7 +664,7 @@ end
 @testitem "Chain intersection" setup = [Setup] begin
   # https://github.com/JuliaGeometry/Meshes.jl/issues/644
   r = Rope(cart(0, 0), cart(1, 1))
-  @test r ∩ r == GeometrySet([Segment(cart(0, 0), cart(1, 1))])
+  @test r ∩ r == Segment(cart(0, 0), cart(1, 1))
   @inferred someornone(r, r)
 
   # CASE 1: chain crosses polygon
@@ -1286,7 +1286,7 @@ end
   )
   r = Ray(cart(-1.0, -1.0, -1.0), vector(1.0, 1.0, 1.0))
   @test intersection(r, o) |> type == Intersecting
-  @test r ∩ o == PointSet(cart(0.0, 0.0, 0.0))
+  @test r ∩ o == cart(0.0, 0.0, 0.0)
   r = Ray(cart(-1.0, -1.0, -1.0), vector(-1.0, -1.0, -1.0))
   @test intersection(r, o) |> type == NotIntersecting
   @test isnothing(r ∩ o)
@@ -1340,9 +1340,11 @@ end
 
 @testitem "Domain intersection" setup = [Setup] begin
   grid = cartgrid(4, 4)
-  pset = PointSet(centroid.(grid))
+  cent = centroid.(grid)
+  pset = PointSet(cent)
+  mult = Multi(cent)
   ball = Ball(cart(0, 0), T(1))
-  @test pset ∩ pset == pset
-  @test pset ∩ grid == grid ∩ pset == pset
-  @test pset ∩ ball == ball ∩ pset == PointSet(cart(0.5, 0.5))
+  @test pset ∩ pset == mult
+  @test pset ∩ grid == grid ∩ pset == mult
+  @test pset ∩ ball == ball ∩ pset == cart(0.5, 0.5)
 end


### PR DESCRIPTION
This PR is a continuation of PR #1397 and addresses to Issue #646 by implementing the `Chain`-`Polygon` intersection method. The implementation builds heavily on the previously introduced `Segment`-`Polygon` intersection method, applying it to each segment that composes the chain and combining the resulting intersections.

Importantly, this method does not apply any additional pruning strategy to avoid duplicating effort, as the `Segment`-`Polygon` method already performs pruning by checking for bounding-box intersections.

**Result**: For my simple tests and applications, the method is working just fine, but I have not stress tested it.