### PR TITLE
Adding `Repair(13)` due to unexpected behavior of `Repair(0)` in `Polytope`s

### DIFF
--- a/src/transforms/repair.jl
+++ b/src/transforms/repair.jl
@@ -297,7 +297,7 @@ function apply(::Repair{13}, g::PolyArea)
 
   outer = first(repaired)
 
-  # Polygon collapsed to a lower-dimensional geometry
+  # polygon collapsed to a lower-dimensional geometry
   outer isa Ring || return outer, nothing
 
   validholes = filter(r -> r isa Ring, repaired[2:end])

--- a/src/transforms/repair.jl
+++ b/src/transforms/repair.jl
@@ -22,6 +22,7 @@ Perform repairing operation with code `K`.
 - K = 10: outer rings of polygon are expanded
 - K = 11: rings of polygon are coherently oriented
 - K = 12: degenerate rings of polygon are removed
+- K = 13: duplicate edges of chains and polygons are removed (no type stability guarantee)
 
 ## Examples
 
@@ -39,97 +40,6 @@ Repair(K) = Repair{K}()
 # --------------
 
 apply(::Repair{0}, geom::Polytope) = unique(geom), nothing
-
-function apply(::Repair{0}, g::Chain)
-  verts = vertices(g)
-
-  # tuple of already seen edges (a, b) where a < b
-  seen = Set{Tuple{eltype(verts),eltype(verts)}}()
-  # already costructed chain parts
-  parts = Vector{eltype(verts)}[]
-  # currently working chain part
-  current = [first(verts)]
-
-  for i in 1:(length(verts) - 1)
-    a = verts[i]
-    b = verts[i + 1]
-
-    # create a key for the edge that is independent of the order of vertices
-    key = isless(a, b) ? (a, b) : (b, a)
-
-    # if the edge has already been seen, we close the current part and start a new one
-    if key in seen
-      length(current) >= 2 && push!(parts, current)
-      current = [b]
-      # if the edge is new, we add it to the seen set and continue building the current part
-    else
-      push!(seen, key)
-      push!(current, b)
-    end
-  end
-
-  # if the last part has at least two vertices, we add it to the parts
-  length(current) >= 2 && push!(parts, current)
-
-  # construct geometries from the parts
-  geoms = map(parts) do verts
-    if length(verts) == 2
-      Segment(verts...)
-    elseif first(verts) == last(verts)
-      Ring(verts[1:(end - 1)])
-    else
-      Rope(verts)
-    end
-  end
-
-  maybemulti(geoms), nothing
-end
-
-function apply(::Repair{0}, g::PolyArea)
-  repaired = map(rings(g)) do ring
-    first(apply(Repair(0), ring))
-  end
-
-  outer = first(repaired)
-
-  # Polygon collapsed to a lower-dimensional geometry
-  outer isa Ring || return outer, nothing
-
-  validholes = filter(r -> r isa Ring, repaired[2:end])
-
-  PolyArea(outer, validholes), nothing
-end
-
-function apply(::Repair{0}, g::Ngon)
-  repaired = first(apply(Repair(0), Ring(vertices(g))))
-
-  repaired isa Ring || return repaired
-
-  Ngon(vertices(repaired)...)
-end
-
-function _flatten!(out, geom)
-    if geom isa Multi
-        for g in parent(geom)
-            _flatten!(out, g)
-        end
-    else
-        push!(out, geom)
-    end
-end
-
-function apply(::Repair{0}, g::Multi)
-  repaired = map(parent(g)) do geom
-    first(apply(Repair(0), geom))
-  end
-
-  flattened = Vector{eltype(repaired)}()
-  for geom in repaired
-    _flatten!(flattened, geom)
-  end
-  
-  maybemulti(unique(flattened)), nothing
-end
 
 function apply(::Repair{0}, mesh::Mesh)
   # retrieve vertices and connectivities
@@ -327,6 +237,101 @@ function apply(::Repair{12}, poly::PolyArea)
   inners = filter(r -> nvertices(r) > 2, r[2:end])
 
   PolyArea([outer; inners]), nothing
