### PR TITLE
Add geometric distances between points

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,11 +28,11 @@ makedocs(
         "algorithms/sideof.md",
         "algorithms/orientation.md",
         "algorithms/neighborsearch.md",
-        "algorithms/distances.md",
         "algorithms/boundingbox.md",
         "algorithms/hulls.md"
       ],
       "Transforms" => "transforms.md",
+      "Distances" => "distances.md",
       "Calculus" => "calculus.md",
       "Random" => "rand.md",
       "Visualization" => "visualization.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(
         "algorithms/sideof.md",
         "algorithms/orientation.md",
         "algorithms/neighborsearch.md",
+        "algorithms/distances.md",
         "algorithms/boundingbox.md",
         "algorithms/hulls.md"
       ],

--- a/docs/src/algorithms/distances.md
+++ b/docs/src/algorithms/distances.md
@@ -12,7 +12,6 @@ is available at compile time.
 ```@docs
 GeometricDistance
 EuclideanDistance
-ManhattanDistance
 GeodesicDistance
 ```
 

--- a/docs/src/algorithms/distances.md
+++ b/docs/src/algorithms/distances.md
@@ -1,0 +1,40 @@
+# Distances
+
+```@example distances
+using Meshes # hide
+using CoordRefSystems # hide
+```
+
+Distances are functors that are evaluated with a pair of points. The
+definition that is used depends on the manifold of the points, which
+is available at compile time.
+
+```@docs
+GeometricDistance
+EuclideanDistance
+ManhattanDistance
+GeodesicDistance
+```
+
+In Euclidean space the Euclidean distance is the length of the straight
+line connecting the points:
+
+```@example distances
+d = EuclideanDistance()
+
+d(Point(0, 0), Point(3, 4))
+```
+
+On the ellipsoid the same distance is the chord that goes through the
+interior of the Earth, whereas the geodesic distance is the length of
+the shortest path along the surface:
+
+```@example distances
+sydney = Point(LatLon(-33.8688, 151.2093))
+london = Point(LatLon(51.5074, -0.1278))
+
+EuclideanDistance()(sydney, london), GeodesicDistance()(sydney, london)
+```
+
+The ellipsoid is taken from the datum of the coordinate reference system,
+so points stored in a different datum are measured on a different ellipsoid.

