### PR TITLE
Add conversion between azimuths and tangent vectors

### DIFF
--- a/docs/src/geodesics.md
+++ b/docs/src/geodesics.md
@@ -13,6 +13,8 @@ ellipsoid attached to the datum of the coordinates.
 ```@docs
 geodesicfwd
 geodesicbwd
+geodesictangent
+geodesicazimuth
 ```
 
 The direct problem walks a given length along a given azimuth. Plain
@@ -51,4 +53,20 @@ obtained by swapping the arguments:
 
 ```@example geodesics
 geodesicbwd(london, sydney)
+```
+
+## Tangent vectors
+
+An azimuth at a point can also be expressed as a unit vector tangent to
+the ellipsoid there, in geocentric Cartesian coordinates:
+
+```@example geodesics
+geodesictangent(sydney, geodesicbwd(sydney, london))
+```
+
+The conversion goes both ways, and any component of the vector along the
+normal of the ellipsoid is ignored:
+
+```@example geodesics
+geodesicazimuth(sydney, geodesictangent(sydney, 45))
 ```

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -475,6 +475,8 @@ export
   # geodesics
   geodesicfwd,
   geodesicbwd,
+  geodesictangent,
+  geodesicazimuth,
 
   # centroids
   centroid,

--- a/src/geodesics.jl
+++ b/src/geodesics.jl
@@ -90,6 +90,57 @@ function geodesicbwd(p₁::Point{🌐}, p₂::Point{🌐})
   T(ϕ₁) * u"°"
 end
 
+"""
+    geodesictangent(p, ϕ)
+
+Unit vector tangent to the ellipsoid at the point `p`, pointing along
+the azimuth `ϕ`, measured clockwise from the north.
+
+The vector is expressed in the geocentric Cartesian coordinates of the
+datum of `p`, and is the direction in which [`geodesicfwd`](@ref) walks.
+
+See also [`geodesicazimuth`](@ref).
+
+## Examples
+
+```julia
+p = Point(LatLon(0, 0))
+
+geodesictangent(p, 90u"°")
+
+geodesictangent(p, 90)
+```
+"""
+function geodesictangent(p::Point{🌐}, ϕ)
+  T = numtype(lentype(p))
+  ê, n̂ = _eastnorth(p)
+  s, c = sincosd(T(ustrip(u"°", asdeg(ϕ))))
+  unormalize(c * n̂ + s * ê)
+end
+
+"""
+    geodesicazimuth(p, v)
+
+Azimuth of the vector `v` at the point `p` of the ellipsoid, measured
+clockwise from the north. Any component of `v` along the normal of the
+ellipsoid is ignored, and the azimuth is undefined if nothing is left.
+
+See also [`geodesictangent`](@ref).
+
+## Examples
+
+```julia
+p = Point(LatLon(0, 0))
+
+geodesicazimuth(p, Vec(0, 1, 0))
+```
+"""
+function geodesicazimuth(p::Point{🌐}, v::Vec{3})
+  T = numtype(lentype(p))
+  ê, n̂ = _eastnorth(p)
+  T(atand(v ⋅ ê, v ⋅ n̂)) * u"°"
+end
+
 # Solution of the direct geodesic problem: the point reached from (lat₁, lon₁)
 # after walking s₁₂ along the geodesic that leaves with azimuth azi₁, following
 # Karney (2013) section 3. Angles are in degrees, the length in the unit of the
@@ -332,6 +383,19 @@ end
 # ------------------------
 # MISCELLANEOUS UTILITIES
 # ------------------------
+
+# East and north unit vectors of the local frame at the point p, expressed in
+# geocentric Cartesian coordinates. Together with the normal of the ellipsoid
+# they form the frame in which azimuths are measured.
+function _eastnorth(p::Point{🌐})
+  c = convert(manifoldcrs(p), coords(p))
+  sφ, cφ = sincosd(ustrip(c.lat))
+  sλ, cλ = sincosd(ustrip(c.lon))
+  u = unit(lentype(p))
+  ê = Vec(-sλ * u, cλ * u, zero(sλ) * u)
+  n̂ = Vec(-sφ * cλ * u, -sφ * sλ * u, cφ * u)
+  (ê, n̂)
+end
 
 # quantities that Karney's series need on top of the parameters that
 # CoordRefSystems.jl already provides for the ellipsoid of revolution