+end
+
+# ---------------
+# OPERATION (13)
+# ---------------
+
+function apply(::Repair{13}, g::Chain)
+  verts = vertices(g)
+
+  # tuple of already seen edges (a, b) where a < b
+  seen = Set{Tuple{eltype(verts),eltype(verts)}}()
+  # already costructed chain parts
+  parts = Vector{eltype(verts)}[]
+  # currently working chain part
+  current = [first(verts)]
+
+  for i in 1:(length(verts) - 1)
+    a = verts[i]
+    b = verts[i + 1]
+
+    # create a key for the edge that is independent of the order of vertices
+    key = isless(a, b) ? (a, b) : (b, a)
+
+    # if the edge has already been seen, we close the current part and start a new one
+    if key in seen
+      length(current) >= 2 && push!(parts, current)
+      current = [b]
+      # if the edge is new, we add it to the seen set and continue building the current part
+    else
+      push!(seen, key)
+      push!(current, b)
+    end
+  end
+
+  # if the last part has at least two vertices, we add it to the parts
+  length(current) >= 2 && push!(parts, current)
+
+  # construct geometries from the parts
+  geoms = map(parts) do verts
+    if length(verts) == 2
+      Segment(verts...)
+    elseif first(verts) == last(verts)
+      Ring(verts[1:(end - 1)])
+    else
+      Rope(verts)
+    end
+  end
+
+  maybemulti(geoms), nothing
+end
+
+function apply(::Repair{13}, g::PolyArea)
+  repaired = map(rings(g)) do ring
+    first(apply(Repair(13), ring))
+  end
+
+  outer = first(repaired)
+
+  # Polygon collapsed to a lower-dimensional geometry
+  outer isa Ring || return outer, nothing
+
+  validholes = filter(r -> r isa Ring, repaired[2:end])
+
+  PolyArea(outer, validholes), nothing
+end
+
+function apply(::Repair{13}, g::Ngon)
+  repaired = first(apply(Repair(13), Ring(vertices(g))))
+
+  repaired isa Ring || return repaired
+
+  Ngon(vertices(repaired)...)
+end
+
+function _flatten!(out, geom)
+    if geom isa Multi
+        for g in parent(geom)
+            _flatten!(out, g)
+        end
+    else
+        push!(out, geom)
+    end
+end
+
+function apply(::Repair{13}, g::Multi)
+  repaired = map(parent(g)) do geom
+    first(apply(Repair(13), geom))
+  end
+
+  flattened = Vector{eltype(repaired)}()
+  for geom in repaired
+    _flatten!(flattened, geom)
+  end
+  
+  maybemulti(unique(flattened)), nothing
 end
 
 # ----------

--- a/src/transforms/repair.jl
+++ b/src/transforms/repair.jl
@@ -40,6 +40,97 @@ Repair(K) = Repair{K}()
 
 apply(::Repair{0}, geom::Polytope) = unique(geom), nothing
 
+function apply(::Repair{0}, g::Chain)
+  verts = vertices(g)
+
+  # tuple of already seen edges (a, b) where a < b
+  seen = Set{Tuple{eltype(verts),eltype(verts)}}()
+  # already costructed chain parts
+  parts = Vector{eltype(verts)}[]
+  # currently working chain part
+  current = [first(verts)]
+
+  for i in 1:(length(verts) - 1)
+    a = verts[i]
+    b = verts[i + 1]
+
+    # create a key for the edge that is independent of the order of vertices
+    key = isless(a, b) ? (a, b) : (b, a)
+
+    # if the edge has already been seen, we close the current part and start a new one
+    if key in seen
+      length(current) >= 2 && push!(parts, current)
+      current = [b]
+      # if the edge is new, we add it to the seen set and continue building the current part
+    else
+      push!(seen, key)
+      push!(current, b)
+    end
+  end
+
+  # if the last part has at least two vertices, we add it to the parts
+  length(current) >= 2 && push!(parts, current)
+
+  # construct geometries from the parts
+  geoms = map(parts) do verts
+    if length(verts) == 2
+      Segment(verts...)
+    elseif first(verts) == last(verts)
+      Ring(verts[1:(end - 1)])
+    else
+      Rope(verts)
+    end
+  end
+
+  maybemulti(geoms), nothing
+end
+
+function apply(::Repair{0}, g::PolyArea)
+  repaired = map(rings(g)) do ring
+    first(apply(Repair(0), ring))
+  end
+
+  outer = first(repaired)
+
+  # Polygon collapsed to a lower-dimensional geometry
+  outer isa Ring || return outer, nothing
+
+  validholes = filter(r -> r isa Ring, repaired[2:end])
+
+  PolyArea(outer, validholes), nothing
+end
+
+function apply(::Repair{0}, g::Ngon)
+  repaired = first(apply(Repair(0), Ring(vertices(g))))
+
+  repaired isa Ring || return repaired
+
+  Ngon(vertices(repaired)...)
+end
+
+function _flatten!(out, geom)
+    if geom isa Multi
+        for g in parent(geom)
+            _flatten!(out, g)
+        end
+    else
+        push!(out, geom)
+    end
+end
+
+function apply(::Repair{0}, g::Multi)
+  repaired = map(parent(g)) do geom
+    first(apply(Repair(0), geom))
+  end
+
+  flattened = Vector{eltype(repaired)}()
+  for geom in repaired
+    _flatten!(flattened, geom)
+  end
+  
+  maybemulti(unique(flattened)), nothing
+end
+
 function apply(::Repair{0}, mesh::Mesh)
   # retrieve vertices and connectivities
   verts = vertices(mesh)