--- a/docs/src/distances.md
+++ b/docs/src/distances.md
@@ -36,4 +36,4 @@ EuclideanDistance()(sydney, london), GeodesicDistance()(sydney, london)
 ```
 
 The ellipsoid is taken from the datum of the coordinate reference system,
-so points stored in a different datum are measured on a different ellipsoid.
+so all parameters are retrieved automatically for the user.

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -619,6 +619,12 @@ export
   isinvertible,
   inverse,
 
+  # distances
+  GeometricDistance,
+  EuclideanDistance,
+  ManhattanDistance,
+  GeodesicDistance,
+
   # miscellaneous
   laplacematrix,
   measurematrix,

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -622,7 +622,6 @@ export
   # distances
   GeometricDistance,
   EuclideanDistance,
-  ManhattanDistance,
   GeodesicDistance,
 
   # miscellaneous

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -135,9 +135,11 @@ include("coarsening.jl")
 # transforms
 include("transforms.jl")
 
+# distances
+include("distances.jl")
+
 # miscellaneous
 include("rand.jl")
-include("distances.jl")
 include("supportfun.jl")
 include("matrices.jl")
 include("projecting.jl")

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -45,24 +45,6 @@ struct EuclideanDistance <: GeometricDistance end
 (::EuclideanDistance)(p₁::Point{M}, p₂::Point{M}) where {M} = norm(p₂ - p₁)
 
 """
-    ManhattanDistance()
-
-Sum of the absolute differences of the coordinates of two points
-in Euclidean space (`𝔼`), also known as the taxicab distance.
-
-## Examples
-
-```julia
-d = ManhattanDistance()
-
-d(Point(0, 0), Point(1, 1))
-```
-"""
-struct ManhattanDistance <: GeometricDistance end
-
-(::ManhattanDistance)(p₁::Point{𝔼{Dim}}, p₂::Point{𝔼{Dim}}) where {Dim} = sum(abs, p₂ - p₁)
-
-"""
     GeodesicDistance()
 
 Length of the shortest path along the manifold of two points.
@@ -98,18 +80,15 @@ function (::GeodesicDistance)(p₁::Point{🌐}, p₂::Point{🌐})
   # the manifold only tells us that the points lie on a sphere,
   # the ellipsoid itself comes from the datum of the coordinates
   🌎 = ellipsoid(datum(c₁))
-  a = majoraxis(🌎)
-  f = flattening(🌎)
 
   T = numtype(lentype(q₁))
   # the series of Karney need double precision to reach round-off
   S = promote_type(T, Float64)
-  g = GeodesicEllipsoid(S(ustrip(a)), S(f))
 
   lat₁, lon₁ = S(ustrip(u"°", c₁.lat)), S(ustrip(u"°", c₁.lon))
   lat₂, lon₂ = S(ustrip(u"°", c₂.lat)), S(ustrip(u"°", c₂.lon))
 
-  T(_geodesic(g, lat₁, lon₁, lat₂, lon₂)) * unit(a)
+  T(_geodesic(🌎, lat₁, lon₁, lat₂, lon₂)) * unit(majoraxis(🌎))
 end
 
 # ----------------

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -2,6 +2,126 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
+"""
+    GeometricDistance
+
+A distance between points that is meaningful in physical settings.
+
+Distances are functors, and are evaluated with a pair of points:
+
+```julia
+d = EuclideanDistance()
+
+d(p₁, p₂)
+```
+
+The definition that is used depends on the manifold of the points,
+which is available at compile time.
+"""
+abstract type GeometricDistance end
+
+"""
+    EuclideanDistance()
+
+Length of the straight line connecting two points in the space
+where they are embedded. For points on the ellipsoid (`🌐`) this
+is the chord through the interior of the ellipsoid, which is
+shorter than any path along the surface.
+
+See also [`GeodesicDistance`](@ref).
+
+## Examples
+
+```julia
+d = EuclideanDistance()
+
+d(Point(0, 0), Point(1, 1))
+
+d(Point(LatLon(0, 0)), Point(LatLon(0, 1)))
+```
+"""
+struct EuclideanDistance <: GeometricDistance end
+
+(::EuclideanDistance)(p₁::Point{M}, p₂::Point{M}) where {M} = norm(p₂ - p₁)
+
+"""
+    ManhattanDistance()
+
+Sum of the absolute differences of the coordinates of two points
+in Euclidean space (`𝔼`), also known as the taxicab distance.
+
+## Examples
+
+```julia
+d = ManhattanDistance()
+
+d(Point(0, 0), Point(1, 1))
+```
+"""
+struct ManhattanDistance <: GeometricDistance end
+
+(::ManhattanDistance)(p₁::Point{𝔼{Dim}}, p₂::Point{𝔼{Dim}}) where {Dim} = sum(abs, p₂ - p₁)
+
+"""
+    GeodesicDistance()
+
+Length of the shortest path along the manifold of two points.
+In Euclidean space (`𝔼`) this is the straight line connecting
+them. On the ellipsoid (`🌐`) this is the geodesic of the
+ellipsoid attached to the datum of the coordinate reference
+system, and is computed with the series of Karney (2013).
+
+See also [`EuclideanDistance`](@ref).
+
+## Examples
+
+```julia
+d = GeodesicDistance()
+
+d(Point(LatLon(0, 0)), Point(LatLon(0, 1)))
+```
+
+## References
+
+* Karney, C. F. F. 2013. [Algorithms for geodesics]
+  (https://doi.org/10.1007/s00190-012-0578-0)
+"""
+struct GeodesicDistance <: GeometricDistance end
+
+(::GeodesicDistance)(p₁::Point{𝔼{Dim}}, p₂::Point{𝔼{Dim}}) where {Dim} = norm(p₂ - p₁)
+
+function (::GeodesicDistance)(p₁::Point{🌐}, p₂::Point{🌐})
+  q₁, q₂ = promote(p₁, p₂)
+  c₁ = convert(manifoldcrs(q₁), coords(q₁))
+  c₂ = convert(manifoldcrs(q₂), coords(q₂))
+
+  # the manifold only tells us that the points lie on a sphere,
+  # the ellipsoid itself comes from the datum of the coordinates
+  🌎 = ellipsoid(datum(c₁))
+  a = majoraxis(🌎)
+  f = flattening(🌎)
+
+  T = numtype(lentype(q₁))
+  # the series of Karney need double precision to reach round-off
+  S = promote_type(T, Float64)
+  g = GeodesicEllipsoid(S(ustrip(a)), S(f))
+
+  lat₁, lon₁ = S(ustrip(u"°", c₁.lat)), S(ustrip(u"°", c₁.lon))
+  lat₂, lon₂ = S(ustrip(u"°", c₂.lat)), S(ustrip(u"°", c₂.lon))
+
+  T(_geodesic(g, lat₁, lon₁, lat₂, lon₂)) * unit(a)
+end
+
+# ----------------
+# IMPLEMENTATIONS
+# ----------------
+
+include("distances/geodesic.jl")
+
+# ---------------
+# DISTANCES.JL
+# ---------------
+
 # flip arguments so that points always come first
 evaluate(d::PreMetric, g::Geometry, p::Point) = evaluate(d, p, g)
 

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -20,86 +20,16 @@ which is available at compile time.
 """
 abstract type GeometricDistance end
 
-"""
-    EuclideanDistance()
-
-Length of the straight line connecting two points in the space
-where they are embedded. For points on the ellipsoid (`🌐`) this
-is the chord through the interior of the ellipsoid, which is
-shorter than any path along the surface.
-
-See also [`GeodesicDistance`](@ref).
-
-## Examples
-
-```julia
-d = EuclideanDistance()
-
-d(Point(0, 0), Point(1, 1))
-
-d(Point(LatLon(0, 0)), Point(LatLon(0, 1)))
-```
-"""
-struct EuclideanDistance <: GeometricDistance end
-
-(::EuclideanDistance)(p₁::Point{M}, p₂::Point{M}) where {M} = norm(p₂ - p₁)
-
-"""
-    GeodesicDistance()
-
-Length of the shortest path along the manifold of two points.
-In Euclidean space (`𝔼`) this is the straight line connecting
-them. On the ellipsoid (`🌐`) this is the geodesic of the
-ellipsoid attached to the datum of the coordinate reference
-system, and is computed with the series of Karney (2013).
-
-See also [`EuclideanDistance`](@ref).
-
-## Examples
-
-```julia
-d = GeodesicDistance()
-
-d(Point(LatLon(0, 0)), Point(LatLon(0, 1)))
-```
-
-## References
-
-* Karney, C. F. F. 2013. [Algorithms for geodesics]
-  (https://doi.org/10.1007/s00190-012-0578-0)
-"""
-struct GeodesicDistance <: GeometricDistance end
-
-(::GeodesicDistance)(p₁::Point{𝔼{Dim}}, p₂::Point{𝔼{Dim}}) where {Dim} = norm(p₂ - p₁)
-
-function (::GeodesicDistance)(p₁::Point{🌐}, p₂::Point{🌐})
-  q₁, q₂ = promote(p₁, p₂)
-  c₁ = convert(manifoldcrs(q₁), coords(q₁))
-  c₂ = convert(manifoldcrs(q₂), coords(q₂))
-
-  # the manifold only tells us that the points lie on a sphere,
-  # the ellipsoid itself comes from the datum of the coordinates
-  🌎 = ellipsoid(datum(c₁))
-
-  T = numtype(lentype(q₁))
-  # the series of Karney need double precision to reach round-off
-  S = promote_type(T, Float64)
-
-  lat₁, lon₁ = S(ustrip(u"°", c₁.lat)), S(ustrip(u"°", c₁.lon))
-  lat₂, lon₂ = S(ustrip(u"°", c₂.lat)), S(ustrip(u"°", c₂.lon))
-
-  T(_geodesic(🌎, lat₁, lon₁, lat₂, lon₂)) * unit(majoraxis(🌎))
-end
-
 # ----------------
 # IMPLEMENTATIONS
 # ----------------
 
+include("distances/euclidean.jl")
 include("distances/geodesic.jl")
 
-# ---------------
+# -------------
 # DISTANCES.JL
-# ---------------
+# -------------
 
 # flip arguments so that points always come first
 evaluate(d::PreMetric, g::Geometry, p::Point) = evaluate(d, p, g)

--- a/src/distances/euclidean.jl
+++ b/src/distances/euclidean.jl
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    EuclideanDistance()
+
+Length of the straight line connecting two points in the space
+where they are embedded. For points on the ellipsoid (`🌐`) this
+is the chord through the interior of the ellipsoid, which is
+shorter than any path along the surface.
+
+See also [`GeodesicDistance`](@ref).
+
+## Examples
+
+```julia
+d = EuclideanDistance()
+
+d(Point(0, 0), Point(1, 1))
+
+d(Point(LatLon(0, 0)), Point(LatLon(0, 1)))
+```
+"""
+struct EuclideanDistance <: GeometricDistance end
+
+(::EuclideanDistance)(p₁::Point{M}, p₂::Point{M}) where {M} = norm(p₂ - p₁)

--- a/src/distances/geodesic.jl
+++ b/src/distances/geodesic.jl
@@ -12,6 +12,9 @@
 # bisected whenever a Newton step leaves the legal range. This keeps the
 # solution accurate for nearly antipodal points, where the simpler series
 # of Vincenty fails to converge.
+#
+# Only oblate ellipsoids are handled, which is what CoordRefSystems.jl can
+# represent, so the prolate branches of the reference algorithm are omitted.
 
 # ---------------
 # ANGLE UTILITIES
@@ -163,30 +166,23 @@ end
 # INVERSE PROBLEM
 # ----------------
 
-# constants of the ellipsoid that are reused across the iteration
-struct GeodesicEllipsoid{T}
-  a::T
-  f::T
-  f₁::T
-  e′²::T
-  n::T
-  b::T
-  a₃::NTuple{6,T}
-  c₃::Tuple{NTuple{5,T},NTuple{4,T},NTuple{3,T},NTuple{2,T},NTuple{1,T}}
-  τ::T
-end
-
-function GeodesicEllipsoid(a::T, f::T) where {T}
+# quantities that Karney's series need on top of the parameters that
+# CoordRefSystems.jl already provides for the ellipsoid of revolution
+function _geodesicparams(🌎::Type{<:RevolutionEllipsoid}, ::Type{T}) where {T}
+  a = T(ustrip(majoraxis(🌎)))
+  b = T(ustrip(minoraxis(🌎)))
+  f = T(flattening(🌎))
+  e² = T(eccentricity²(🌎))
   f₁ = 1 - f
-  e² = f * (2 - f)
-  n = f / (2 - f)
+  e′² = e² / (1 - e²)  # second eccentricity squared
+  n = f / (2 - f)      # third flattening
   # threshold on σ₁₂ below which the auxiliary sphere solution is accurate enough
   τ = T(0.1) * sqrt(eps(T)) / sqrt(max(T(0.001), abs(f)) * min(one(T), 1 - f / 2) / 2)
-  GeodesicEllipsoid{T}(a, f, f₁, e² / (f₁ * f₁), n, a * f₁, _A3coeffs(n), _C3coeffs(n), τ)
+  (; a, b, f, f₁, e′², n, a₃=_A3coeffs(n), c₃=_C3coeffs(n), τ)
 end
 
 # distance and reduced length divided by the polar semi-axis (Karney, eq. 15 and 38)
-function _lengths(🌎::GeodesicEllipsoid, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+function _lengths(𝐠, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
   A₁ = _A1m1(ε)
   A₂ = _A2m1(ε)
   C₁ = _C1(ε)
@@ -230,7 +226,7 @@ function _astroid(x::T, y::T) where {T}
 end
 
 # starting azimuth for Newton's method (Karney, section 5)
-function _inversestart(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂) where {T}
+function _inversestart(𝐠, sβ₁::T, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂) where {T}
   σ₁₂ = -one(T)
   dnₘ = one(T)
   sβ₁₂ = sβ₂ * cβ₁ - cβ₂ * sβ₁
@@ -241,8 +237,8 @@ function _inversestart(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂
   if short
     sβₘ² = (sβ₁ + sβ₂)^2
     sβₘ² /= sβₘ² + (cβ₁ + cβ₂)^2
-    dnₘ = sqrt(1 + 🌎.e′² * sβₘ²)
-    sω₁₂, cω₁₂ = sincos(λ₁₂ / (🌎.f₁ * dnₘ))
+    dnₘ = sqrt(1 + 𝐠.e′² * sβₘ²)
+    sω₁₂, cω₁₂ = sincos(λ₁₂ / (𝐠.f₁ * dnₘ))
   else
     sω₁₂, cω₁₂ = sλ₁₂, cλ₁₂
   end
@@ -255,43 +251,29 @@ function _inversestart(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂
 
   sα₂ = zero(T)
   cα₂ = zero(T)
-  if short && sσ₁₂ < 🌎.τ
+  if short && sσ₁₂ < 𝐠.τ
     # really short line, no iteration needed
     sα₂ = cβ₁ * sω₁₂
     cα₂ = sβ₁₂ - cβ₁ * sβ₂ * (cω₁₂ ≥ 0 ? sω₁₂^2 / (1 + cω₁₂) : 1 - cω₁₂)
     sα₂, cα₂ = _hnorm(sα₂, cα₂)
     σ₁₂ = atan(sσ₁₂, cσ₁₂)
-  elseif !(abs(🌎.n) > T(0.1) || cσ₁₂ ≥ 0 || sσ₁₂ ≥ 6 * abs(🌎.n) * T(π) * cβ₁^2)
+  elseif !(abs(𝐠.n) > T(0.1) || cσ₁₂ ≥ 0 || sσ₁₂ ≥ 6 * abs(𝐠.n) * T(π) * cβ₁^2)
     # nearly antipodal, the spherical guess is useless and the astroid is solved
     # in a frame where the antipodal point is at the origin (Karney, section 5)
     λ₁₂ₓ = atan(-sλ₁₂, -cλ₁₂)
-    if 🌎.f ≥ 0
-      k² = sβ₁^2 * 🌎.e′²
-      ε = k² / (2 * (1 + sqrt(1 + k²)) + k²)
-      λscale = 🌎.f * cβ₁ * evalpoly(ε, 🌎.a₃) * T(π)
-      βscale = λscale * cβ₁
-      x = λ₁₂ₓ / λscale
-      y = sβ₁₂ₐ / βscale
-    else
-      β₁₂ₐ = atan(sβ₁₂ₐ, cβ₂ * cβ₁ - sβ₂ * sβ₁)
-      _, m₁₂, m₀ = _lengths(🌎, 🌎.n, T(π) + β₁₂ₐ, sβ₁, -cβ₁, dn₁, sβ₂, cβ₂, dn₂)
-      x = -1 + m₁₂ / (cβ₁ * cβ₂ * m₀ * T(π))
-      βscale = x < T(-0.01) ? sβ₁₂ₐ / x : -🌎.f * cβ₁^2 * T(π)
-      λscale = βscale / cβ₁
-      y = λ₁₂ₓ / λscale
-    end
+    k² = sβ₁^2 * 𝐠.e′²
+    ε = k² / (2 * (1 + sqrt(1 + k²)) + k²)
+    λscale = 𝐠.f * cβ₁ * evalpoly(ε, 𝐠.a₃) * T(π)
+    βscale = λscale * cβ₁
+    x = λ₁₂ₓ / λscale
+    y = sβ₁₂ₐ / βscale
     if y > -200eps(T) && x > -1 - 1000sqrt(eps(T))
       # strip near the cut
-      if 🌎.f ≥ 0
-        sα₁ = min(one(T), -x)
-        cα₁ = -sqrt(1 - sα₁^2)
-      else
-        cα₁ = max(x > -200eps(T) ? zero(T) : -one(T), x)
-        sα₁ = sqrt(1 - cα₁^2)
-      end
+      sα₁ = min(one(T), -x)
+      cα₁ = -sqrt(1 - sα₁^2)
     else
       k = _astroid(x, y)
-      ω₁₂ₐ = λscale * (🌎.f ≥ 0 ? -x * k / (1 + k) : -y * (1 + k) / k)
+      ω₁₂ₐ = -λscale * x * k / (1 + k)
       sω₁₂ = sin(ω₁₂ₐ)
       cω₁₂ = -cos(ω₁₂ₐ)
       sα₁ = cβ₂ * sω₁₂
@@ -309,7 +291,7 @@ function _inversestart(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂
 end
 
 # residual λ₁₂(α₁) - λ₁₂ and its derivative (Karney, section 4)
-function _lambda12(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, diff) where {T}
+function _lambda12(𝐠, sβ₁::T, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, diff) where {T}
   # break the degeneracy of the equatorial line
   (iszero(sβ₁) && iszero(cα₁)) && (cα₁ = -sqrt(floatmin(T)))
 
@@ -339,27 +321,28 @@ function _lambda12(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂, c�
   cω₁₂ = cω₁ * cω₂ + sω₁ * sω₂
   η = atan(sω₁₂ * cλ₁₂ - cω₁₂ * sλ₁₂, cω₁₂ * cλ₁₂ + sω₁₂ * sλ₁₂)
 
-  k² = cα₀^2 * 🌎.e′²
+  k² = cα₀^2 * 𝐠.e′²
   ε = k² / (2 * (1 + sqrt(1 + k²)) + k²)
-  C₃ = _C3(🌎.c₃, ε)
+  C₃ = _C3(𝐠.c₃, ε)
   B₃ = _sinseries(sσ₂, cσ₂, C₃) - _sinseries(sσ₁, cσ₁, C₃)
-  v = η - 🌎.f * evalpoly(ε, 🌎.a₃) * sα₀ * (σ₁₂ + B₃)
+  v = η - 𝐠.f * evalpoly(ε, 𝐠.a₃) * sα₀ * (σ₁₂ + B₃)
 
   # the derivative follows from the reduced length (Karney, eq. 38)
   dv = if !diff
     zero(T)
   elseif iszero(cα₂)
-    -2 * 🌎.f₁ * dn₁ / sβ₁
+    -2 * 𝐠.f₁ * dn₁ / sβ₁
   else
-    _, m₁₂, _ = _lengths(🌎, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
-    m₁₂ * 🌎.f₁ / (cα₂ * cβ₂)
+    _, m₁₂, _ = _lengths(𝐠, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+    m₁₂ * 𝐠.f₁ / (cα₂ * cβ₂)
   end
 
   (v, dv, σ₁₂, sσ₁, cσ₁, sσ₂, cσ₂, ε)
 end
 
 # length of the shortest geodesic between two points given in degrees
-function _geodesic(🌎::GeodesicEllipsoid{T}, lat₁::T, lon₁::T, lat₂::T, lon₂::T) where {T}
+function _geodesic(🌎::Type{<:RevolutionEllipsoid}, lat₁::T, lon₁::T, lat₂::T, lon₂::T) where {T}
+  𝐠 = _geodesicparams(🌎, T)
   tiny = sqrt(floatmin(T))
   tol = eps(T)
   maxit₁ = 20
@@ -386,11 +369,11 @@ function _geodesic(🌎::GeodesicEllipsoid{T}, lat₁::T, lon₁::T, lat₂::T, 
 
   # reduced latitudes
   sβ₁, cβ₁ = sincosd(lat₁)
-  sβ₁ *= 🌎.f₁
+  sβ₁ *= 𝐠.f₁
   sβ₁, cβ₁ = _hnorm(sβ₁, cβ₁)
   cβ₁ = max(tiny, cβ₁)
   sβ₂, cβ₂ = sincosd(lat₂)
-  sβ₂ *= 🌎.f₁
+  sβ₂ *= 𝐠.f₁
   sβ₂, cβ₂ = _hnorm(sβ₂, cβ₂)
   cβ₂ = max(tiny, cβ₂)
 
@@ -401,8 +384,8 @@ function _geodesic(🌎::GeodesicEllipsoid{T}, lat₁::T, lon₁::T, lat₂::T, 
     abs(sβ₂) == -sβ₁ && (cβ₂ = cβ₁)
   end
 
-  dn₁ = sqrt(1 + 🌎.e′² * sβ₁^2)
-  dn₂ = sqrt(1 + 🌎.e′² * sβ₂^2)
+  dn₁ = sqrt(1 + 𝐠.e′² * sβ₁^2)
+  dn₂ = sqrt(1 + 𝐠.e′² * sβ₂^2)
 
   s₁₂ = zero(T)
 
@@ -412,24 +395,20 @@ function _geodesic(🌎::GeodesicEllipsoid{T}, lat₁::T, lon₁::T, lat₂::T, 
     sσ₁, cσ₁ = sβ₁, cλ₁₂ * cβ₁
     sσ₂, cσ₂ = sβ₂, cβ₂
     σ₁₂ = atan(max(zero(T), cσ₁ * sσ₂ - sσ₁ * cσ₂), cσ₁ * cσ₂ + sσ₁ * sσ₂)
-    s₁₂, m₁₂, _ = _lengths(🌎, 🌎.n, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
-    if σ₁₂ < sqrt(tol) || m₁₂ ≥ 0
-      (σ₁₂ < 3tiny || (σ₁₂ < tol && (s₁₂ < 0 || m₁₂ < 0))) && (s₁₂ = zero(T))
-      s₁₂ *= 🌎.b
-    else
-      # prolate ellipsoid with points too close to antipodal
-      meridian = false
-    end
+    s₁₂, m₁₂, _ = _lengths(𝐠, 𝐠.n, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+    # zero length geodesics might yield a negative reduced length
+    (σ₁₂ < 3tiny || (σ₁₂ < tol && (s₁₂ < 0 || m₁₂ < 0))) && (s₁₂ = zero(T))
+    s₁₂ *= 𝐠.b
   end
 
-  if !meridian && iszero(sβ₁) && (🌎.f ≤ 0 || lon₁₂ₛ ≥ 🌎.f * 180)
+  if !meridian && iszero(sβ₁) && (iszero(𝐠.f) || lon₁₂ₛ ≥ 𝐠.f * 180)
     # the geodesic runs along the equator
-    s₁₂ = 🌎.a * λ₁₂
+    s₁₂ = 𝐠.a * λ₁₂
   elseif !meridian
-    σ₁₂, sα₁, cα₁, _, _, dnₘ = _inversestart(🌎, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂)
+    σ₁₂, sα₁, cα₁, _, _, dnₘ = _inversestart(𝐠, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂)
     if σ₁₂ ≥ 0
       # short line, the auxiliary sphere solution is accurate enough
-      s₁₂ = σ₁₂ * 🌎.b * dnₘ
+      s₁₂ = σ₁₂ * 𝐠.b * dnₘ
     else
       # Newton's method on the azimuth α₁, with a bracketing interval that is
       # bisected whenever a Newton step would leave the legal range
@@ -441,7 +420,7 @@ function _geodesic(🌎::GeodesicEllipsoid{T}, lat₁::T, lon₁::T, lat₂::T, 
       tripb = false
       while true
         v, dv, σ₁₂, sσ₁, cσ₁, sσ₂, cσ₂, ε =
-          _lambda12(🌎, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, numit < maxit₁)
+          _lambda12(𝐠, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, numit < maxit₁)
         (tripb || !(abs(v) ≥ (tripn ? 8 : 1) * tol) || numit == maxit₂) && break
 
         # shrink the bracketing interval
@@ -479,8 +458,8 @@ function _geodesic(🌎::GeodesicEllipsoid{T}, lat₁::T, lon₁::T, lat₂::T, 
 
         numit += 1
       end
-      s₁₂, _, _ = _lengths(🌎, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
-      s₁₂ *= 🌎.b
+      s₁₂, _, _ = _lengths(𝐠, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+      s₁₂ *= 𝐠.b
     end
   end
 

--- a/src/distances/geodesic.jl
+++ b/src/distances/geodesic.jl
@@ -2,6 +2,53 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
+"""
+    GeodesicDistance()
+
+Length of the shortest path along the manifold of two points.
+In Euclidean space (`𝔼`) this is the straight line connecting
+them. On the ellipsoid (`🌐`) this is the geodesic of the
+ellipsoid attached to the datum of the coordinate reference
+system, and is computed with the series of Karney (2013).
+
+See also [`EuclideanDistance`](@ref).
+
+## Examples
+
+```julia
+d = GeodesicDistance()
+
+d(Point(LatLon(0, 0)), Point(LatLon(0, 1)))
+```
+
+## References
+
+* Karney, C. F. F. 2013. [Algorithms for geodesics]
+  (https://doi.org/10.1007/s00190-012-0578-0)
+"""
+struct GeodesicDistance <: GeometricDistance end
+
+(::GeodesicDistance)(p₁::Point{𝔼{Dim}}, p₂::Point{𝔼{Dim}}) where {Dim} = norm(p₂ - p₁)
+
+function (::GeodesicDistance)(p₁::Point{🌐}, p₂::Point{🌐})
+  q₁, q₂ = promote(p₁, p₂)
+  c₁ = convert(manifoldcrs(q₁), coords(q₁))
+  c₂ = convert(manifoldcrs(q₂), coords(q₂))
+
+  # the manifold only tells us that the points lie on a sphere,
+  # the ellipsoid itself comes from the datum of the coordinates
+  🌎 = ellipsoid(datum(c₁))
+
+  # the series of Karney need double precision to reach round-off
+  T = numtype(lentype(c₁))
+  S = promote_type(T, Float64)
+
+  lat₁, lon₁ = S(ustrip(c₁.lat)), S(ustrip(c₁.lon))
+  lat₂, lon₂ = S(ustrip(c₂.lat)), S(ustrip(c₂.lon))
+
+  T(_geodesic(🌎, lat₁, lon₁, lat₂, lon₂)) * unit(majoraxis(🌎))
+end
+
 # Solution of the inverse geodesic problem on an ellipsoid of revolution
 # following Karney, C. F. F. 2013. Algorithms for geodesics. Journal of
 # Geodesy 87(1), 43-55. https://doi.org/10.1007/s00190-012-0578-0

--- a/src/distances/geodesic.jl
+++ b/src/distances/geodesic.jl
@@ -23,8 +23,7 @@ d(Point(LatLon(0, 0)), Point(LatLon(0, 1)))
 
 ## References
 
-* Karney, C. F. F. 2013. [Algorithms for geodesics]
-  (https://doi.org/10.1007/s00190-012-0578-0)
+* Karney, C. F. F. 2013. [Algorithms for geodesics](https://doi.org/10.1007/s00190-012-0578-z)
 """
 struct GeodesicDistance <: GeometricDistance end
 

--- a/src/distances/geodesic.jl
+++ b/src/distances/geodesic.jl
@@ -31,6 +31,7 @@ struct GeodesicDistance <: GeometricDistance end
 (::GeodesicDistance)(p₁::Point{𝔼{Dim}}, p₂::Point{𝔼{Dim}}) where {Dim} = norm(p₂ - p₁)
 
 function (::GeodesicDistance)(p₁::Point{🌐}, p₂::Point{🌐})
+  # convert coordinates to same LatLon CRS
   q₁, q₂ = promote(p₁, p₂)
   c₁ = convert(manifoldcrs(q₁), coords(q₁))
   c₂ = convert(manifoldcrs(q₂), coords(q₂))
@@ -42,7 +43,6 @@ function (::GeodesicDistance)(p₁::Point{🌐}, p₂::Point{🌐})
   # the series of Karney need double precision to reach round-off
   T = numtype(lentype(c₁))
   S = promote_type(T, Float64)
-
   lat₁, lon₁ = S(ustrip(c₁.lat)), S(ustrip(c₁.lon))
   lat₂, lon₂ = S(ustrip(c₂.lat)), S(ustrip(c₂.lon))
 
@@ -63,155 +63,131 @@ end
 # Only oblate ellipsoids are handled, which is what CoordRefSystems.jl can
 # represent, so the prolate branches of the reference algorithm are omitted.
 
-# ---------------
-# ANGLE UTILITIES
-# ---------------
+# length of the shortest geodesic between two points given in degrees
+function _geodesic(🌎::Type{<:RevolutionEllipsoid}, lat₁::T, lon₁::T, lat₂::T, lon₂::T) where {T}
+  𝐠 = _geodesicparams(🌎, T)
+  tiny = sqrt(floatmin(T))
+  tol = eps(T)
+  maxit₁ = 20
+  maxit₂ = maxit₁ + precision(T) + 10
 
-_hnorm(x, y) = (h = hypot(x, y); (x / h, y / h))
-
-# coarsen x to the resolution available near 1/16 degree, so that angles
-# that are tiny but not zero do not turn into near singular cases. The
-# expression is not a no-op, the rounding happens in the two subtractions.
-function _anground(x::T) where {T}
-  z = T(1) / 16
-  y = abs(x)
-  w = z - y
-  y = w > 0 ? z - w : y
-  copysign(y, x)
-end
-
-# sum with error term
-function _twosum(u::T, v::T) where {T}
-  s = u + v
-  uᵣ = s - v
-  vᵣ = s - uᵣ
-  uᵣ -= u
-  vᵣ -= v
-  (s, iszero(s) ? s : -(uᵣ + vᵣ))
-end
-
-# difference y - x in (-180, 180] with error term
-function _angdiff(x::T, y::T) where {T}
-  d, e = _twosum(rem(-x, T(360), RoundNearest), rem(y, T(360), RoundNearest))
-  d, e = _twosum(rem(d, T(360), RoundNearest), e)
-  if iszero(d) || abs(d) == 180
-    d = copysign(d, iszero(e) ? y - x : -e)
+  # longitude difference, made positive
+  lon₁₂, δlon₁₂ = _angdiff(lon₁, lon₂)
+  if signbit(lon₁₂)
+    lon₁₂ = -lon₁₂
+    δlon₁₂ = -δlon₁₂
   end
-  (d, e)
-end
+  λ₁₂ = deg2rad(lon₁₂)
+  sλ₁₂, cλ₁₂ = _sincosde(lon₁₂, δlon₁₂)
+  lon₁₂ₛ = (T(180) - lon₁₂) - δlon₁₂
 
-# sine and cosine of (x + t) degrees with exact reduction of x
-function _sincosde(x::T, t::T) where {T}
-  d = rem(x, T(90), RoundNearest)
-  q = round(Int, (x - d) / 90)
-  d = _anground(d + t)
-  r = deg2rad(d)
-  s, c = sincos(r)
-  if 2abs(d) == 90
-    c = sqrt(T(1) / 2)
-    s = copysign(c, r)
-  elseif 3abs(d) == 90
-    c = sqrt(T(3)) / 2
-    s = copysign(T(1) / 2, r)
+  # canonical form -90 ≤ lat₁ ≤ -0 and lat₁ ≤ lat₂ ≤ -lat₁, which the
+  # branches below rely on. Reflections do not change the distance.
+  lat₁ = _anground(lat₁)
+  lat₂ = _anground(lat₂)
+  abs(lat₁) < abs(lat₂) && ((lat₁, lat₂) = (lat₂, lat₁))
+  latsign = signbit(lat₁) ? 1 : -1
+  lat₁ *= latsign
+  lat₂ *= latsign
+
+  # reduced latitudes
+  sβ₁, cβ₁ = sincosd(lat₁)
+  sβ₁ *= 𝐠.f₁
+  sβ₁, cβ₁ = _hnorm(sβ₁, cβ₁)
+  cβ₁ = max(tiny, cβ₁)
+  sβ₂, cβ₂ = sincosd(lat₂)
+  sβ₂ *= 𝐠.f₁
+  sβ₂, cβ₂ = _hnorm(sβ₂, cβ₂)
+  cβ₂ = max(tiny, cβ₂)
+
+  # force β₂ = ±β₁ exactly when the difference vanishes
+  if cβ₁ < -sβ₁
+    cβ₂ == cβ₁ && (sβ₂ = copysign(sβ₁, sβ₂))
+  else
+    abs(sβ₂) == -sβ₁ && (cβ₂ = cβ₁)
   end
-  m = q & 3
-  m == 0 ? (s, c) : m == 1 ? (c, -s) : m == 2 ? (-s, -c) : (-c, s)
-end
 
-# Clenshaw summation of ∑ cₗ sin(2lx)
-@inline function _sinseries(sinx::T, cosx::T, c::NTuple{N,T}) where {N,T}
-  α = 2 * (cosx - sinx) * (cosx + sinx)
-  b₁ = zero(T)
-  b₂ = zero(T)
-  for cₗ in reverse(c)
-    b₁, b₂ = α * b₁ - b₂ + cₗ, b₁
+  dn₁ = sqrt(1 + 𝐠.e′² * sβ₁^2)
+  dn₂ = sqrt(1 + 𝐠.e′² * sβ₂^2)
+
+  s₁₂ = zero(T)
+
+  # the geodesic may lie on a meridian
+  meridian = lat₁ == -90 || iszero(sλ₁₂)
+  if meridian
+    sσ₁, cσ₁ = sβ₁, cλ₁₂ * cβ₁
+    sσ₂, cσ₂ = sβ₂, cβ₂
+    σ₁₂ = atan(max(zero(T), cσ₁ * sσ₂ - sσ₁ * cσ₂), cσ₁ * cσ₂ + sσ₁ * sσ₂)
+    s₁₂, m₁₂, _ = _lengths(𝐠, 𝐠.n, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+    # zero length geodesics might yield a negative reduced length
+    (σ₁₂ < 3tiny || (σ₁₂ < tol && (s₁₂ < 0 || m₁₂ < 0))) && (s₁₂ = zero(T))
+    s₁₂ *= 𝐠.b
   end
-  2 * sinx * cosx * b₁
+
+  if !meridian && iszero(sβ₁) && (iszero(𝐠.f) || lon₁₂ₛ ≥ 𝐠.f * 180)
+    # the geodesic runs along the equator
+    s₁₂ = 𝐠.a * λ₁₂
+  elseif !meridian
+    σ₁₂, sα₁, cα₁, _, _, dnₘ = _inversestart(𝐠, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂)
+    if σ₁₂ ≥ 0
+      # short line, the auxiliary sphere solution is accurate enough
+      s₁₂ = σ₁₂ * 𝐠.b * dnₘ
+    else
+      # Newton's method on the azimuth α₁, with a bracketing interval that is
+      # bisected whenever a Newton step would leave the legal range
+      sσ₁ = cσ₁ = sσ₂ = cσ₂ = ε = zero(T)
+      sα₁ₐ, cα₁ₐ = tiny, one(T)
+      sα₁ᵦ, cα₁ᵦ = tiny, -one(T)
+      numit = 0
+      tripn = false
+      tripb = false
+      while true
+        v, dv, σ₁₂, sσ₁, cσ₁, sσ₂, cσ₂, ε =
+          _lambda12(𝐠, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, numit < maxit₁)
+        (tripb || !(abs(v) ≥ (tripn ? 8 : 1) * tol) || numit == maxit₂) && break
+
+        # shrink the bracketing interval
+        if v > 0 && (numit > maxit₁ || cα₁ / sα₁ > cα₁ᵦ / sα₁ᵦ)
+          sα₁ᵦ, cα₁ᵦ = sα₁, cα₁
+        elseif v < 0 && (numit > maxit₁ || cα₁ / sα₁ < cα₁ₐ / sα₁ₐ)
+          sα₁ₐ, cα₁ₐ = sα₁, cα₁
+        end
+
+        newton = false
+        if numit < maxit₁ && dv > 0
+          dα₁ = -v / dv
+          if abs(dα₁) < π
+            sdα₁, cdα₁ = sincos(dα₁)
+            sα₁′ = sα₁ * cdα₁ + cα₁ * sdα₁
+            if sα₁′ > 0
+              cα₁ = cα₁ * cdα₁ - sα₁ * sdα₁
+              sα₁ = sα₁′
+              sα₁, cα₁ = _hnorm(sα₁, cα₁)
+              # the slope vanishes in some regimes, so the convergence
+              # criterion is based on eps and not on its square root
+              tripn = abs(v) ≤ 16tol
+              newton = true
+            end
+          end
+        end
+
+        if !newton
+          sα₁ = (sα₁ₐ + sα₁ᵦ) / 2
+          cα₁ = (cα₁ₐ + cα₁ᵦ) / 2
+          sα₁, cα₁ = _hnorm(sα₁, cα₁)
+          tripn = false
+          tripb = abs(sα₁ₐ - sα₁) + (cα₁ₐ - cα₁) < tol || abs(sα₁ - sα₁ᵦ) + (cα₁ - cα₁ᵦ) < tol
+        end
+
+        numit += 1
+      end
+      s₁₂, _, _ = _lengths(𝐠, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+      s₁₂ *= 𝐠.b
+    end
+  end
+
+  s₁₂
 end
-
-# -------------
-# KARNEY SERIES
-# -------------
-
-# A₁ - 1 (Karney, eq. 17)
-_A1m1(ε::T) where {T} = (evalpoly(ε * ε, (T(0), T(64), T(4), T(1))) / 256 + ε) / (1 - ε)
-
-# A₂ - 1 (Karney, eq. 42)
-_A2m1(ε::T) where {T} = (evalpoly(ε * ε, (T(0), T(-192), T(-28), T(-11))) / 256 - ε) / (1 + ε)
-
-# C₁ₗ (Karney, eq. 18)
-function _C1(ε::T) where {T}
-  ε² = ε * ε
-  (
-    ε * evalpoly(ε², (T(-16), T(6), T(-1))) / 32,
-    ε^2 * evalpoly(ε², (T(-128), T(64), T(-9))) / 2048,
-    ε^3 * evalpoly(ε², (T(-16), T(9))) / 768,
-    ε^4 * evalpoly(ε², (T(-5), T(3))) / 512,
-    ε^5 * T(-7) / 1280,
-    ε^6 * T(-7) / 2048
-  )
-end
-
-# C₂ₗ (Karney, eq. 43)
-function _C2(ε::T) where {T}
-  ε² = ε * ε
-  (
-    ε * evalpoly(ε², (T(16), T(2), T(1))) / 32,
-    ε^2 * evalpoly(ε², (T(384), T(64), T(35))) / 2048,
-    ε^3 * evalpoly(ε², (T(80), T(15))) / 768,
-    ε^4 * evalpoly(ε², (T(35), T(7))) / 512,
-    ε^5 * T(63) / 1280,
-    ε^6 * T(77) / 2048
-  )
-end
-
-# coefficients of A₃ as a polynomial in ε (Karney, eq. 24)
-function _A3coeffs(n::T) where {T}
-  (
-    one(T),
-    (n - 1) / 2,
-    evalpoly(n, (T(-2), T(-1), T(3))) / 8,
-    -evalpoly(n, (T(1), T(3), T(1))) / 16,
-    -(2n + 3) / 64,
-    T(-3) / 128
-  )
-end
-
-# coefficients of C₃ₗ as polynomials in ε (Karney, eq. 25)
-function _C3coeffs(n::T) where {T}
-  (
-    (
-      evalpoly(n, (T(1), T(-1))) / 4,
-      evalpoly(n, (T(1), T(0), T(-1))) / 8,
-      evalpoly(n, (T(3), T(3), T(-1))) / 64,
-      evalpoly(n, (T(5), T(2))) / 128,
-      T(3) / 128
-    ),
-    (
-      evalpoly(n, (T(2), T(-3), T(1))) / 32,
-      evalpoly(n, (T(3), T(-2), T(-3))) / 64,
-      evalpoly(n, (T(3), T(1))) / 128,
-      T(5) / 256
-    ),
-    (evalpoly(n, (T(5), T(-9), T(5))) / 192, evalpoly(n, (T(9), T(-10))) / 384, T(7) / 512),
-    (evalpoly(n, (T(7), T(-14))) / 512, T(7) / 512),
-    (T(21) / 2560,)
-  )
-end
-
-function _C3(c₃, ε::T) where {T}
-  (
-    ε * evalpoly(ε, c₃[1]),
-    ε^2 * evalpoly(ε, c₃[2]),
-    ε^3 * evalpoly(ε, c₃[3]),
-    ε^4 * evalpoly(ε, c₃[4]),
-    ε^5 * evalpoly(ε, c₃[5])
-  )
-end
-
-# ----------------
-# INVERSE PROBLEM
-# ----------------
 
 # quantities that Karney's series need on top of the parameters that
 # CoordRefSystems.jl already provides for the ellipsoid of revolution
@@ -387,128 +363,148 @@ function _lambda12(𝐠, sβ₁::T, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁
   (v, dv, σ₁₂, sσ₁, cσ₁, sσ₂, cσ₂, ε)
 end
 
-# length of the shortest geodesic between two points given in degrees
-function _geodesic(🌎::Type{<:RevolutionEllipsoid}, lat₁::T, lon₁::T, lat₂::T, lon₂::T) where {T}
-  𝐠 = _geodesicparams(🌎, T)
-  tiny = sqrt(floatmin(T))
-  tol = eps(T)
-  maxit₁ = 20
-  maxit₂ = maxit₁ + precision(T) + 10
+# ----------------
+# ANGLE UTILITIES
+# ----------------
 
-  # longitude difference, made positive
-  lon₁₂, δlon₁₂ = _angdiff(lon₁, lon₂)
-  if signbit(lon₁₂)
-    lon₁₂ = -lon₁₂
-    δlon₁₂ = -δlon₁₂
+_hnorm(x, y) = (h = hypot(x, y); (x / h, y / h))
+
+# coarsen x to the resolution available near 1/16 degree, so that angles
+# that are tiny but not zero do not turn into near singular cases. The
+# expression is not a no-op, the rounding happens in the two subtractions.
+function _anground(x::T) where {T}
+  z = T(1) / 16
+  y = abs(x)
+  w = z - y
+  y = w > 0 ? z - w : y
+  copysign(y, x)
+end
+
+# sum with error term
+function _twosum(u::T, v::T) where {T}
+  s = u + v
+  uᵣ = s - v
+  vᵣ = s - uᵣ
+  uᵣ -= u
+  vᵣ -= v
+  (s, iszero(s) ? s : -(uᵣ + vᵣ))
+end
+
+# difference y - x in (-180, 180] with error term
+function _angdiff(x::T, y::T) where {T}
+  d, e = _twosum(rem(-x, T(360), RoundNearest), rem(y, T(360), RoundNearest))
+  d, e = _twosum(rem(d, T(360), RoundNearest), e)
+  if iszero(d) || abs(d) == 180
+    d = copysign(d, iszero(e) ? y - x : -e)
   end
-  λ₁₂ = deg2rad(lon₁₂)
-  sλ₁₂, cλ₁₂ = _sincosde(lon₁₂, δlon₁₂)
-  lon₁₂ₛ = (T(180) - lon₁₂) - δlon₁₂
+  (d, e)
+end
 
-  # canonical form -90 ≤ lat₁ ≤ -0 and lat₁ ≤ lat₂ ≤ -lat₁, which the
-  # branches below rely on. Reflections do not change the distance.
-  lat₁ = _anground(lat₁)
-  lat₂ = _anground(lat₂)
-  abs(lat₁) < abs(lat₂) && ((lat₁, lat₂) = (lat₂, lat₁))
-  latsign = signbit(lat₁) ? 1 : -1
-  lat₁ *= latsign
-  lat₂ *= latsign
-
-  # reduced latitudes
-  sβ₁, cβ₁ = sincosd(lat₁)
-  sβ₁ *= 𝐠.f₁
-  sβ₁, cβ₁ = _hnorm(sβ₁, cβ₁)
-  cβ₁ = max(tiny, cβ₁)
-  sβ₂, cβ₂ = sincosd(lat₂)
-  sβ₂ *= 𝐠.f₁
-  sβ₂, cβ₂ = _hnorm(sβ₂, cβ₂)
-  cβ₂ = max(tiny, cβ₂)
-
-  # force β₂ = ±β₁ exactly when the difference vanishes
-  if cβ₁ < -sβ₁
-    cβ₂ == cβ₁ && (sβ₂ = copysign(sβ₁, sβ₂))
-  else
-    abs(sβ₂) == -sβ₁ && (cβ₂ = cβ₁)
+# sine and cosine of (x + t) degrees with exact reduction of x
+function _sincosde(x::T, t::T) where {T}
+  d = rem(x, T(90), RoundNearest)
+  q = round(Int, (x - d) / 90)
+  d = _anground(d + t)
+  r = deg2rad(d)
+  s, c = sincos(r)
+  if 2abs(d) == 90
+    c = sqrt(T(1) / 2)
+    s = copysign(c, r)
+  elseif 3abs(d) == 90
+    c = sqrt(T(3)) / 2
+    s = copysign(T(1) / 2, r)
   end
+  m = q & 3
+  m == 0 ? (s, c) : m == 1 ? (c, -s) : m == 2 ? (-s, -c) : (-c, s)
+end
 
-  dn₁ = sqrt(1 + 𝐠.e′² * sβ₁^2)
-  dn₂ = sqrt(1 + 𝐠.e′² * sβ₂^2)
-
-  s₁₂ = zero(T)
-
-  # the geodesic may lie on a meridian
-  meridian = lat₁ == -90 || iszero(sλ₁₂)
-  if meridian
-    sσ₁, cσ₁ = sβ₁, cλ₁₂ * cβ₁
-    sσ₂, cσ₂ = sβ₂, cβ₂
-    σ₁₂ = atan(max(zero(T), cσ₁ * sσ₂ - sσ₁ * cσ₂), cσ₁ * cσ₂ + sσ₁ * sσ₂)
-    s₁₂, m₁₂, _ = _lengths(𝐠, 𝐠.n, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
-    # zero length geodesics might yield a negative reduced length
-    (σ₁₂ < 3tiny || (σ₁₂ < tol && (s₁₂ < 0 || m₁₂ < 0))) && (s₁₂ = zero(T))
-    s₁₂ *= 𝐠.b
+# Clenshaw summation of ∑ cₗ sin(2lx)
+@inline function _sinseries(sinx::T, cosx::T, c::NTuple{N,T}) where {N,T}
+  α = 2 * (cosx - sinx) * (cosx + sinx)
+  b₁ = zero(T)
+  b₂ = zero(T)
+  for cₗ in reverse(c)
+    b₁, b₂ = α * b₁ - b₂ + cₗ, b₁
   end
+  2 * sinx * cosx * b₁
+end
 
-  if !meridian && iszero(sβ₁) && (iszero(𝐠.f) || lon₁₂ₛ ≥ 𝐠.f * 180)
-    # the geodesic runs along the equator
-    s₁₂ = 𝐠.a * λ₁₂
-  elseif !meridian
-    σ₁₂, sα₁, cα₁, _, _, dnₘ = _inversestart(𝐠, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂)
-    if σ₁₂ ≥ 0
-      # short line, the auxiliary sphere solution is accurate enough
-      s₁₂ = σ₁₂ * 𝐠.b * dnₘ
-    else
-      # Newton's method on the azimuth α₁, with a bracketing interval that is
-      # bisected whenever a Newton step would leave the legal range
-      sσ₁ = cσ₁ = sσ₂ = cσ₂ = ε = zero(T)
-      sα₁ₐ, cα₁ₐ = tiny, one(T)
-      sα₁ᵦ, cα₁ᵦ = tiny, -one(T)
-      numit = 0
-      tripn = false
-      tripb = false
-      while true
-        v, dv, σ₁₂, sσ₁, cσ₁, sσ₂, cσ₂, ε =
-          _lambda12(𝐠, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, numit < maxit₁)
-        (tripb || !(abs(v) ≥ (tripn ? 8 : 1) * tol) || numit == maxit₂) && break
+# --------------
+# KARNEY SERIES
+# --------------
 
-        # shrink the bracketing interval
-        if v > 0 && (numit > maxit₁ || cα₁ / sα₁ > cα₁ᵦ / sα₁ᵦ)
-          sα₁ᵦ, cα₁ᵦ = sα₁, cα₁
-        elseif v < 0 && (numit > maxit₁ || cα₁ / sα₁ < cα₁ₐ / sα₁ₐ)
-          sα₁ₐ, cα₁ₐ = sα₁, cα₁
-        end
+# A₁ - 1 (Karney, eq. 17)
+_A1m1(ε::T) where {T} = (evalpoly(ε * ε, (T(0), T(64), T(4), T(1))) / 256 + ε) / (1 - ε)
 
-        newton = false
-        if numit < maxit₁ && dv > 0
-          dα₁ = -v / dv
-          if abs(dα₁) < π
-            sdα₁, cdα₁ = sincos(dα₁)
-            sα₁′ = sα₁ * cdα₁ + cα₁ * sdα₁
-            if sα₁′ > 0
-              cα₁ = cα₁ * cdα₁ - sα₁ * sdα₁
-              sα₁ = sα₁′
-              sα₁, cα₁ = _hnorm(sα₁, cα₁)
-              # the slope vanishes in some regimes, so the convergence
-              # criterion is based on eps and not on its square root
-              tripn = abs(v) ≤ 16tol
-              newton = true
-            end
-          end
-        end
+# A₂ - 1 (Karney, eq. 42)
+_A2m1(ε::T) where {T} = (evalpoly(ε * ε, (T(0), T(-192), T(-28), T(-11))) / 256 - ε) / (1 + ε)
 
-        if !newton
-          sα₁ = (sα₁ₐ + sα₁ᵦ) / 2
-          cα₁ = (cα₁ₐ + cα₁ᵦ) / 2
-          sα₁, cα₁ = _hnorm(sα₁, cα₁)
-          tripn = false
-          tripb = abs(sα₁ₐ - sα₁) + (cα₁ₐ - cα₁) < tol || abs(sα₁ - sα₁ᵦ) + (cα₁ - cα₁ᵦ) < tol
-        end
+# C₁ₗ (Karney, eq. 18)
+function _C1(ε::T) where {T}
+  ε² = ε * ε
+  (
+    ε * evalpoly(ε², (T(-16), T(6), T(-1))) / 32,
+    ε^2 * evalpoly(ε², (T(-128), T(64), T(-9))) / 2048,
+    ε^3 * evalpoly(ε², (T(-16), T(9))) / 768,
+    ε^4 * evalpoly(ε², (T(-5), T(3))) / 512,
+    ε^5 * T(-7) / 1280,
+    ε^6 * T(-7) / 2048
+  )
+end
 
-        numit += 1
-      end
-      s₁₂, _, _ = _lengths(𝐠, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
-      s₁₂ *= 𝐠.b
-    end
-  end
+# C₂ₗ (Karney, eq. 43)
+function _C2(ε::T) where {T}
+  ε² = ε * ε
+  (
+    ε * evalpoly(ε², (T(16), T(2), T(1))) / 32,
+    ε^2 * evalpoly(ε², (T(384), T(64), T(35))) / 2048,
+    ε^3 * evalpoly(ε², (T(80), T(15))) / 768,
+    ε^4 * evalpoly(ε², (T(35), T(7))) / 512,
+    ε^5 * T(63) / 1280,
+    ε^6 * T(77) / 2048
+  )
+end
 
-  s₁₂
+# coefficients of A₃ as a polynomial in ε (Karney, eq. 24)
+function _A3coeffs(n::T) where {T}
+  (
+    one(T),
+    (n - 1) / 2,
+    evalpoly(n, (T(-2), T(-1), T(3))) / 8,
+    -evalpoly(n, (T(1), T(3), T(1))) / 16,
+    -(2n + 3) / 64,
+    T(-3) / 128
+  )
+end
+
+# coefficients of C₃ₗ as polynomials in ε (Karney, eq. 25)
+function _C3coeffs(n::T) where {T}
+  (
+    (
+      evalpoly(n, (T(1), T(-1))) / 4,
+      evalpoly(n, (T(1), T(0), T(-1))) / 8,
+      evalpoly(n, (T(3), T(3), T(-1))) / 64,
+      evalpoly(n, (T(5), T(2))) / 128,
+      T(3) / 128
+    ),
+    (
+      evalpoly(n, (T(2), T(-3), T(1))) / 32,
+      evalpoly(n, (T(3), T(-2), T(-3))) / 64,
+      evalpoly(n, (T(3), T(1))) / 128,
+      T(5) / 256
+    ),
+    (evalpoly(n, (T(5), T(-9), T(5))) / 192, evalpoly(n, (T(9), T(-10))) / 384, T(7) / 512),
+    (evalpoly(n, (T(7), T(-14))) / 512, T(7) / 512),
+    (T(21) / 2560,)
+  )
+end
+
+function _C3(c₃, ε::T) where {T}
+  (
+    ε * evalpoly(ε, c₃[1]),
+    ε^2 * evalpoly(ε, c₃[2]),
+    ε^3 * evalpoly(ε, c₃[3]),
+    ε^4 * evalpoly(ε, c₃[4]),
+    ε^5 * evalpoly(ε, c₃[5])
+  )
 end

--- a/src/distances/geodesic.jl
+++ b/src/distances/geodesic.jl
@@ -1,0 +1,488 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+# Solution of the inverse geodesic problem on an ellipsoid of revolution
+# following Karney, C. F. F. 2013. Algorithms for geodesics. Journal of
+# Geodesy 87(1), 43-55. https://doi.org/10.1007/s00190-012-0578-0
+#
+# The series are truncated at order 6, which reaches round-off in double
+# precision for ellipsoids with terrestrial flattening. Newton's method is
+# used on the azimuth at the first point, with the bracketing interval
+# bisected whenever a Newton step leaves the legal range. This keeps the
+# solution accurate for nearly antipodal points, where the simpler series
+# of Vincenty fails to converge.
+
+# ---------------
+# ANGLE UTILITIES
+# ---------------
+
+_hnorm(x, y) = (h = hypot(x, y); (x / h, y / h))
+
+# coarsen x to the resolution available near 1/16 degree, so that angles
+# that are tiny but not zero do not turn into near singular cases. The
+# expression is not a no-op, the rounding happens in the two subtractions.
+function _anground(x::T) where {T}
+  z = T(1) / 16
+  y = abs(x)
+  w = z - y
+  y = w > 0 ? z - w : y
+  copysign(y, x)
+end
+
+# sum with error term
+function _twosum(u::T, v::T) where {T}
+  s = u + v
+  uᵣ = s - v
+  vᵣ = s - uᵣ
+  uᵣ -= u
+  vᵣ -= v
+  (s, iszero(s) ? s : -(uᵣ + vᵣ))
+end
+
+# difference y - x in (-180, 180] with error term
+function _angdiff(x::T, y::T) where {T}
+  d, e = _twosum(rem(-x, T(360), RoundNearest), rem(y, T(360), RoundNearest))
+  d, e = _twosum(rem(d, T(360), RoundNearest), e)
+  if iszero(d) || abs(d) == 180
+    d = copysign(d, iszero(e) ? y - x : -e)
+  end
+  (d, e)
+end
+
+# sine and cosine of (x + t) degrees with exact reduction of x
+function _sincosde(x::T, t::T) where {T}
+  d = rem(x, T(90), RoundNearest)
+  q = round(Int, (x - d) / 90)
+  d = _anground(d + t)
+  r = deg2rad(d)
+  s, c = sincos(r)
+  if 2abs(d) == 90
+    c = sqrt(T(1) / 2)
+    s = copysign(c, r)
+  elseif 3abs(d) == 90
+    c = sqrt(T(3)) / 2
+    s = copysign(T(1) / 2, r)
+  end
+  m = q & 3
+  m == 0 ? (s, c) : m == 1 ? (c, -s) : m == 2 ? (-s, -c) : (-c, s)
+end
+
+# Clenshaw summation of ∑ cₗ sin(2lx)
+@inline function _sinseries(sinx::T, cosx::T, c::NTuple{N,T}) where {N,T}
+  α = 2 * (cosx - sinx) * (cosx + sinx)
+  b₁ = zero(T)
+  b₂ = zero(T)
+  for cₗ in reverse(c)
+    b₁, b₂ = α * b₁ - b₂ + cₗ, b₁
+  end
+  2 * sinx * cosx * b₁
+end
+
+# -------------
+# KARNEY SERIES
+# -------------
+
+# A₁ - 1 (Karney, eq. 17)
+_A1m1(ε::T) where {T} = (evalpoly(ε * ε, (T(0), T(64), T(4), T(1))) / 256 + ε) / (1 - ε)
+
+# A₂ - 1 (Karney, eq. 42)
+_A2m1(ε::T) where {T} = (evalpoly(ε * ε, (T(0), T(-192), T(-28), T(-11))) / 256 - ε) / (1 + ε)
+
+# C₁ₗ (Karney, eq. 18)
+function _C1(ε::T) where {T}
+  ε² = ε * ε
+  (
+    ε * evalpoly(ε², (T(-16), T(6), T(-1))) / 32,
+    ε^2 * evalpoly(ε², (T(-128), T(64), T(-9))) / 2048,
+    ε^3 * evalpoly(ε², (T(-16), T(9))) / 768,
+    ε^4 * evalpoly(ε², (T(-5), T(3))) / 512,
+    ε^5 * T(-7) / 1280,
+    ε^6 * T(-7) / 2048
+  )
+end
+
+# C₂ₗ (Karney, eq. 43)
+function _C2(ε::T) where {T}
+  ε² = ε * ε
+  (
+    ε * evalpoly(ε², (T(16), T(2), T(1))) / 32,
+    ε^2 * evalpoly(ε², (T(384), T(64), T(35))) / 2048,
+    ε^3 * evalpoly(ε², (T(80), T(15))) / 768,
+    ε^4 * evalpoly(ε², (T(35), T(7))) / 512,
+    ε^5 * T(63) / 1280,
+    ε^6 * T(77) / 2048
+  )
+end
+
+# coefficients of A₃ as a polynomial in ε (Karney, eq. 24)
+function _A3coeffs(n::T) where {T}
+  (
+    one(T),
+    (n - 1) / 2,
+    evalpoly(n, (T(-2), T(-1), T(3))) / 8,
+    -evalpoly(n, (T(1), T(3), T(1))) / 16,
+    -(2n + 3) / 64,
+    T(-3) / 128
+  )
+end
+
+# coefficients of C₃ₗ as polynomials in ε (Karney, eq. 25)
+function _C3coeffs(n::T) where {T}
+  (
+    (
+      evalpoly(n, (T(1), T(-1))) / 4,
+      evalpoly(n, (T(1), T(0), T(-1))) / 8,
+      evalpoly(n, (T(3), T(3), T(-1))) / 64,
+      evalpoly(n, (T(5), T(2))) / 128,
+      T(3) / 128
+    ),
+    (
+      evalpoly(n, (T(2), T(-3), T(1))) / 32,
+      evalpoly(n, (T(3), T(-2), T(-3))) / 64,
+      evalpoly(n, (T(3), T(1))) / 128,
+      T(5) / 256
+    ),
+    (evalpoly(n, (T(5), T(-9), T(5))) / 192, evalpoly(n, (T(9), T(-10))) / 384, T(7) / 512),
+    (evalpoly(n, (T(7), T(-14))) / 512, T(7) / 512),
+    (T(21) / 2560,)
+  )
+end
+
+function _C3(c₃, ε::T) where {T}
+  (
+    ε * evalpoly(ε, c₃[1]),
+    ε^2 * evalpoly(ε, c₃[2]),
+    ε^3 * evalpoly(ε, c₃[3]),
+    ε^4 * evalpoly(ε, c₃[4]),
+    ε^5 * evalpoly(ε, c₃[5])
+  )
+end
+
+# ----------------
+# INVERSE PROBLEM
+# ----------------
+
+# constants of the ellipsoid that are reused across the iteration
+struct GeodesicEllipsoid{T}
+  a::T
+  f::T
+  f₁::T
+  e′²::T
+  n::T
+  b::T
+  a₃::NTuple{6,T}
+  c₃::Tuple{NTuple{5,T},NTuple{4,T},NTuple{3,T},NTuple{2,T},NTuple{1,T}}
+  τ::T
+end
+
+function GeodesicEllipsoid(a::T, f::T) where {T}
+  f₁ = 1 - f
+  e² = f * (2 - f)
+  n = f / (2 - f)
+  # threshold on σ₁₂ below which the auxiliary sphere solution is accurate enough
+  τ = T(0.1) * sqrt(eps(T)) / sqrt(max(T(0.001), abs(f)) * min(one(T), 1 - f / 2) / 2)
+  GeodesicEllipsoid{T}(a, f, f₁, e² / (f₁ * f₁), n, a * f₁, _A3coeffs(n), _C3coeffs(n), τ)
+end
+
+# distance and reduced length divided by the polar semi-axis (Karney, eq. 15 and 38)
+function _lengths(🌎::GeodesicEllipsoid, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+  A₁ = _A1m1(ε)
+  A₂ = _A2m1(ε)
+  C₁ = _C1(ε)
+  C₂ = _C2(ε)
+  m₀ = A₁ - A₂
+  A₁ += 1
+  A₂ += 1
+  B₁ = _sinseries(sσ₂, cσ₂, C₁) - _sinseries(sσ₁, cσ₁, C₁)
+  B₂ = _sinseries(sσ₂, cσ₂, C₂) - _sinseries(sσ₁, cσ₁, C₂)
+  J₁₂ = m₀ * σ₁₂ + (A₁ * B₁ - A₂ * B₂)
+  s₁₂ = A₁ * (σ₁₂ + B₁)
+  m₁₂ = dn₂ * (cσ₁ * sσ₂) - dn₁ * (sσ₁ * cσ₂) - cσ₁ * cσ₂ * J₁₂
+  (s₁₂, m₁₂, m₀)
+end
+
+# positive root of k⁴ + 2k³ - (x² + y² - 1)k² - 2y²k - y² = 0 (Karney, eq. 65)
+function _astroid(x::T, y::T) where {T}
+  p = x * x
+  q = y * y
+  r = (p + q - 1) / 6
+  (iszero(q) && r ≤ 0) && return zero(T)
+  S = p * q / 4
+  r² = r * r
+  r³ = r * r²
+  disc = S * (S + 2r³)
+  u = r
+  if disc ≥ 0
+    t³ = S + r³
+    t³ += t³ < 0 ? -sqrt(disc) : sqrt(disc)
+    t = cbrt(t³)
+    u += t + (iszero(t) ? zero(T) : r² / t)
+  else
+    # the cube root is complex but u is real, this form avoids cancellation
+    ang = atan(sqrt(-disc), -(S + r³))
+    u += 2r * cos(ang / 3)
+  end
+  v = sqrt(u * u + q)
+  uv = u < 0 ? q / (v - u) : u + v
+  w = (uv - q) / (2v)
+  uv / (sqrt(uv + w * w) + w)
+end
+
+# starting azimuth for Newton's method (Karney, section 5)
+function _inversestart(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂) where {T}
+  σ₁₂ = -one(T)
+  dnₘ = one(T)
+  sβ₁₂ = sβ₂ * cβ₁ - cβ₂ * sβ₁
+  cβ₁₂ = cβ₂ * cβ₁ + sβ₂ * sβ₁
+  sβ₁₂ₐ = sβ₂ * cβ₁ + cβ₂ * sβ₁
+
+  short = cβ₁₂ ≥ 0 && sβ₁₂ < T(0.5) && cβ₂ * λ₁₂ < T(0.5)
+  if short
+    sβₘ² = (sβ₁ + sβ₂)^2
+    sβₘ² /= sβₘ² + (cβ₁ + cβ₂)^2
+    dnₘ = sqrt(1 + 🌎.e′² * sβₘ²)
+    sω₁₂, cω₁₂ = sincos(λ₁₂ / (🌎.f₁ * dnₘ))
+  else
+    sω₁₂, cω₁₂ = sλ₁₂, cλ₁₂
+  end
+
+  sα₁ = cβ₂ * sω₁₂
+  cα₁ = cω₁₂ ≥ 0 ? sβ₁₂ + cβ₂ * sβ₁ * sω₁₂^2 / (1 + cω₁₂) : sβ₁₂ₐ - cβ₂ * sβ₁ * sω₁₂^2 / (1 - cω₁₂)
+
+  sσ₁₂ = hypot(sα₁, cα₁)
+  cσ₁₂ = sβ₁ * sβ₂ + cβ₁ * cβ₂ * cω₁₂
+
+  sα₂ = zero(T)
+  cα₂ = zero(T)
+  if short && sσ₁₂ < 🌎.τ
+    # really short line, no iteration needed
+    sα₂ = cβ₁ * sω₁₂
+    cα₂ = sβ₁₂ - cβ₁ * sβ₂ * (cω₁₂ ≥ 0 ? sω₁₂^2 / (1 + cω₁₂) : 1 - cω₁₂)
+    sα₂, cα₂ = _hnorm(sα₂, cα₂)
+    σ₁₂ = atan(sσ₁₂, cσ₁₂)
+  elseif !(abs(🌎.n) > T(0.1) || cσ₁₂ ≥ 0 || sσ₁₂ ≥ 6 * abs(🌎.n) * T(π) * cβ₁^2)
+    # nearly antipodal, the spherical guess is useless and the astroid is solved
+    # in a frame where the antipodal point is at the origin (Karney, section 5)
+    λ₁₂ₓ = atan(-sλ₁₂, -cλ₁₂)
+    if 🌎.f ≥ 0
+      k² = sβ₁^2 * 🌎.e′²
+      ε = k² / (2 * (1 + sqrt(1 + k²)) + k²)
+      λscale = 🌎.f * cβ₁ * evalpoly(ε, 🌎.a₃) * T(π)
+      βscale = λscale * cβ₁
+      x = λ₁₂ₓ / λscale
+      y = sβ₁₂ₐ / βscale
+    else
+      β₁₂ₐ = atan(sβ₁₂ₐ, cβ₂ * cβ₁ - sβ₂ * sβ₁)
+      _, m₁₂, m₀ = _lengths(🌎, 🌎.n, T(π) + β₁₂ₐ, sβ₁, -cβ₁, dn₁, sβ₂, cβ₂, dn₂)
+      x = -1 + m₁₂ / (cβ₁ * cβ₂ * m₀ * T(π))
+      βscale = x < T(-0.01) ? sβ₁₂ₐ / x : -🌎.f * cβ₁^2 * T(π)
+      λscale = βscale / cβ₁
+      y = λ₁₂ₓ / λscale
+    end
+    if y > -200eps(T) && x > -1 - 1000sqrt(eps(T))
+      # strip near the cut
+      if 🌎.f ≥ 0
+        sα₁ = min(one(T), -x)
+        cα₁ = -sqrt(1 - sα₁^2)
+      else
+        cα₁ = max(x > -200eps(T) ? zero(T) : -one(T), x)
+        sα₁ = sqrt(1 - cα₁^2)
+      end
+    else
+      k = _astroid(x, y)
+      ω₁₂ₐ = λscale * (🌎.f ≥ 0 ? -x * k / (1 + k) : -y * (1 + k) / k)
+      sω₁₂ = sin(ω₁₂ₐ)
+      cω₁₂ = -cos(ω₁₂ₐ)
+      sα₁ = cβ₂ * sω₁₂
+      cα₁ = sβ₁₂ₐ - cβ₂ * sβ₁ * sω₁₂^2 / (1 - cω₁₂)
+    end
+  end
+
+  if sα₁ > 0
+    sα₁, cα₁ = _hnorm(sα₁, cα₁)
+  else
+    sα₁, cα₁ = one(T), zero(T)
+  end
+
+  (σ₁₂, sα₁, cα₁, sα₂, cα₂, dnₘ)
+end
+
+# residual λ₁₂(α₁) - λ₁₂ and its derivative (Karney, section 4)
+function _lambda12(🌎::GeodesicEllipsoid{T}, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, diff) where {T}
+  # break the degeneracy of the equatorial line
+  (iszero(sβ₁) && iszero(cα₁)) && (cα₁ = -sqrt(floatmin(T)))
+
+  # Clairaut's relation sinα₀ = sinα cosβ
+  sα₀ = sα₁ * cβ₁
+  cα₀ = hypot(cα₁, sα₁ * sβ₁)
+
+  sσ₁ = sβ₁
+  sω₁ = sα₀ * sβ₁
+  cσ₁ = cω₁ = cα₁ * cβ₁
+  sσ₁, cσ₁ = _hnorm(sσ₁, cσ₁)
+
+  sα₂ = cβ₂ ≠ cβ₁ ? sα₀ / cβ₂ : sα₁
+  cα₂ = if cβ₂ ≠ cβ₁ || abs(sβ₂) ≠ -sβ₁
+    sqrt((cα₁ * cβ₁)^2 + (cβ₁ < -sβ₁ ? (cβ₂ - cβ₁) * (cβ₁ + cβ₂) : (sβ₁ - sβ₂) * (sβ₁ + sβ₂))) / cβ₂
+  else
+    abs(cα₁)
+  end
+
+  sσ₂ = sβ₂
+  sω₂ = sα₀ * sβ₂
+  cσ₂ = cω₂ = cα₂ * cβ₂
+  sσ₂, cσ₂ = _hnorm(sσ₂, cσ₂)
+
+  σ₁₂ = atan(max(zero(T), cσ₁ * sσ₂ - sσ₁ * cσ₂), cσ₁ * cσ₂ + sσ₁ * sσ₂)
+  sω₁₂ = max(zero(T), cω₁ * sω₂ - sω₁ * cω₂)
+  cω₁₂ = cω₁ * cω₂ + sω₁ * sω₂
+  η = atan(sω₁₂ * cλ₁₂ - cω₁₂ * sλ₁₂, cω₁₂ * cλ₁₂ + sω₁₂ * sλ₁₂)
+
+  k² = cα₀^2 * 🌎.e′²
+  ε = k² / (2 * (1 + sqrt(1 + k²)) + k²)
+  C₃ = _C3(🌎.c₃, ε)
+  B₃ = _sinseries(sσ₂, cσ₂, C₃) - _sinseries(sσ₁, cσ₁, C₃)
+  v = η - 🌎.f * evalpoly(ε, 🌎.a₃) * sα₀ * (σ₁₂ + B₃)
+
+  # the derivative follows from the reduced length (Karney, eq. 38)
+  dv = if !diff
+    zero(T)
+  elseif iszero(cα₂)
+    -2 * 🌎.f₁ * dn₁ / sβ₁
+  else
+    _, m₁₂, _ = _lengths(🌎, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+    m₁₂ * 🌎.f₁ / (cα₂ * cβ₂)
+  end
+
+  (v, dv, σ₁₂, sσ₁, cσ₁, sσ₂, cσ₂, ε)
+end
+
+# length of the shortest geodesic between two points given in degrees
+function _geodesic(🌎::GeodesicEllipsoid{T}, lat₁::T, lon₁::T, lat₂::T, lon₂::T) where {T}
+  tiny = sqrt(floatmin(T))
+  tol = eps(T)
+  maxit₁ = 20
+  maxit₂ = maxit₁ + precision(T) + 10
+
+  # longitude difference, made positive
+  lon₁₂, δlon₁₂ = _angdiff(lon₁, lon₂)
+  if signbit(lon₁₂)
+    lon₁₂ = -lon₁₂
+    δlon₁₂ = -δlon₁₂
+  end
+  λ₁₂ = deg2rad(lon₁₂)
+  sλ₁₂, cλ₁₂ = _sincosde(lon₁₂, δlon₁₂)
+  lon₁₂ₛ = (T(180) - lon₁₂) - δlon₁₂
+
+  # canonical form -90 ≤ lat₁ ≤ -0 and lat₁ ≤ lat₂ ≤ -lat₁, which the
+  # branches below rely on. Reflections do not change the distance.
+  lat₁ = _anground(lat₁)
+  lat₂ = _anground(lat₂)
+  abs(lat₁) < abs(lat₂) && ((lat₁, lat₂) = (lat₂, lat₁))
+  latsign = signbit(lat₁) ? 1 : -1
+  lat₁ *= latsign
+  lat₂ *= latsign
+
+  # reduced latitudes
+  sβ₁, cβ₁ = sincosd(lat₁)
+  sβ₁ *= 🌎.f₁
+  sβ₁, cβ₁ = _hnorm(sβ₁, cβ₁)
+  cβ₁ = max(tiny, cβ₁)
+  sβ₂, cβ₂ = sincosd(lat₂)
+  sβ₂ *= 🌎.f₁
+  sβ₂, cβ₂ = _hnorm(sβ₂, cβ₂)
+  cβ₂ = max(tiny, cβ₂)
+
+  # force β₂ = ±β₁ exactly when the difference vanishes
+  if cβ₁ < -sβ₁
+    cβ₂ == cβ₁ && (sβ₂ = copysign(sβ₁, sβ₂))
+  else
+    abs(sβ₂) == -sβ₁ && (cβ₂ = cβ₁)
+  end
+
+  dn₁ = sqrt(1 + 🌎.e′² * sβ₁^2)
+  dn₂ = sqrt(1 + 🌎.e′² * sβ₂^2)
+
+  s₁₂ = zero(T)
+
+  # the geodesic may lie on a meridian
+  meridian = lat₁ == -90 || iszero(sλ₁₂)
+  if meridian
+    sσ₁, cσ₁ = sβ₁, cλ₁₂ * cβ₁
+    sσ₂, cσ₂ = sβ₂, cβ₂
+    σ₁₂ = atan(max(zero(T), cσ₁ * sσ₂ - sσ₁ * cσ₂), cσ₁ * cσ₂ + sσ₁ * sσ₂)
+    s₁₂, m₁₂, _ = _lengths(🌎, 🌎.n, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+    if σ₁₂ < sqrt(tol) || m₁₂ ≥ 0
+      (σ₁₂ < 3tiny || (σ₁₂ < tol && (s₁₂ < 0 || m₁₂ < 0))) && (s₁₂ = zero(T))
+      s₁₂ *= 🌎.b
+    else
+      # prolate ellipsoid with points too close to antipodal
+      meridian = false
+    end
+  end
+
+  if !meridian && iszero(sβ₁) && (🌎.f ≤ 0 || lon₁₂ₛ ≥ 🌎.f * 180)
+    # the geodesic runs along the equator
+    s₁₂ = 🌎.a * λ₁₂
+  elseif !meridian
+    σ₁₂, sα₁, cα₁, _, _, dnₘ = _inversestart(🌎, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, λ₁₂, sλ₁₂, cλ₁₂)
+    if σ₁₂ ≥ 0
+      # short line, the auxiliary sphere solution is accurate enough
+      s₁₂ = σ₁₂ * 🌎.b * dnₘ
+    else
+      # Newton's method on the azimuth α₁, with a bracketing interval that is
+      # bisected whenever a Newton step would leave the legal range
+      sσ₁ = cσ₁ = sσ₂ = cσ₂ = ε = zero(T)
+      sα₁ₐ, cα₁ₐ = tiny, one(T)
+      sα₁ᵦ, cα₁ᵦ = tiny, -one(T)
+      numit = 0
+      tripn = false
+      tripb = false
+      while true
+        v, dv, σ₁₂, sσ₁, cσ₁, sσ₂, cσ₂, ε =
+          _lambda12(🌎, sβ₁, cβ₁, dn₁, sβ₂, cβ₂, dn₂, sα₁, cα₁, sλ₁₂, cλ₁₂, numit < maxit₁)
+        (tripb || !(abs(v) ≥ (tripn ? 8 : 1) * tol) || numit == maxit₂) && break
+
+        # shrink the bracketing interval
+        if v > 0 && (numit > maxit₁ || cα₁ / sα₁ > cα₁ᵦ / sα₁ᵦ)
+          sα₁ᵦ, cα₁ᵦ = sα₁, cα₁
+        elseif v < 0 && (numit > maxit₁ || cα₁ / sα₁ < cα₁ₐ / sα₁ₐ)
+          sα₁ₐ, cα₁ₐ = sα₁, cα₁
+        end
+
+        newton = false
+        if numit < maxit₁ && dv > 0
+          dα₁ = -v / dv
+          if abs(dα₁) < π
+            sdα₁, cdα₁ = sincos(dα₁)
+            sα₁′ = sα₁ * cdα₁ + cα₁ * sdα₁
+            if sα₁′ > 0
+              cα₁ = cα₁ * cdα₁ - sα₁ * sdα₁
+              sα₁ = sα₁′
+              sα₁, cα₁ = _hnorm(sα₁, cα₁)
+              # the slope vanishes in some regimes, so the convergence
+              # criterion is based on eps and not on its square root
+              tripn = abs(v) ≤ 16tol
+              newton = true
+            end
+          end
+        end
+
+        if !newton
+          sα₁ = (sα₁ₐ + sα₁ᵦ) / 2
+          cα₁ = (cα₁ₐ + cα₁ᵦ) / 2
+          sα₁, cα₁ = _hnorm(sα₁, cα₁)
+          tripn = false
+          tripb = abs(sα₁ₐ - sα₁) + (cα₁ₐ - cα₁) < tol || abs(sα₁ - sα₁ᵦ) + (cα₁ - cα₁ᵦ) < tol
+        end
+
+        numit += 1
+      end
+      s₁₂, _, _ = _lengths(🌎, ε, σ₁₂, sσ₁, cσ₁, dn₁, sσ₂, cσ₂, dn₂)
+      s₁₂ *= 🌎.b
+    end
+  end
+
+  s₁₂
+end

--- a/src/distances/geodesic.jl
+++ b/src/distances/geodesic.jl
@@ -50,7 +50,7 @@ end
 
 # Solution of the inverse geodesic problem on an ellipsoid of revolution
 # following Karney, C. F. F. 2013. Algorithms for geodesics. Journal of
-# Geodesy 87(1), 43-55. https://doi.org/10.1007/s00190-012-0578-0
+# Geodesy 87(1), 43-55. https://doi.org/10.1007/s00190-012-0578-z
 #
 # The series are truncated at order 6, which reaches round-off in double
 # precision for ellipsoids with terrestrial flattening. Newton's method is

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -60,3 +60,111 @@
   @test evaluate(SphericalAngle(), p1, p2) ≈ deg2rad(T(1) * u"°")
   @test evaluate(SphericalAngle(), p3, p4) ≈ deg2rad(T(1) * u"°")
 end
+
+@testitem "Geometric distances" setup = [Setup] begin
+  # ---------------
+  # EUCLIDEAN SPACE
+  # ---------------
+
+  d = EuclideanDistance()
+  @test d(cart(0, 0), cart(3, 4)) == T(5) * u"m"
+  @test d(cart(0, 0, 0), cart(1, 2, 2)) == T(3) * u"m"
+  @test d(cart(1, 1), cart(1, 1)) == T(0) * u"m"
+
+  d = ManhattanDistance()
+  @test d(cart(0, 0), cart(3, 4)) == T(7) * u"m"
+  @test d(cart(0, 0, 0), cart(1, -2, 2)) == T(5) * u"m"
+  @test d(cart(1, 1), cart(1, 1)) == T(0) * u"m"
+
+  # the geodesic of Euclidean space is the straight line
+  d = GeodesicDistance()
+  @test d(cart(0, 0), cart(3, 4)) == EuclideanDistance()(cart(0, 0), cart(3, 4))
+  @test d(cart(0, 0, 0), cart(1, 2, 2)) == EuclideanDistance()(cart(0, 0, 0), cart(1, 2, 2))
+
+  # the Manhattan distance is not defined on the ellipsoid
+  @test_throws MethodError ManhattanDistance()(latlon(0, 0), latlon(0, 1))
+
+  # ---------
+  # ELLIPSOID
+  # ---------
+
+  d = GeodesicDistance()
+  e = EuclideanDistance()
+
+  # the Euclidean distance is the chord, which is shorter than the geodesic
+  p₁ = latlon(-33.8688, 151.2093)
+  p₂ = latlon(51.5074, -0.1278)
+  @test e(p₁, p₂) < d(p₁, p₂)
+
+  # identity and symmetry
+  @test d(p₁, p₁) == T(0) * u"m"
+  @test d(p₁, p₂) == d(p₂, p₁)
+
+  # units are inherited from the ellipsoid of the datum
+  @test unit(d(p₁, p₂)) == u"m"
+  @test Unitful.numtype(d(p₁, p₂)) === T
+
+  if T === Float64
+    # reference values from the test set of Karney (2013), which is
+    # computed with high precision arithmetic on the WGS84 ellipsoid
+    # https://geographiclib.sourceforge.io/C++/doc/geodesic.html#testgeod
+    τ = 1e-6u"m"
+    @test isapprox(
+      d(latlon(36.530042355041, 0), latlon(-48.164270779097769, 5.7623446946765105)),
+      9398502.0434687u"m",
+      atol=τ
+    )
+    @test isapprox(
+      d(latlon(31.371144087006, 0), latlon(28.909631785856762, 17.071526465331372)),
+      1665550.2846815u"m",
+      atol=τ
+    )
+    @test isapprox(
+      d(latlon(19.707097385334, 0), latlon(19.707739582810257, 0.00026025642810105)),
+      76.1478894u"m",
+      atol=τ
+    )
+
+    # nearly antipodal points, where the series of Vincenty fail to converge
+    @test isapprox(
+      d(latlon(41.211099672963, 0), latlon(-41.567531864088980, 179.92621956183250)),
+      19964100.0439999u"m",
+      atol=τ
+    )
+    @test isapprox(
+      d(latlon(0.925973600837, 0), latlon(-0.607398400683232, 179.95083146293813)),
+      19968558.8681118u"m",
+      atol=τ
+    )
+    @test isapprox(
+      d(latlon(74.098356057014, 0), latlon(-74.073175364040975, 179.99585371619742)),
+      20001120.0416458u"m",
+      atol=τ
+    )
+
+    # a quarter of the equator is a quarter of the equatorial circumference
+    a = CoordRefSystems.majoraxis(ellipsoid(WGS84Latest))
+    @test isapprox(d(latlon(0, 0), latlon(0, 90)), π * a / 2, atol=τ)
+
+    # pole to pole is half of the meridian, obtained by numerical
+    # integration of the meridional radius of curvature
+    @test isapprox(d(latlon(90, 0), latlon(-90, 0)), 20003931.4586254u"m", atol=τ)
+
+    # on a datum with a spherical ellipsoid the geodesic is the great circle
+    R = CoordRefSystems.majoraxis(ellipsoid(CoordRefSystems.GRS80S))
+    for (lat₁, lon₁, lat₂, lon₂) in [(-33.8688, 151.2093, 51.5074, -0.1278), (0, 0, 0.5, 179.7), (60, -45, -60, 135)]
+      s₁, c₁ = sincosd(lat₁)
+      s₂, c₂ = sincosd(lat₂)
+      sΔ, cΔ = sincosd(lon₂ - lon₁)
+      greatcircle = R * atan(hypot(c₂ * sΔ, c₁ * s₂ - s₁ * c₂ * cΔ), s₁ * s₂ + c₁ * c₂ * cΔ)
+      geodesic = d(Point(LatLon{CoordRefSystems.GRS80S}(lat₁, lon₁)), Point(LatLon{CoordRefSystems.GRS80S}(lat₂, lon₂)))
+      @test isapprox(geodesic, greatcircle, atol=τ)
+    end
+
+    # the ellipsoid comes from the datum, so a different datum gives a different answer
+    q₁ = Point(LatLon{ITRF{2008}}(-33.8688, 151.2093))
+    q₂ = Point(LatLon{ITRF{2008}}(51.5074, -0.1278))
+    @test d(q₁, q₂) ≠ d(p₁, p₂)
+    @test isapprox(d(q₁, q₂), d(p₁, p₂), atol=1e-3u"m")
+  end
+end

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -1,70 +1,7 @@
-@testitem "Distances" setup = [Setup] begin
-  p = cart(0, 1)
-  l = Line(cart(0, 0), cart(1, 0))
-  @test evaluate(Euclidean(), p, l) == T(1) * u"m"
-  @test evaluate(Euclidean(), l, p) == T(1) * u"m"
-  p = cart(-3, 4)
-  s = Segment(cart(0, 0), cart(1, 0))
-  @test evaluate(Euclidean(), p, s) == T(5) * u"m"
-  @test evaluate(Euclidean(), s, p) == T(5) * u"m"
-  @test evaluate(Euclidean(), p, l) != T(5) * u"m"
-
-  p = cart(68, 259)
-  l = Line(cart(68, 260), cart(69, 261))
-  @test evaluate(Euclidean(), p, l) ≤ T(0.8) * u"m"
-  line1 = Line(cart(-1, 0, 0), cart(1, 0, 0))
-  line2 = Line(cart(0, -1, 1), cart(0, 1, 1))  # line2 ⟂ line1, z++
-  line3 = Line(cart(-1, 1, 0), cart(1, 1, 0))  # line3 ∥ line1
-  line4 = Line(cart(-2, 0, 0), cart(2, 0, 0))  # line4 colinear with line1
-  line5 = Line(cart(0, -1, 0), cart(0, 1, 0))  # line5 intersects line1
-  line6 = Line(cart(0, -1, 0), cart(0, -2, 0))  # line6 intersects line1, if infinite
-  @test evaluate(Euclidean(), line1, line2) ≈ T(1) * u"m"
-  @test evaluate(Euclidean(), line1, line3) ≈ T(1) * u"m"
-  @test evaluate(Euclidean(), line1, line4) ≈ T(0) * u"m"
-  @test evaluate(Euclidean(), line1, line5) ≈ T(0) * u"m"
-  @test evaluate(Euclidean(), line1, line6) ≈ T(0) * u"m"
-  seg1 = Segment(cart(-1, 0, 0), cart(1, 0, 0))
-  seg2 = Segment(cart(0, -1, 1), cart(0, 1, 1))  # seg2 ⟂ seg1, z++
-  seg3 = Segment(cart(-1, 1, 0), cart(1, 1, 0))  # seg3 ∥ seg1
-  seg4 = Segment(cart(-0, 0, 0), cart(2, 0, 0))  # seg4 colinear with seg1
-  seg5 = Segment(cart(0, -1, 0), cart(0, 1, 0))  # seg5 intersects seg1
-  seg6 = Segment(cart(0, -1, 0), cart(0, -2, 0))  # seg6 intersects seg1, if infinite
-  seg7 = Segment(cart(2, 0, 0), cart(4, 0, 0))  # seg7 colinear with seg1 but shifted (gap of 1)
-  seg8 = Segment(cart(3, -2, 0), cart(5, -2, 0))  # seg8 ∥ seg1 but offset (gap of 2 by 2=√8)
-  @test evaluate(Euclidean(), seg1, seg2) ≈ T(1) * u"m"
-  @test evaluate(Euclidean(), seg1, seg3) ≈ T(1) * u"m"
-  @test evaluate(Euclidean(), seg1, seg4) ≈ T(0) * u"m"
-  @test evaluate(Euclidean(), seg1, seg5) ≈ T(0) * u"m"
-  @test evaluate(Euclidean(), seg1, seg6) ≈ T(1) * u"m"
-  @test evaluate(Euclidean(), seg1, seg7) ≈ T(1) * u"m"
-  @test evaluate(Euclidean(), seg1, seg8) ≈ T(√8) * u"m"
-
-  p1, p2 = cart(1, 0), cart(0, 1)
-  @test evaluate(Chebyshev(), p1, p2) == T(1) * u"m"
-  @test evaluate(Euclidean(), p1, p2) == T(√2) * u"m"
-
-  latlon1 = LatLon(T(0), T(0))
-  latlon2 = LatLon(T(1), T(0))
-  cart1 = convert(Cartesian, latlon1)
-  cart2 = convert(Cartesian, latlon2)
-  p1 = Point(latlon1)
-  p2 = Point(latlon2)
-  p3 = Point(cart1)
-  p4 = Point(cart2)
-  @test evaluate(Haversine(), p1, p2) ≈ T(111194.92664455874) * u"m"
-  @test evaluate(Haversine(), p3, p4) ≈ T(111194.92664455874) * u"m"
-  @test evaluate(Haversine(6371000u"m"), p1, p2) ≈ T(111194.92664455874) * u"m"
-  @test evaluate(Haversine(6371000u"m"), p3, p4) ≈ T(111194.92664455874) * u"m"
-  @test evaluate(Haversine(6371u"km"), p1, p2) ≈ T(111.19492664455874) * u"km"
-  @test evaluate(Haversine(6371u"km"), p3, p4) ≈ T(111.19492664455874) * u"km"
-  @test evaluate(SphericalAngle(), p1, p2) ≈ deg2rad(T(1) * u"°")
-  @test evaluate(SphericalAngle(), p3, p4) ≈ deg2rad(T(1) * u"°")
-end
-
-@testitem "Geometric distances" setup = [Setup] begin
-  # ---------------
+@testitem "GeometricDistance" setup = [Setup] begin
+  # ----------------
   # EUCLIDEAN SPACE
-  # ---------------
+  # ----------------
 
   d = EuclideanDistance()
   @test d(cart(0, 0), cart(3, 4)) == T(5) * u"m"
@@ -76,9 +13,9 @@ end
   @test d(cart(0, 0), cart(3, 4)) == EuclideanDistance()(cart(0, 0), cart(3, 4))
   @test d(cart(0, 0, 0), cart(1, 2, 2)) == EuclideanDistance()(cart(0, 0, 0), cart(1, 2, 2))
 
-  # ---------
+  # ----------
   # ELLIPSOID
-  # ---------
+  # ----------
 
   d = GeodesicDistance()
   e = EuclideanDistance()
@@ -143,13 +80,13 @@ end
     @test isapprox(d(latlon(90, 0), latlon(-90, 0)), 20003931.4586254u"m", atol=τ)
 
     # on a datum with a spherical ellipsoid the geodesic is the great circle
-    R = CoordRefSystems.majoraxis(ellipsoid(CoordRefSystems.GRS80S))
+    R = CoordRefSystems.majoraxis(ellipsoid(GRS80S))
     for (lat₁, lon₁, lat₂, lon₂) in [(-33.8688, 151.2093, 51.5074, -0.1278), (0, 0, 0.5, 179.7), (60, -45, -60, 135)]
       s₁, c₁ = sincosd(lat₁)
       s₂, c₂ = sincosd(lat₂)
       sΔ, cΔ = sincosd(lon₂ - lon₁)
       greatcircle = R * atan(hypot(c₂ * sΔ, c₁ * s₂ - s₁ * c₂ * cΔ), s₁ * s₂ + c₁ * c₂ * cΔ)
-      geodesic = d(Point(LatLon{CoordRefSystems.GRS80S}(lat₁, lon₁)), Point(LatLon{CoordRefSystems.GRS80S}(lat₂, lon₂)))
+      geodesic = d(Point(LatLon{GRS80S}(lat₁, lon₁)), Point(LatLon{GRS80S}(lat₂, lon₂)))
       @test isapprox(geodesic, greatcircle, atol=τ)
     end
 
@@ -159,4 +96,67 @@ end
     @test d(q₁, q₂) ≠ d(p₁, p₂)
     @test isapprox(d(q₁, q₂), d(p₁, p₂), atol=1e-3u"m")
   end
+end
+
+@testitem "Distances.jl" setup = [Setup] begin
+  p = cart(0, 1)
+  l = Line(cart(0, 0), cart(1, 0))
+  @test evaluate(Euclidean(), p, l) == T(1) * u"m"
+  @test evaluate(Euclidean(), l, p) == T(1) * u"m"
+  p = cart(-3, 4)
+  s = Segment(cart(0, 0), cart(1, 0))
+  @test evaluate(Euclidean(), p, s) == T(5) * u"m"
+  @test evaluate(Euclidean(), s, p) == T(5) * u"m"
+  @test evaluate(Euclidean(), p, l) != T(5) * u"m"
+
+  p = cart(68, 259)
+  l = Line(cart(68, 260), cart(69, 261))
+  @test evaluate(Euclidean(), p, l) ≤ T(0.8) * u"m"
+  line1 = Line(cart(-1, 0, 0), cart(1, 0, 0))
+  line2 = Line(cart(0, -1, 1), cart(0, 1, 1))  # line2 ⟂ line1, z++
+  line3 = Line(cart(-1, 1, 0), cart(1, 1, 0))  # line3 ∥ line1
+  line4 = Line(cart(-2, 0, 0), cart(2, 0, 0))  # line4 colinear with line1
+  line5 = Line(cart(0, -1, 0), cart(0, 1, 0))  # line5 intersects line1
+  line6 = Line(cart(0, -1, 0), cart(0, -2, 0))  # line6 intersects line1, if infinite
+  @test evaluate(Euclidean(), line1, line2) ≈ T(1) * u"m"
+  @test evaluate(Euclidean(), line1, line3) ≈ T(1) * u"m"
+  @test evaluate(Euclidean(), line1, line4) ≈ T(0) * u"m"
+  @test evaluate(Euclidean(), line1, line5) ≈ T(0) * u"m"
+  @test evaluate(Euclidean(), line1, line6) ≈ T(0) * u"m"
+  seg1 = Segment(cart(-1, 0, 0), cart(1, 0, 0))
+  seg2 = Segment(cart(0, -1, 1), cart(0, 1, 1))  # seg2 ⟂ seg1, z++
+  seg3 = Segment(cart(-1, 1, 0), cart(1, 1, 0))  # seg3 ∥ seg1
+  seg4 = Segment(cart(-0, 0, 0), cart(2, 0, 0))  # seg4 colinear with seg1
+  seg5 = Segment(cart(0, -1, 0), cart(0, 1, 0))  # seg5 intersects seg1
+  seg6 = Segment(cart(0, -1, 0), cart(0, -2, 0))  # seg6 intersects seg1, if infinite
+  seg7 = Segment(cart(2, 0, 0), cart(4, 0, 0))  # seg7 colinear with seg1 but shifted (gap of 1)
+  seg8 = Segment(cart(3, -2, 0), cart(5, -2, 0))  # seg8 ∥ seg1 but offset (gap of 2 by 2=√8)
+  @test evaluate(Euclidean(), seg1, seg2) ≈ T(1) * u"m"
+  @test evaluate(Euclidean(), seg1, seg3) ≈ T(1) * u"m"
+  @test evaluate(Euclidean(), seg1, seg4) ≈ T(0) * u"m"
+  @test evaluate(Euclidean(), seg1, seg5) ≈ T(0) * u"m"
+  @test evaluate(Euclidean(), seg1, seg6) ≈ T(1) * u"m"
+  @test evaluate(Euclidean(), seg1, seg7) ≈ T(1) * u"m"
+  @test evaluate(Euclidean(), seg1, seg8) ≈ T(√8) * u"m"
+
+  p1, p2 = cart(1, 0), cart(0, 1)
+  @test evaluate(Chebyshev(), p1, p2) == T(1) * u"m"
+  @test evaluate(Euclidean(), p1, p2) == T(√2) * u"m"
+
+  latlon1 = LatLon(T(0), T(0))
+  latlon2 = LatLon(T(1), T(0))
+  cart1 = convert(Cartesian, latlon1)
+  cart2 = convert(Cartesian, latlon2)
+  p1 = Point(latlon1)
+  p2 = Point(latlon2)
+  p3 = Point(cart1)
+  p4 = Point(cart2)
+  @test evaluate(Haversine(), p1, p2) ≈ T(111194.92664455874) * u"m"
+  @test evaluate(Haversine(), p3, p4) ≈ T(111194.92664455874) * u"m"
+  @test evaluate(Haversine(6371000u"m"), p1, p2) ≈ T(111194.92664455874) * u"m"
+  @test evaluate(Haversine(6371000u"m"), p3, p4) ≈ T(111194.92664455874) * u"m"
+  @test evaluate(Haversine(6371u"km"), p1, p2) ≈ T(111.19492664455874) * u"km"
+  @test evaluate(Haversine(6371u"km"), p3, p4) ≈ T(111.19492664455874) * u"km"
+  @test evaluate(SphericalAngle(), p1, p2) ≈ deg2rad(T(1) * u"°")
+  @test evaluate(SphericalAngle(), p3, p4) ≈ deg2rad(T(1) * u"°")
 end

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -71,18 +71,10 @@ end
   @test d(cart(0, 0, 0), cart(1, 2, 2)) == T(3) * u"m"
   @test d(cart(1, 1), cart(1, 1)) == T(0) * u"m"
 
-  d = ManhattanDistance()
-  @test d(cart(0, 0), cart(3, 4)) == T(7) * u"m"
-  @test d(cart(0, 0, 0), cart(1, -2, 2)) == T(5) * u"m"
-  @test d(cart(1, 1), cart(1, 1)) == T(0) * u"m"
-
   # the geodesic of Euclidean space is the straight line
   d = GeodesicDistance()
   @test d(cart(0, 0), cart(3, 4)) == EuclideanDistance()(cart(0, 0), cart(3, 4))
   @test d(cart(0, 0, 0), cart(1, 2, 2)) == EuclideanDistance()(cart(0, 0, 0), cart(1, 2, 2))
-
-  # the Manhattan distance is not defined on the ellipsoid
-  @test_throws MethodError ManhattanDistance()(latlon(0, 0), latlon(0, 1))
 
   # ---------
   # ELLIPSOID


### PR DESCRIPTION
Addresses #98, for pairs of points only. The existing `evaluate` methods are untouched.

```julia
EuclideanDistance()(p₁, p₂)
ManhattanDistance()(p₁, p₂)
GeodesicDistance()(p₁, p₂)
```

Dispatch is on the manifold. On `🌐` the Euclidean distance is the chord, and the geodesic is solved with the series of Karney (2013) on the ellipsoid of the datum. No new dependencies.

Verification:

- 500000 cases from Karney's test set, 167289 near antipodal: max error 7.451 nm
- 47 ellipsoids in CoordRefSystems against PROJ `geod_inverse`: worst 3.7 nm
- on a spherical datum it reproduces the great circle formula to 0.2 nm

1036 ns per pair, no allocations.

Karney, C. F. F. 2013. Algorithms for geodesics. https://doi.org/10.1007/s00190-012-0578-z