--- a/test/geodesics.jl
+++ b/test/geodesics.jl
@@ -94,3 +94,55 @@
     @test isapprox(geodesicbwd(r₁, r₂), greatcircle * u"°", atol=1e-9u"°")
   end
 end
+
+@testitem "Tangent vectors" setup = [Setup] begin
+  # taking the direction from a chord differences two geocentric vectors of
+  # about 6400 km, which leaves little of a Float32 mantissa for a short chord
+  τϕ = T === Float64 ? 1e-2u"°" : 1u"°"
+
+  # tangent vectors and azimuths are only defined on the ellipsoid
+  @test_throws MethodError geodesictangent(cart(0, 0, 0), 90)
+  @test_throws MethodError geodesicazimuth(cart(0, 0, 0), vector(0, 1, 0))
+
+  # the frame at the origin of the coordinates is aligned with the axes
+  p = latlon(0, 0)
+  @test geodesictangent(p, 0) ≈ vector(0, 0, 1)
+  @test geodesictangent(p, 90) ≈ vector(0, 1, 0)
+  @test geodesictangent(p, 180) ≈ vector(0, 0, -1)
+
+  # the vector is a unit vector in the length unit of the point
+  for ϕ in (0, 37, 90, 143, 180, -75)
+    @test isapprox(norm(geodesictangent(latlon(43, -21), ϕ)), oneunit(T) * u"m", atol=1e-6u"m")
+  end
+
+  # units are optional, and the numeric type follows the point and not the angle
+  @test geodesictangent(latlon(30, 40), 25u"°") ≈ geodesictangent(latlon(30, 40), 25)
+  @test Unitful.numtype(eltype(geodesictangent(latlon(30, 40), 25))) === T
+  @test Unitful.numtype(typeof(geodesicazimuth(latlon(30, 40), geodesictangent(latlon(30, 40), 25)))) === T
+
+  # azimuth inverts tangent
+  for lat in T.(-80:20:80), lon in T.(-150:50:150), ϕ in T.(-150:50:150)
+    q = latlon(lat, lon)
+    @test isapprox(geodesicazimuth(q, geodesictangent(q, ϕ)), ϕ * u"°", atol=1e-4u"°")
+  end
+
+  # the two tangents span the horizon plane, and any component of the
+  # vector along the normal of that plane is ignored
+  q = latlon(45, 10)
+  v = geodesictangent(q, 30)
+  n = normal(Plane(q, geodesictangent(q, 90), geodesictangent(q, 0)))
+  @test geodesicazimuth(q, v) ≈ geodesicazimuth(q, 2v)
+  @test isapprox(geodesicazimuth(q, v + n), geodesicazimuth(q, v), atol=1000eps(T) * u"°")
+  @test isapprox(geodesicazimuth(q, v - 3n), geodesicazimuth(q, v), atol=1000eps(T) * u"°")
+
+  # the tangent points in the direction that geodesicfwd walks
+  for ϕ in T.((-120, -30, 15, 88, 170))
+    q = latlon(-12, 77)
+    @test isapprox(geodesicazimuth(q, geodesicfwd(q, ϕ, 1000) - q), ϕ * u"°", atol=τϕ)
+  end
+
+  # the tangent is consistent with the azimuth of the inverse problem
+  p₁ = latlon(-33.8688, 151.2093)
+  p₂ = latlon(51.5074, -0.1278)
+  @test isapprox(geodesicazimuth(p₁, geodesictangent(p₁, geodesicbwd(p₁, p₂))), geodesicbwd(p₁, p₂), atol=1e-4u"°")
+end


### PR DESCRIPTION
Follow up to #1426, adds the conversion between azimuths and tangent vectors.

```julia
geodesictangent(p, ϕ)   # unit vector tangent at p along azimuth ϕ
geodesicazimuth(p, v)   # azimuth of v at p
```

This is just the local east/north frame at `p`, so there is no new numerics here. The vector comes back with norm 1 m, the same as `normal` does, and any part of `v` along the normal of the ellipsoid gets ignored.

I checked the tangent against the exact derivative of `geodesicfwd` using autodiff, worst case 2.3e-14 deg, and the round trip is 2.8e-14 deg over 51840 cases. No allocations.

One thing to know, at the poles the frame depends on the stored longitude, so ϕ is relative to that there.
