### PR TITLE
Add Geodesic primitive

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -201,6 +201,7 @@ export
   Point,
   Ray,
   Line,
+  Geodesic,
   BezierCurve,
   ParametrizedCurve,
   Plane,

--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -37,6 +37,13 @@ boundary(::Line) = nothing
 
 embedboundary(l::Line) = l
 
+function boundary(g::Geodesic)
+  p₁, p₂ = extrema(g)
+  p₁ ≈ p₂ ? nothing : Multi([p₁, p₂])
+end
+
+embedboundary(g::Geodesic) = g
+
 function boundary(b::BezierCurve)
   p = controls(b)
   p₁, p₂ = first(p), last(p)

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -201,6 +201,8 @@ function simplexify end
 
 simplexify(box::Box) = discretize(box, ManualSimplexification())
 
+simplexify(geodesic::Geodesic) = discretize(geodesic, RegularDiscretization(50))
+
 simplexify(bezier::BezierCurve) = discretize(bezier, RegularDiscretization(50))
 
 simplexify(curve::ParametrizedCurve) = discretize(curve, RegularDiscretization(50))

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -5,11 +5,9 @@
 """
     Segment(p1, p2)
 
-An oriented line segment with end points `p1`, `p2`.
-The segment can be called as `s(t)` with `t` between
-`0` and `1` to interpolate linearly between its endpoints.
+An oriented line segment from point `p1` to `p2`.
 
-See also [`Rope`](@ref), [`Ring`](@ref), [`Line`](@ref).
+See also [`Geodesic`](@ref), [`Line`](@ref).
 """
 @polytope Segment 1 2
 

--- a/src/geometries/primitives.jl
+++ b/src/geometries/primitives.jl
@@ -15,6 +15,7 @@ abstract type Primitive{M<:Manifold,C<:CRS} <: Geometry{M,C} end
 include("primitives/point.jl")
 include("primitives/ray.jl")
 include("primitives/line.jl")
+include("primitives/geodesic.jl")
 include("primitives/beziercurve.jl")
 include("primitives/paramcurve.jl")
 include("primitives/plane.jl")

--- a/src/geometries/primitives/geodesic.jl
+++ b/src/geometries/primitives/geodesic.jl
@@ -41,7 +41,7 @@ Base.extrema(g::Geodesic) = g.a, g.b
 Base.isapprox(g₁::Geodesic, g₂::Geodesic; atol=atol(lentype(g₁)), kwargs...) =
   isapprox(g₁.a, g₂.a; atol=atol, kwargs...) && isapprox(g₁.b, g₂.b; atol=atol, kwargs...)
 
-(g::Geodesic{𝔼})(t) = g.a + (t * g.length) * g.dirvec
+(g::Geodesic{<:𝔼})(t) = g.a + t * (g.b - g.a)
 
 (g::Geodesic{🌐})(t) = geodesicfwd(g.a, geodesicazimuth(g.a, g.dirvec), t * g.length)
 
@@ -66,5 +66,5 @@ end
 # HELPER FUNCTIONS
 # -----------------
 
-_geodesicdirection(a::Point{𝔼}, b::Point{𝔼}) = unormalize(b - a)
+_geodesicdirection(a::Point{<:𝔼}, b::Point{<:𝔼}) = unormalize(b - a)
 _geodesicdirection(a::Point{🌐}, b::Point{🌐}) = geodesictangent(a, geodesicbwd(a, b))

--- a/src/geometries/primitives/geodesic.jl
+++ b/src/geometries/primitives/geodesic.jl
@@ -15,15 +15,15 @@ struct Geodesic{M<:Manifold,C<:CRS,V<:Vec,ℒ<:Len} <: Primitive{M,C}
   b::Point{M,C}
 
   # state fields
-  dirvec::V
-  length::ℒ
+  v::V
+  l::ℒ
 end
 
 function Geodesic(a::Point, b::Point)
   a′, b′ = promote(a, b)
-  dirvec = _geodesicdirection(a′, b′)
-  length = GeodesicDistance()(a′, b′)
-  Geodesic(a′, b′, dirvec, length)
+  v = _geodesicdir(a′, b′)
+  l = _geodesiclen(a′, b′)
+  Geodesic(a′, b′, v, l)
 end
 
 Geodesic(a::Tuple, b::Tuple) = Geodesic(Point(a), Point(b))