--- a/src/transforms/repair.jl
+++ b/src/transforms/repair.jl
@@ -244,8 +244,10 @@ end
 # ---------------
 
 function apply(::Repair{13}, g::Chain)
-  verts = vertices(g)
+  verts = collect(vertices(g))
 
+  # make sure the chain is closed if it is a ring
+  g isa Ring && push!(verts, first(verts))
   # tuple of already seen edges (a, b) where a < b
   seen = Set{Tuple{eltype(verts),eltype(verts)}}()
   # already costructed chain parts
@@ -262,7 +264,7 @@ function apply(::Repair{13}, g::Chain)
 
     # if the edge has already been seen, we close the current part and start a new one
     if key in seen
-      length(current) >= 2 && push!(parts, current)
+      length(current) ≥ 2 && push!(parts, current)
       current = [b]
       # if the edge is new, we add it to the seen set and continue building the current part
     else
@@ -272,7 +274,7 @@ function apply(::Repair{13}, g::Chain)
   end
 
   # if the last part has at least two vertices, we add it to the parts
-  length(current) >= 2 && push!(parts, current)
+  length(current) ≥ 2 && push!(parts, current)
 
   # construct geometries from the parts
   geoms = map(parts) do verts
@@ -299,8 +301,13 @@ function apply(::Repair{13}, g::PolyArea)
   outer isa Ring || return outer, nothing
 
   validholes = filter(r -> r isa Ring, repaired[2:end])
+  
+  if isempty(validholes)
+    return PolyArea([outer]), nothing
+  else
+    return PolyArea([outer; validholes]), nothing
+  end
 
-  PolyArea(outer, validholes), nothing
 end
 
 function apply(::Repair{13}, g::Ngon)
@@ -308,17 +315,17 @@ function apply(::Repair{13}, g::Ngon)
 
   repaired isa Ring || return repaired
 
-  Ngon(vertices(repaired)...)
+  Ngon(vertices(repaired)...), nothing
 end
 
 function _flatten!(out, geom)
-    if geom isa Multi
-        for g in parent(geom)
-            _flatten!(out, g)
-        end
-    else
-        push!(out, geom)
+  if geom isa Multi
+    for g in parent(geom)
+      _flatten!(out, g)
     end
+  else
+    push!(out, geom)
+  end
 end
 
 function apply(::Repair{13}, g::Multi)
@@ -330,7 +337,7 @@ function apply(::Repair{13}, g::Multi)
   for geom in repaired
     _flatten!(flattened, geom)
   end
-  
+
   maybemulti(unique(flattened)), nothing
 end
 

--- a/src/transforms/repair.jl
+++ b/src/transforms/repair.jl
@@ -22,7 +22,7 @@ Perform repairing operation with code `K`.
 - K = 10: outer rings of polygon are expanded
 - K = 11: rings of polygon are coherently oriented
 - K = 12: degenerate rings of polygon are removed
-- K = 13: duplicate edges of chains and polygons are removed (no type stability guarantee)
+- K = 13: duplicate edges of chains are removed
 
 ## Examples
 
@@ -243,102 +243,32 @@ end
 # OPERATION (13)
 # ---------------
 
-function apply(::Repair{13}, g::Chain)
-  verts = collect(vertices(g))
+_segmentkey(seg) = begin
+  a, b = vertices(seg)
+  isless(a, b) ? (a, b) : (b, a)
+end
 
-  # make sure the chain is closed if it is a ring
-  g isa Ring && push!(verts, first(verts))
-  # tuple of already seen edges (a, b) where a < b
-  seen = Set{Tuple{eltype(verts),eltype(verts)}}()
-  # already costructed chain parts
-  parts = Vector{eltype(verts)}[]
-  # currently working chain part
-  current = [first(verts)]
+function _uniquesegments(segs::AbstractVector{<:Segment})
+  seen = Set([_segmentkey(first(segs))])
+  unique = [first(segs)]
 
-  for i in 1:(length(verts) - 1)
-    a = verts[i]
-    b = verts[i + 1]
+  for seg in Iterators.drop(segs, 1)
+    key = _segmentkey(seg)
 
-    # create a key for the edge that is independent of the order of vertices
-    key = isless(a, b) ? (a, b) : (b, a)
-
-    # if the edge has already been seen, we close the current part and start a new one
-    if key in seen
-      length(current) ≥ 2 && push!(parts, current)
-      current = [b]
-      # if the edge is new, we add it to the seen set and continue building the current part
-    else
+    if key ∉ seen
       push!(seen, key)
-      push!(current, b)
+      push!(unique, seg)
     end
   end
 
-  # if the last part has at least two vertices, we add it to the parts
-  length(current) ≥ 2 && push!(parts, current)
-
-  # construct geometries from the parts
-  geoms = map(parts) do verts
-    if length(verts) == 2
-      Segment(verts...)
-    elseif first(verts) == last(verts)
-      Ring(verts[1:(end - 1)])
-    else
-      Rope(verts)
-    end
-  end
-
-  maybemulti(geoms), nothing
+  unique
 end
 
-function apply(::Repair{13}, g::PolyArea)
-  repaired = map(rings(g)) do ring
-    first(apply(Repair(13), ring))
-  end
+apply(::Repair{13}, g::Segment) = g, nothing
 
-  outer = first(repaired)
-
-  # polygon collapsed to a lower-dimensional geometry
-  outer isa Ring || return outer, nothing
-
-  validholes = filter(r -> r isa Ring, repaired[2:end])
-  
-  if isempty(validholes)
-    return PolyArea([outer]), nothing
-  else
-    return PolyArea([outer; validholes]), nothing
-  end
-
-end
-
-function apply(::Repair{13}, g::Ngon)
-  repaired = first(apply(Repair(13), Ring(vertices(g))))
-
-  repaired isa Ring || return repaired
-
-  Ngon(vertices(repaired)...), nothing
-end
-
-function _flatten!(out, geom)
-  if geom isa Multi
-    for g in parent(geom)
-      _flatten!(out, g)
-    end
-  else
-    push!(out, geom)
-  end
-end
-
-function apply(::Repair{13}, g::Multi)
-  repaired = map(parent(g)) do geom
-    first(apply(Repair(13), geom))
-  end
-
-  flattened = Vector{eltype(repaired)}()
-  for geom in repaired
-    _flatten!(flattened, geom)
-  end
-
-  maybemulti(unique(flattened)), nothing
+function apply(::Repair{13}, g::Chain)
+  segs = collect(segments(g))
+  Multi(_uniquesegments(segs)), nothing
 end
 
 # ----------