@@ -36,16 +36,16 @@ Base.maximum(g::Geodesic) = g.b
 
 Base.extrema(g::Geodesic) = g.a, g.b
 
-Base.length(g::Geodesic) = g.length
+Base.length(g::Geodesic) = g.l
 
 ==(g₁::Geodesic, g₂::Geodesic) = g₁.a == g₂.a && g₁.b == g₂.b
 
 Base.isapprox(g₁::Geodesic, g₂::Geodesic; atol=atol(lentype(g₁)), kwargs...) =
   isapprox(g₁.a, g₂.a; atol=atol, kwargs...) && isapprox(g₁.b, g₂.b; atol=atol, kwargs...)
 
-(g::Geodesic{<:𝔼})(t) = g.a + t * g.length * g.dirvec
+(g::Geodesic{<:𝔼})(t) = g.a + (t * g.l) * g.v
 
-(g::Geodesic{🌐})(t) = geodesicfwd(g.a, geodesicazimuth(g.a, g.dirvec), t * g.length)
+(g::Geodesic{🌐})(t) = geodesicfwd(g.a, geodesicazimuth(g.a, g.v), t * g.l)
 
 Base.reverse(g::Geodesic) = Geodesic(g.b, g.a)
 
@@ -70,5 +70,6 @@ end
 # HELPER FUNCTIONS
 # -----------------
 
-_geodesicdirection(a::Point{<:𝔼}, b::Point{<:𝔼}) = unormalize(b - a)
-_geodesicdirection(a::Point{🌐}, b::Point{🌐}) = geodesictangent(a, geodesicbwd(a, b))
+_geodesicdir(a::Point{𝔼{Dim}}, b::Point{𝔼{Dim}}) where {Dim} = unormalize(b - a)
+_geodesicdir(a::Point{🌐}, b::Point{🌐}) = geodesictangent(a, geodesicbwd(a, b))
+_geodesiclen(a::Point, b::Point) = GeodesicDistance()(a, b)

--- a/src/geometries/primitives/geodesic.jl
+++ b/src/geometries/primitives/geodesic.jl
@@ -36,14 +36,18 @@ Base.maximum(g::Geodesic) = g.b
 
 Base.extrema(g::Geodesic) = g.a, g.b
 
+Base.length(g::Geodesic) = g.length
+
 ==(g₁::Geodesic, g₂::Geodesic) = g₁.a == g₂.a && g₁.b == g₂.b
 
 Base.isapprox(g₁::Geodesic, g₂::Geodesic; atol=atol(lentype(g₁)), kwargs...) =
   isapprox(g₁.a, g₂.a; atol=atol, kwargs...) && isapprox(g₁.b, g₂.b; atol=atol, kwargs...)
 
-(g::Geodesic{<:𝔼})(t) = g.a + t * (g.b - g.a)
+(g::Geodesic{<:𝔼})(t) = g.a + t * g.length * g.dirvec
 
 (g::Geodesic{🌐})(t) = geodesicfwd(g.a, geodesicazimuth(g.a, g.dirvec), t * g.length)
+
+Base.reverse(g::Geodesic) = Geodesic(g.b, g.a)
 
 # -----------
 # IO METHODS