--- a/src/utils/basic.jl
+++ b/src/utils/basic.jl
@@ -69,3 +69,83 @@ isthreaded(cond=true) = cond && Threads.nthreads() > 1
 Return `only(geoms)` or `Multi(geoms)` depending on the length of `geoms`.
 """
 maybemulti(geoms) = length(geoms) == 1 ? only(geoms) : Multi(geoms)
+
+"""
+    glue(segs)
+Glue unique segments into `Segment`s, `Rope`s and `Ring`s. Segments are sorted.
+"""
+function glue(segs::AbstractVector{<:Segment{M,C}}) where {M,C}
+  length(segs) == 1 && return only(segs)
+
+  # sort segments independently of input order
+  segs = sort(segs; by=_segmentkey)
+
+  # build adjacency dictionary
+  adj = Dict{Point{M,C},Vector{Int}}()
+  for (i, seg) in enumerate(segs)
+    a, b = vertices(seg)
+    push!(get!(adj, a, Int[]), i)
+    push!(get!(adj, b, Int[]), i)
+  end
+
+  visited = falses(length(segs))
+  chains = Chain{M,C}[]
+
+  # trace a maximal path from a starting vertex through a segment
+  function trace(start, segind)
+    verts = [start]
+    current = start
+    currentind = segind
+
+    while true
+      visited[currentind] = true
+
+      a, b = vertices(segs[currentind])
+      next = current == a ? b : a
+      push!(verts, next)
+
+      # stop at terminal or branching vertices
+      length(adj[next]) == 2 || break
+
+      i, j = adj[next]
+      nextind = i == currentind ? j : i
+
+      visited[nextind] && break
+
+      current = next
+      currentind = nextind
+    end
+
+    verts
+  end
+
+  # first trace maximal non-cyclic paths
+  starts = sort([v for (v, inds) in adj if length(inds) != 2])
+
+  for start in starts
+    for segind in adj[start]
+      visited[segind] && continue
+
+      verts = trace(start, segind)
+
+      geom = length(verts) == 2 ? Segment(verts...) : Rope(verts)
+      push!(chains, geom)
+    end
+  end
+
+  # remaining unvisited segments belong to cycles
+  for segind in eachindex(segs)
+    visited[segind] && continue
+
+    a, b = vertices(segs[segind])
+    start = isless(a, b) ? a : b
+
+    verts = trace(start, segind)
+
+    push!(chains, Ring(verts[1:(end - 1)]))
+  end
+
+  chains
+end
+
+glue(g::Multi) = glue(parent(g))

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -2512,7 +2512,7 @@ end
   rpoly, cache = TB.apply(repair, poly)
   @test rpoly == poly
 
-  # degenerate hole is removed
+  # degenerate hole is removed (equivalent to Repair(12))
   hole = Ring(cart(1, 1), cart(2, 1))
   hpoly = PolyArea([outer, hole])
 

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -2443,6 +2443,119 @@ end
   @test rpoly == PolyArea(outer)
 end
 
+@testitem "Repair(13)" setup = [Setup] begin
+  seg = Segment(cart(0, 0), cart(1, 0))
+  rope = Rope(cart(0, 0), cart(1, 0), cart(2, 0))
+  ring = Ring(cart(0, 0), cart(1, 0), cart(1, 1), cart(0, 1))
+  poly = PolyArea(ring)
+  ngon = Ngon(vertices(ring)...)
+  multi = Multi([seg, rope, ring, poly, ngon])
+  repair = Repair(13)
+
+  # unduplicated geometries are preserved
+  rseg, cache = TB.apply(repair, seg)
+  @test rseg == seg
+  rrope, cache = TB.apply(repair, rope)
+  @test rrope == rope
+  rring, cache = TB.apply(repair, ring)
+  @test rring == ring
+  rpoly, cache = TB.apply(repair, poly)
+  @test rpoly == poly
+  rngon, cache = TB.apply(repair, ngon)
+  @test rngon == ngon
+  rmulti, cache = TB.apply(repair, multi)
+  @test rmulti == Multi([seg, rope, ring, poly, ngon])
+
+  # duplicated geometries are repaired
+  dseg = Rope([vertices(seg)..., vertices(seg)...])
+  drope = Rope([vertices(rope)..., vertices(rope)[2:end]...])
+  dring = Ring([vertices(ring)..., vertices(ring)...])
+  dpoly = PolyArea([vertices(poly)..., vertices(poly)...])
+  dnpoly = Ngon(vertices(poly)..., vertices(poly)...)
+  dmulti = Multi([dseg, drope, dring, dpoly, dnpoly])
+
+  rseg, cache = TB.apply(repair, dseg)
+  @test rseg == seg
+  rrope, cache = TB.apply(repair, drope)
+  @test rrope == rope
+  rring, cache = TB.apply(repair, dring)
+  @test rring == ring
+  rpoly, cache = TB.apply(repair, dpoly)
+  @test rpoly == poly
+  rngon, cache = TB.apply(repair, dnpoly)
+  @test rngon == ngon
+  rmulti, cache = TB.apply(repair, dmulti)
+  @test rmulti == Multi([seg, rope, ring, poly, ngon])
+
+  # branching rope
+  a = cart(0, 3)
+  b = cart(1, 2)
+  c = cart(0, 1)
+  d = cart(1, 0)
+  e = cart(2, 2)
+  branch = Rope(a, b, c, b, d, b, e)
+
+  rbranch, cache = TB.apply(repair, branch)
+  @test rbranch == Multi([Rope(a, b, c), Segment(b, d), Segment(b, e)])
+
+  # two-vertex ring collapses to a segment
+  dring = Ring(cart(0, 0), cart(1, 0))
+
+  rring, cache = TB.apply(repair, dring)
+  @test rring == Segment(cart(0, 0), cart(1, 0))
+
+  # poly with holes
+  outer = Ring(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
+  inner = Ring(cart(1, 1), cart(2, 1), cart(2, 2), cart(1, 2))
+  poly = PolyArea(outer, inner)
+
+  rpoly, cache = TB.apply(repair, poly)
+  @test rpoly == poly
+
+  # degenerate hole is removed
+  hole = Ring(cart(1, 1), cart(2, 1))
+  hpoly = PolyArea([outer, hole])
+
+  rpoly, cache = TB.apply(repair, hpoly)
+  @test rpoly == PolyArea(outer)
+
+  # degenerate outer ring collapses the polygon
+  outer = Ring(cart(0, 0), cart(1, 0))
+  dpoly = PolyArea(outer)
+
+  rpoly, cache = TB.apply(repair, dpoly)
+  @test rpoly == Segment(cart(0, 0), cart(1, 0))
+
+  # duplicated geometries in a Multi are removed
+  p1 = cart(0, 0)
+  p2 = cart(1, 1)
+  dmulti = Multi([p1, p1, p2])
+
+  rmulti, cache = TB.apply(repair, dmulti)
+  @test rmulti == Multi([p1, p2])
+
+  # nested Multis are flattened
+  p1 = cart(0, 0)
+  p2 = cart(1, 1)
+  p3 = cart(2, 2)
+  nmulti = Multi([p1, Multi([p2, p3])])
+
+  rmulti, cache = TB.apply(repair, nmulti)
+  @test rmulti == Multi([p1, p2, p3])
+
+  # nested Multis are flattened and duplicated geometries are removed
+  dmulti = Multi([p1, Multi([p1, p2]), p2])
+
+  rmulti, cache = TB.apply(repair, dmulti)
+  @test rmulti == Multi([p1, p2])
+
+  # a Multi with a single unique geometry is unwrapped
+  dmulti = Multi([p1, p1])
+
+  rmulti, cache = TB.apply(repair, dmulti)
+  @test rmulti == p1
+end
+
 @testitem "Repair fallbacks" setup = [Setup] begin
   quad = Quadrangle(cart(0, 1, 0), cart(1, 1, 0), cart(1, 0, 0), cart(0, 0, 0))
   repair = Repair(10)
@@ -2511,8 +2624,7 @@ end
   hole1 = Ring(cart.([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]))
   hole2 = Ring(cart.([(0.6, 0.2), (0.8, 0.2), (0.8, 0.4), (0.6, 0.4)]))
   poly = PolyArea([outer, reverse(hole1), reverse(hole2)])
-  @test vertices(poly) ==
-        cart.([
+  @test vertices(poly) == cart.([
     (0, 0),
     (1, 0),
     (1, 1),
@@ -2527,25 +2639,24 @@ end
     (0.8, 0.2)
   ])
   bpoly = poly |> Bridge(T(0.01))
-  target =
-    cart.([
-      (-0.0035355339059327372, 0.0035355339059327372),
-      (0.19646446609406729, 0.20353553390593274),
-      (0.2, 0.4),
-      (0.4, 0.405),
-      (0.6, 0.405),
-      (0.8, 0.4),
-      (0.8, 0.2),
-      (0.6, 0.2),
-      (0.6, 0.395),
-      (0.4, 0.395),
-      (0.4, 0.2),
-      (0.20353553390593274, 0.19646446609406729),
-      (0.0035355339059327372, -0.0035355339059327372),
-      (1.0, 0.0),
-      (1.0, 1.0),
-      (0.0, 1.0)
-    ])
+  target = cart.([
+    (-0.0035355339059327372, 0.0035355339059327372),
+    (0.19646446609406729, 0.20353553390593274),
+    (0.2, 0.4),
+    (0.4, 0.405),
+    (0.6, 0.405),
+    (0.8, 0.4),
+    (0.8, 0.2),
+    (0.6, 0.2),
+    (0.6, 0.395),
+    (0.4, 0.395),
+    (0.4, 0.2),
+    (0.20353553390593274, 0.19646446609406729),
+    (0.0035355339059327372, -0.0035355339059327372),
+    (1.0, 0.0),
+    (1.0, 1.0),
+    (0.0, 1.0)
+  ])
   @test all(vertices(bpoly) .≈ target)
 
   poly = Quadrangle(cart(0, 1, 0), cart(1, 1, 0), cart(1, 0, 0), cart(0, 0, 0))

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -2444,50 +2444,67 @@ end
 end
 
 @testitem "Repair(13)" setup = [Setup] begin
-  seg = Segment(cart(0, 0), cart(1, 0))
-  rope = Rope(cart(0, 0), cart(1, 0), cart(2, 0))
-  ring = Ring(cart(0, 0), cart(1, 0), cart(1, 1), cart(0, 1))
-  poly = PolyArea(ring)
-  ngon = Ngon(vertices(ring)...)
-  multi = Multi([seg, rope, ring, poly, ngon])
   repair = Repair(13)
 
-  # unduplicated geometries are preserved
+  # segment is preserved
+  seg = Segment(cart(0, 0), cart(1, 0))
+
   rseg, cache = TB.apply(repair, seg)
   @test rseg == seg
+  @test isnothing(cache)
+
+  # rope is decomposed into segments
+  a = cart(0, 0)
+  b = cart(1, 0)
+  c = cart(2, 0)
+  rope = Rope(a, b, c)
+
   rrope, cache = TB.apply(repair, rope)
-  @test rrope == rope
+  @test rrope == Multi([Segment(a, b), Segment(b, c)])
+  @test isnothing(cache)
+
+  # ring is decomposed into segments
+  a = cart(0, 0)
+  b = cart(1, 0)
+  c = cart(1, 1)
+  d = cart(0, 1)
+  ring = Ring(a, b, c, d)
+
   rring, cache = TB.apply(repair, ring)
-  @test rring == ring
-  rpoly, cache = TB.apply(repair, poly)
-  @test rpoly == poly
-  rngon, cache = TB.apply(repair, ngon)
-  @test rngon == ngon
-  rmulti, cache = TB.apply(repair, multi)
-  @test rmulti == Multi([seg, rope, ring, poly, ngon])
+  @test rring == Multi([Segment(a, b), Segment(b, c), Segment(c, d), Segment(d, a)])
+  @test isnothing(cache)
 
-  # duplicated geometries are repaired
-  dseg = Rope([vertices(seg)..., vertices(seg)...])
-  drope = Rope([vertices(rope)..., vertices(rope)[2:end]...])
-  dring = Ring([vertices(ring)..., vertices(ring)...])
-  dpoly = PolyArea([vertices(poly)..., vertices(poly)...])
-  dnpoly = Ngon(vertices(poly)..., vertices(poly)...)
-  dmulti = Multi([dseg, drope, dring, dpoly, dnpoly])
+  # duplicated segments are removed
+  a = cart(0, 0)
+  b = cart(1, 0)
+  c = cart(2, 0)
+  rope = Rope(a, b, c, b, a)
 
-  rseg, cache = TB.apply(repair, dseg)
-  @test rseg == seg
-  rrope, cache = TB.apply(repair, drope)
-  @test rrope == rope
-  rring, cache = TB.apply(repair, dring)
-  @test rring == ring
-  rpoly, cache = TB.apply(repair, dpoly)
-  @test rpoly == poly
-  rngon, cache = TB.apply(repair, dnpoly)
-  @test rngon == ngon
-  rmulti, cache = TB.apply(repair, dmulti)
-  @test rmulti == Multi([seg, rope, ring, poly, ngon])
+  rrope, cache = TB.apply(repair, rope)
+  @test rrope == Multi([Segment(a, b), Segment(b, c)])
+  @test isnothing(cache)
 
-  # branching rope
+  # duplicated segments with opposite orientations are removed
+  a = cart(0, 0)
+  b = cart(1, 0)
+  c = cart(2, 0)
+  rope = Rope(a, b, c, b, a, b)
+
+  rrope, cache = TB.apply(repair, rope)
+  @test rrope == Multi([Segment(a, b), Segment(b, c)])
+  @test isnothing(cache)
+
+  # first occurrence determines segment orientation
+  a = cart(0, 0)
+  b = cart(1, 0)
+  c = cart(2, 0)
+  rope = Rope(b, a, b, c)
+
+  rrope, cache = TB.apply(repair, rope)
+  @test rrope == Multi([Segment(b, a), Segment(b, c)])
+  @test isnothing(cache)
+
+  # branching rope retains all unique segments
   a = cart(0, 3)
   b = cart(1, 2)
   c = cart(0, 1)
@@ -2496,86 +2513,23 @@ end
   branch = Rope(a, b, c, b, d, b, e)
 
   rbranch, cache = TB.apply(repair, branch)
-  @test rbranch == Multi([Rope(a, b, c), Segment(b, d), Segment(b, e)])
+  @test rbranch == Multi([Segment(a, b), Segment(b, c), Segment(b, d), Segment(b, e)])
+  @test isnothing(cache)
 
-  # two-vertex ring collapses to a segment
-  dring = Ring(cart(0, 0), cart(1, 0))
+  # two-vertex ring collapses to a single unique segment
+  a = cart(0, 0)
+  b = cart(1, 0)
+  ring = Ring(a, b)
 
-  rring, cache = TB.apply(repair, dring)
-  @test rring == Segment(cart(0, 0), cart(1, 0))
+  rring, cache = TB.apply(repair, ring)
+  @test rring == Multi([Segment(a, b)])
+  @test isnothing(cache)
 
-  # poly with holes
-  outer = Ring(cart(0, 0), cart(4, 0), cart(4, 4), cart(0, 4))
-  inner = Ring(cart(1, 1), cart(2, 1), cart(2, 2), cart(1, 2))
-  poly = PolyArea(outer, inner)
-
-  rpoly, cache = TB.apply(repair, poly)
-  @test rpoly == poly
-
-  # degenerate hole is removed (equivalent to Repair(12))
-  hole = Ring(cart(1, 1), cart(2, 1))
-  hpoly = PolyArea([outer, hole])
-
-  rpoly, cache = TB.apply(repair, hpoly)
-  @test rpoly == PolyArea(outer)
-
-  # degenerate outer ring collapses the polygon
-  outer = Ring(cart(0, 0), cart(1, 0))
-  dpoly = PolyArea(outer)
-
-  rpoly, cache = TB.apply(repair, dpoly)
-  @test rpoly == Segment(cart(0, 0), cart(1, 0))
-
-  # duplicated geometries in a Multi are removed
-  p1 = cart(0, 0)
-  p2 = cart(1, 1)
-  dmulti = Multi([p1, p1, p2])
-
-  rmulti, cache = TB.apply(repair, dmulti)
-  @test rmulti == Multi([p1, p2])
-
-  # nested Multis are flattened
-  p1 = cart(0, 0)
-  p2 = cart(1, 1)
-  p3 = cart(2, 2)
-  nmulti = Multi([p1, Multi([p2, p3])])
-
-  rmulti, cache = TB.apply(repair, nmulti)
-  @test rmulti == Multi([p1, p2, p3])
-
-  # nested Multis are flattened and duplicated geometries are removed
-  dmulti = Multi([p1, Multi([p1, p2]), p2])
-
-  rmulti, cache = TB.apply(repair, dmulti)
-  @test rmulti == Multi([p1, p2])
-
-  # a Multi with a single unique geometry is unwrapped
-  dmulti = Multi([p1, p1])
-
-  rmulti, cache = TB.apply(repair, dmulti)
-  @test rmulti == p1
-end
-
-@testitem "Repair fallbacks" setup = [Setup] begin
-  quad = Quadrangle(cart(0, 1, 0), cart(1, 1, 0), cart(1, 0, 0), cart(0, 0, 0))
-  repair = Repair(10)
-  rquad, cache = TB.apply(repair, quad)
-  @test rquad isa Quadrangle
-  @test rquad == quad
-
-  poly1 = PolyArea(cart.([(0, 0), (0, 2), (2, 2), (2, 0)]))
-  poly2 = PolyArea(cart.([(0, 0), (0, 1), (1, 1), (1, 0)]))
-  multi = Multi([poly1, poly2])
-  repair = Repair(11)
-  rmulti, cache = TB.apply(repair, multi)
-  @test rmulti == Multi([repair(poly1), repair(poly2)])
-
-  poly1 = PolyArea(cart.([(0, 0), (0, 2), (2, 2), (2, 0)]))
-  poly2 = PolyArea(cart.([(0, 0), (0, 1), (1, 1), (1, 0)]))
-  gset = GeometrySet([poly1, poly2])
-  repair = Repair(11)
-  rgset, cache = TB.apply(repair, gset)
-  @test rgset == GeometrySet([repair(poly1), repair(poly2)])
+  # type-stability
+  @inferred repair(seg)
+  @inferred repair(rope)
+  @inferred repair(ring)
+  @inferred repair(branch)
 end
 
 @testitem "Repair IO" setup = [Setup] begin


### PR DESCRIPTION
This PR follows up on Issue #1408.

### Example

Consider the following `Rope` (see the corresponding plot in the issue):
```julia
r = Rope([
    Point(632596.1106999982, 7.466356763999997e6),
    Point(632596.9879999992, 7.466353485000003e6),
    Point(632593.2699999996, 7.466351208799998e6),
    Point(632596.9879999992, 7.466353485000003e6),
    Point(632599.0611,       7.4663482532e6),
    Point(632596.9879999992, 7.466353485000003e6),
    Point(632604.8297999997, 7.466354170700002e6),
])
```
Currently, `Repair(0)` removes duplicated vertices directly:
```julia
julia> r |> Repair(0)
Rope
├─ Point(x: 632596.1106999982 m, y: 7.466356763999997e6 m)
├─ Point(x: 632593.2699999996 m, y: 7.466351208799998e6 m)
├─ Point(x: 632599.0611 m, y: 7.4663482532e6 m)
├─ Point(x: 632596.9879999992 m, y: 7.466353485000003e6 m)
└─ Point(x: 632604.8297999997 m, y: 7.466354170700002e6 m)
```
This changes the original geometry by creating connections that were not present in the input.

This PR changes the duplicate-removal logic so that duplicated edges are removed while the valid parts of the original geometry are preserved.

### Discussion

The above behavior results from the current handling of `Polytope`s. Consequently, `Repair(0)` can create new edges not only for `Chain`s, but also for `Polygon`s in general. If we consider this behavior problematic, then the `Repair` algorithm for these geometries should be reconsidered.

Notice that the new algorithm cannot preserve type stability in general (a `Rope` can become a `Multi`, as in the example above). Therefore, overriding the current behavior of `Repair(0)` leads to failures across several parts of Meshes.jl that rely on its existing behavior. For this reason, I propose introducing `Repair(13)` specifically for the removal of duplicated edges.   

### Result

With the proposed changes:
```julia
julia> r |> Repair(13)
Multi(3×Chain)
├─ Rope((x: 6.32596e5 m, y: 7.46636e6 m), (x: 632597.0 m, y: 7.46635e6 m), (x: 6.32593e5 m, y: 7.46635e6 m))
├─ Segment((x: 632597.0 m, y: 7.46635e6 m), (x: 6.32599e5 m, y: 7.46635e6 m))
└─ Segment((x: 632597.0 m, y: 7.46635e6 m), (x: 6.32605e5 m, y: 7.46635e6 m))
```
Hence, the repaired result preserves the geometry encoded by the raw data while removing duplicated edge information.