--- a/src/geometries/primitives/geodesic.jl
+++ b/src/geometries/primitives/geodesic.jl
@@ -1,0 +1,70 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    Geodesic(a, b)
+
+A geodesic from point `a` to `b`.
+
+See also [`Segment`](@ref), [`Line`](@ref).
+"""
+struct Geodesic{M<:Manifold,C<:CRS,V<:Vec,ℒ<:Len} <: Primitive{M,C}
+  # input fields
+  a::Point{M,C}
+  b::Point{M,C}
+
+  # state fields
+  dirvec::V
+  length::ℒ
+end
+
+function Geodesic(a::Point, b::Point)
+  a′, b′ = promote(a, b)
+  dirvec = _geodesicdirection(a′, b′)
+  length = GeodesicDistance()(a′, b′)
+  Geodesic(a′, b′, dirvec, length)
+end
+
+Geodesic(a::Tuple, b::Tuple) = Geodesic(Point(a), Point(b))
+
+paramdim(::Type{<:Geodesic}) = 1
+
+Base.minimum(g::Geodesic) = g.a
+
+Base.maximum(g::Geodesic) = g.b
+
+Base.extrema(g::Geodesic) = g.a, g.b
+
+==(g₁::Geodesic, g₂::Geodesic) = g₁.a == g₂.a && g₁.b == g₂.b
+
+Base.isapprox(g₁::Geodesic, g₂::Geodesic; atol=atol(lentype(g₁)), kwargs...) =
+  isapprox(g₁.a, g₂.a; atol=atol, kwargs...) && isapprox(g₁.b, g₂.b; atol=atol, kwargs...)
+
+(g::Geodesic{𝔼})(t) = g.a + (t * g.length) * g.dirvec
+
+(g::Geodesic{🌐})(t) = geodesicfwd(g.a, geodesicazimuth(g.a, g.dirvec), t * g.length)
+
+# -----------
+# IO METHODS
+# -----------
+
+function Base.show(io::IO, g::Geodesic)
+  name = prettyname(g)
+  ioctx = IOContext(io, :compact => true)
+  print(io, "$name(")
+  printfields(ioctx, g, (:a, :b), singleline=true)
+  print(io, ")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", g::Geodesic)
+  summary(io, g)
+  printfields(io, g, (:a, :b))
+end
+
+# -----------------
+# HELPER FUNCTIONS
+# -----------------
+
+_geodesicdirection(a::Point{𝔼}, b::Point{𝔼}) = unormalize(b - a)
+_geodesicdirection(a::Point{🌐}, b::Point{🌐}) = geodesictangent(a, geodesicbwd(a, b))

--- a/src/geometries/primitives/line.jl
+++ b/src/geometries/primitives/line.jl
@@ -7,7 +7,7 @@
 
 A line passing through points `a` and `b`.
 
-See also [`Segment`](@ref).
+See also [`Segment`](@ref), [`Geodesic`](@ref).
 """
 struct Line{M<:Manifold,C<:CRS} <: Primitive{M,C}
   a::Point{M,C}

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -19,6 +19,8 @@ measure(g::GeometryOrDomain) = integral(_ -> 1, g)
 
 measure(p::Point) = zero(lentype(p))
 
+measure(g::Geodesic) = length(g)
+
 measure(r::Ray) = typemax(lentype(r))
 
 measure(l::Line) = typemax(lentype(l))
@@ -168,6 +170,8 @@ the [`measure`](@ref) of its [`boundary`](@ref).
 perimeter(g) = measure(boundary(g))
 
 perimeter(s::Segment) = zero(lentype(s))
+
+perimeter(g::Geodesic) = zero(lentype(g))
 
 perimeter(c::BezierCurve) = zero(lentype(c))
 

--- a/src/predicates/isparametrized.jl
+++ b/src/predicates/isparametrized.jl
@@ -19,11 +19,13 @@ isparametrized(::Type{<:Ray}) = true
 
 isparametrized(::Type{<:Line}) = true
 
-isparametrized(::Type{<:Plane}) = true
+isparametrized(::Type{<:Geodesic}) = true
 
 isparametrized(::Type{<:BezierCurve}) = true
 
 isparametrized(::Type{<:ParametrizedCurve}) = true
+
+isparametrized(::Type{<:Plane}) = true
 
 isparametrized(::Type{<:Box{<:𝔼}}) = true
 

--- a/src/predicates/isperiodic.jl
+++ b/src/predicates/isperiodic.jl
@@ -16,6 +16,8 @@ isperiodic(::Type{<:Ray}) = (false,)
 
 isperiodic(::Type{<:Line}) = (false,)
 
+isperiodic(g::Geodesic) = (minimum(g) == maximum(g),)
+
 isperiodic(b::BezierCurve) = (first(controls(b)) == last(controls(b)),)
 
 isperiodic(c::ParametrizedCurve) = (minimum(c) == maximum(c),)


### PR DESCRIPTION
So that we can treat geodesics as first-class objects.

For example:

```julia
using Meshes
using CoordRefSystems
import GLMakie

s = Segment(Point(LatLon(0,0)), Point(LatLon(45,90)))
g = Geodesic(Point(LatLon(0,0)), Point(LatLon(45,90)))

viz(s, color="teal")
viz!(g, color="salmon")
```
<img width="450" height="343" alt="image" src="https://github.com/user-attachments/assets/aa73eaf0-bb84-40ca-9f96-7d62e90d2619" />
