### PR TITLE
Fix `Segment` definition on ellipsoid

### DIFF
--- a/src/geodesics.jl
+++ b/src/geodesics.jl
@@ -29,21 +29,28 @@ geodesicfwd(p, 90, 1000000)
 * Karney, C. F. F. 2013. [Algorithms for geodesics](https://doi.org/10.1007/s00190-012-0578-z)
 """
 function geodesicfwd(p::Point{🌐}, ϕ, l)
+  # convert coordinates to LatLon
   c = convert(manifoldcrs(p), coords(p))
-
-  # the ellipsoid comes from the datum of the coordinates
   🌎 = ellipsoid(datum(c))
+  u = unit(majoraxis(🌎))
+
+  # unitful azimuth and length
+  ϕ′ = asdeg(ϕ)
+  l′ = aslen(l)
 
   # the series of Karney need double precision to reach round-off
   T = numtype(lentype(c))
-  S = promote_type(T, Float64)
-  lat, lon = S(ustrip(c.lat)), S(ustrip(c.lon))
-  azi = S(ustrip(u"°", asdeg(ϕ)))
-  len = S(ustrip(unit(majoraxis(🌎)), aslen(l)))
+  U = numtype(typeof(ϕ′))
+  V = numtype(typeof(l′))
+  S = promote_type(T, U, V, Float64)
+  lat = S(ustrip(c.lat))
+  lon = S(ustrip(c.lon))
+  azi = S(ustrip(ϕ′))
+  len = S(ustrip(u, l′))
 
   lat′, lon′, _ = _geodesicdirect(🌎, lat, lon, azi, len)
 
-  withcrs(p, (T(lat′), T(lon′)))
+  withcrs(p, (lat′, lon′))
 end
 
 """

--- a/src/geodesics.jl
+++ b/src/geodesics.jl
@@ -42,6 +42,7 @@ function geodesicfwd(p::Point{🌐}, ϕ, l)
   T = numtype(lentype(c))
   U = numtype(typeof(ϕ′))
   V = numtype(typeof(l′))
+  R = promote_type(T, U, V)
   S = promote_type(T, U, V, Float64)
   lat = S(ustrip(c.lat))
   lon = S(ustrip(c.lon))
@@ -50,7 +51,7 @@ function geodesicfwd(p::Point{🌐}, ϕ, l)
 
   lat′, lon′, _ = _geodesicdirect(🌎, lat, lon, azi, len)
 
-  withcrs(p, (lat′, lon′))
+  withcrs(p, (R(lat′), R(lon′)))
 end
 
 """
@@ -119,9 +120,12 @@ geodesictangent(p, 90)
 ```
 """
 function geodesictangent(p::Point{🌐}, ϕ)
+  ϕ′ = asdeg(ϕ)
   T = numtype(lentype(p))
+  U = numtype(typeof(ϕ′))
+  S = promote_type(T, U)
   ê, n̂ = _eastnorth(p)
-  s, c = sincosd(T(ustrip(u"°", asdeg(ϕ))))
+  s, c = sincosd(S(ustrip(ϕ′)))
   unormalize(c * n̂ + s * ê)
 end
 
@@ -144,8 +148,10 @@ geodesicazimuth(p, Vec(0, 1, 0))
 """
 function geodesicazimuth(p::Point{🌐}, v::Vec{3})
   T = numtype(lentype(p))
+  U = numtype(eltype(v))
+  S = promote_type(T, U)
   ê, n̂ = _eastnorth(p)
-  T(atand(v ⋅ ê, v ⋅ n̂)) * u"°"
+  S(atand(v ⋅ ê, v ⋅ n̂)) * u"°"
 end
 
 # Solution of the direct geodesic problem: the point reached from (lat₁, lon₁)

--- a/src/geometries/polytopes.jl
+++ b/src/geometries/polytopes.jl
@@ -5,7 +5,7 @@
 """
     Polytope{K,M,CRS}
 
-We say that a geometry is a K-polytope when it is a collection of "flat" sides
+We say that a geometry is a `K`-polytope when it is a collection of "sides"
 that constitute a `K`-dimensional subspace. They are called chain, polygon and
 polyhedron respectively for 1D (`K=1`), 2D (`K=2`) and 3D (`K=3`) subspaces.
 The parameter `K` is also known as the rank or parametric dimension

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -57,23 +57,6 @@ Base.isapprox(s₁::Segment, s₂::Segment; atol=atol(lentype(s₁)), kwargs...)
 
 Base.reverse(s::Segment) = Segment(s.b, s.a)
 
-# -----------
-# IO METHODS
-# -----------
-
-function Base.show(io::IO, s::Segment)
-  name = prettyname(s)
-  ioctx = IOContext(io, :compact => true)
-  print(io, "$name(")
-  printfields(ioctx, s, (:a, :b), singleline=true)
-  print(io, ")")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", s::Segment)
-  summary(io, s)
-  printfields(io, s, (:a, :b))
-end
-
 # -----------------
 # HELPER FUNCTIONS
 # -----------------

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -5,44 +5,47 @@
 """
     Segment(p1, p2)
 
-An oriented line segment from point `p1` to point `p2`.
+An oriented, geodesic line segment from point `p1` to point `p2`.
+
+## Examples
+
+```julia
+# segment in Euclidean manifold
+Segment((0, 0), (1, 1))
+
+# segment in ellipsoid manifold
+Segment(Point(LatLon(0, 0)), Point(LatLon(45, 90)))
+```
 
 See also [`Rope`](@ref), [`Ring`](@ref), [`Line`](@ref).
 """
-struct Segment{M<:Manifold,C<:CRS} <: Chain{M,C}
-  a::Point{M,C}
-  b::Point{M,C}
-end
-
-Segment(a::Tuple, b::Tuple) = Segment(Point(a), Point(b))
-
-Segment(ab::AbstractVector) = Segment(ab...)
-
-Segment(ab::Tuple) = Segment(ab...)
+@polytope Segment 1 2
 
 nvertices(::Type{<:Segment}) = 2
 
-vertices(s::Segment) = SVector(s.a, s.b)
+Base.minimum(s::Segment) = s.vertices[1]
 
-Base.minimum(s::Segment) = s.a
+Base.maximum(s::Segment) = s.vertices[2]
 
-Base.maximum(s::Segment) = s.b
-
-Base.extrema(s::Segment) = s.a, s.b
+Base.extrema(s::Segment) = s.vertices[1], s.vertices[2]
 
 center(s::Segment{<:𝔼}) = s(1 // 2)
 
-==(s₁::Segment, s₂::Segment) = s₁.a == s₂.a && s₁.b == s₂.b
+==(s₁::Segment, s₂::Segment) = s₁.vertices == s₂.vertices
 
 Base.isapprox(s₁::Segment, s₂::Segment; atol=atol(lentype(s₁)), kwargs...) =
-  isapprox(s₁.a, s₂.a; atol=atol, kwargs...) && isapprox(s₁.b, s₂.b; atol=atol, kwargs...)
+  all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))
 
-(s::Segment{<:𝔼})(t) = s.a + t * (s.b - s.a)
-
-function (s::Segment{🌐})(t)
-  d = GeodesicDistance()
-  ϕ = geodesicbwd(s.a, s.b)
-  geodesicfwd(s.a, ϕ, t * d(s.a, s.b))
+function (s::Segment{<:𝔼})(t)
+  a, b = s.vertices
+  a + t * (b - a)
 end
 
-Base.reverse(s::Segment) = Segment(s.b, s.a)
+function (s::Segment{🌐})(t)
+  a, b = s.vertices
+  d = GeodesicDistance()
+  ϕ = geodesicbwd(a, b)
+  geodesicfwd(a, ϕ, t * d(a, b))
+end
+
+Base.reverse(s::Segment) = Segment(reverse(s.vertices))

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -28,7 +28,9 @@ end
 
 Segment(a::Tuple, b::Tuple) = Segment(Point(a), Point(b))
 
-Segment(vertices::AbstractVector) = Segment(vertices...)
+Segment(ab::AbstractVector) = Segment(ab...)
+
+Segment(ab::Tuple) = Segment(ab...)
 
 nvertices(::Type{<:Segment}) = 2
 

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -34,6 +34,8 @@ Segment(ab::Tuple) = Segment(ab...)
 
 nvertices(::Type{<:Segment}) = 2
 
+vertices(s::Segment) = SVector(s.a, s.b)
+
 Base.minimum(s::Segment) = s.a
 
 Base.maximum(s::Segment) = s.b

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -5,32 +5,75 @@
 """
     Segment(p1, p2)
 
-An oriented line segment with end points `p1`, `p2`.
-The segment can be called as `s(t)` with `t` between
-`0` and `1` to interpolate linearly between its endpoints.
+An oriented line segment from point `p1` to point `p2`.
 
 See also [`Rope`](@ref), [`Ring`](@ref), [`Line`](@ref).
 """
-@polytope Segment 1 2
+struct Segment{M<:Manifold,C<:CRS,V<:Vec,ℒ<:Len} <: Chain{M,C}
+  # input fields
+  a::Point{M,C}
+  b::Point{M,C}
+
+  # state fields
+  v::V
+  l::ℒ
+end
+
+function Segment(a::Point, b::Point)
+  a′, b′ = promote(a, b)
+  v = _geodesicvec(a′, b′)
+  l = _geodesiclen(a′, b′)
+  Segment(a′, b′, v, l)
+end
+
+Segment(a::Tuple, b::Tuple) = Segment(Point(a), Point(b))
+
+Segment(vertices::AbstractVector) = Segment(vertices...)
 
 nvertices(::Type{<:Segment}) = 2
 
-Base.minimum(s::Segment) = s.vertices[1]
+Base.minimum(s::Segment) = s.a
 
-Base.maximum(s::Segment) = s.vertices[2]
+Base.maximum(s::Segment) = s.b
 
-Base.extrema(s::Segment) = s.vertices[1], s.vertices[2]
+Base.extrema(s::Segment) = s.a, s.b
 
-center(s::Segment) = coordmean(extrema(s))
+Base.length(s::Segment) = s.l
 
-==(s₁::Segment, s₂::Segment) = s₁.vertices == s₂.vertices
+center(s::Segment{<:𝔼}) = s(1 // 2)
+
+==(s₁::Segment, s₂::Segment) = s₁.a == s₂.a && s₁.b == s₂.b
 
 Base.isapprox(s₁::Segment, s₂::Segment; atol=atol(lentype(s₁)), kwargs...) =
-  all(isapprox(v₁, v₂; atol, kwargs...) for (v₁, v₂) in zip(s₁.vertices, s₂.vertices))
+  isapprox(s₁.a, s₂.a; atol=atol, kwargs...) && isapprox(s₁.b, s₂.b; atol=atol, kwargs...)
 
-function (s::Segment)(t)
-  a, b = s.vertices
-  coordsum((a, b), weights=((1 - t), t))
+(s::Segment{<:𝔼})(t) = s.a + (t * ustrip(s.l)) * s.v
+
+(s::Segment{🌐})(t) = geodesicfwd(s.a, geodesicazimuth(s.a, s.v), t * s.l)
+
+Base.reverse(s::Segment) = Segment(s.b, s.a)
+
+# -----------
+# IO METHODS
+# -----------
+
+function Base.show(io::IO, s::Segment)
+  name = prettyname(s)
+  ioctx = IOContext(io, :compact => true)
+  print(io, "$name(")
+  printfields(ioctx, s, (:a, :b), singleline=true)
+  print(io, ")")
 end
 
-Base.reverse(s::Segment) = Segment(reverse(extrema(s)))
+function Base.show(io::IO, ::MIME"text/plain", s::Segment)
+  summary(io, s)
+  printfields(io, s, (:a, :b))
+end
+
+# -----------------
+# HELPER FUNCTIONS
+# -----------------
+
+_geodesicvec(a::Point{𝔼{Dim}}, b::Point{𝔼{Dim}}) where {Dim} = unormalize(b - a)
+_geodesicvec(a::Point{🌐}, b::Point{🌐}) = geodesictangent(a, geodesicbwd(a, b))
+_geodesiclen(a::Point, b::Point) = GeodesicDistance()(a, b)

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -10,10 +10,10 @@ An oriented, geodesic line segment from point `p1` to point `p2`.
 ## Examples
 
 ```julia
-# segment in Euclidean manifold
+# straight segment in Euclidean space
 Segment((0, 0), (1, 1))
 
-# segment in ellipsoid manifold
+# geodesic segment in Earth's surface
 Segment(Point(LatLon(0, 0)), Point(LatLon(45, 90)))
 ```
 

--- a/src/geometries/polytopes/segment.jl
+++ b/src/geometries/polytopes/segment.jl
@@ -9,21 +9,9 @@ An oriented line segment from point `p1` to point `p2`.
 
 See also [`Rope`](@ref), [`Ring`](@ref), [`Line`](@ref).
 """
-struct Segment{M<:Manifold,C<:CRS,V<:Vec,ℒ<:Len} <: Chain{M,C}
-  # input fields
+struct Segment{M<:Manifold,C<:CRS} <: Chain{M,C}
   a::Point{M,C}
   b::Point{M,C}
-
-  # state fields
-  v::V
-  l::ℒ
-end
-
-function Segment(a::Point, b::Point)
-  a′, b′ = promote(a, b)
-  v = _geodesicvec(a′, b′)
-  l = _geodesiclen(a′, b′)
-  Segment(a′, b′, v, l)
 end
 
 Segment(a::Tuple, b::Tuple) = Segment(Point(a), Point(b))
@@ -42,8 +30,6 @@ Base.maximum(s::Segment) = s.b
 
 Base.extrema(s::Segment) = s.a, s.b
 
-Base.length(s::Segment) = s.l
-
 center(s::Segment{<:𝔼}) = s(1 // 2)
 
 ==(s₁::Segment, s₂::Segment) = s₁.a == s₂.a && s₁.b == s₂.b
@@ -51,16 +37,12 @@ center(s::Segment{<:𝔼}) = s(1 // 2)
 Base.isapprox(s₁::Segment, s₂::Segment; atol=atol(lentype(s₁)), kwargs...) =
   isapprox(s₁.a, s₂.a; atol=atol, kwargs...) && isapprox(s₁.b, s₂.b; atol=atol, kwargs...)
 
-(s::Segment{<:𝔼})(t) = s.a + (t * ustrip(s.l)) * s.v
+(s::Segment{<:𝔼})(t) = s.a + t * (s.b - s.a)
 
-(s::Segment{🌐})(t) = geodesicfwd(s.a, geodesicazimuth(s.a, s.v), t * s.l)
+function (s::Segment{🌐})(t)
+  d = GeodesicDistance()
+  ϕ = geodesicbwd(s.a, s.b)
+  geodesicfwd(s.a, ϕ, t * d(s.a, s.b))
+end
 
 Base.reverse(s::Segment) = Segment(s.b, s.a)
-
-# -----------------
-# HELPER FUNCTIONS
-# -----------------
-
-_geodesicvec(a::Point{𝔼{Dim}}, b::Point{𝔼{Dim}}) where {Dim} = unormalize(b - a)
-_geodesicvec(a::Point{🌐}, b::Point{🌐}) = geodesictangent(a, geodesicbwd(a, b))
-_geodesiclen(a::Point, b::Point) = GeodesicDistance()(a, b)

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -75,7 +75,7 @@ function measure(t::Torus)
   4 * T(π)^2 * R * r
 end
 
-measure(s::Segment{<:𝔼}) = norm(maximum(s) - minimum(s))
+measure(s::Segment) = length(s)
 
 measure(c::Chain{<:𝔼}) = sum(measure, segments(c))
 

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -75,7 +75,7 @@ function measure(t::Torus)
   4 * T(π)^2 * R * r
 end
 
-measure(s::Segment) = length(s)
+measure(s::Segment) = GeodesicDistance()(extrema(s)...)
 
 measure(c::Chain{<:𝔼}) = sum(measure, segments(c))
 

--- a/src/predicates/isperiodic.jl
+++ b/src/predicates/isperiodic.jl
@@ -10,8 +10,6 @@ along each parametric dimension.
 """
 isperiodic(g::Geometry) = isperiodic(typeof(g))
 
-isperiodic(::Type{<:Segment}) = (false,)
-
 isperiodic(::Type{<:Ray}) = (false,)
 
 isperiodic(::Type{<:Line}) = (false,)
@@ -49,6 +47,8 @@ isperiodic(::Type{<:FrustumSurface}) = (true, false)
 isperiodic(::Type{<:Paraboloid}) = (false, true)
 
 isperiodic(::Type{<:Torus}) = (true, true)
+
+isperiodic(s::Segment) = (minimum(s) == maximum(s),)
 
 isperiodic(::Type{<:Rope}) = (false,)
 

--- a/src/predicates/isperiodic.jl
+++ b/src/predicates/isperiodic.jl
@@ -48,7 +48,7 @@ isperiodic(::Type{<:Paraboloid}) = (false, true)
 
 isperiodic(::Type{<:Torus}) = (true, true)
 
-isperiodic(s::Segment) = (minimum(s) == maximum(s),)
+isperiodic(::Type{<:Segment}) = (false,)
 
 isperiodic(::Type{<:Rope}) = (false,)
 

--- a/test/geodesics.jl
+++ b/test/geodesics.jl
@@ -1,6 +1,6 @@
 @testitem "Geodesics" setup = [Setup] begin
   # the geodesics are accurate to nanometres, which is far coarser than the
-  # picometre default tolerance that Meshes uses to compare points
+  # picometer default tolerance that Meshes uses to compare points
   τ = T === Float64 ? 1e-7u"m" : 10u"m"
 
   # the azimuth is only defined for points on the ellipsoid

--- a/test/geodesics.jl
+++ b/test/geodesics.jl
@@ -137,8 +137,8 @@ end
 
   # the tangent points in the direction that geodesicfwd walks
   for ϕ in T.((-120, -30, 15, 88, 170))
-    q = latlon(-12, 77)
-    @test isapprox(geodesicazimuth(q, geodesicfwd(q, ϕ, 1000) - q), ϕ * u"°", atol=τϕ)
+    ll = latlon(-12, 77)
+    @test isapprox(geodesicazimuth(ll, geodesicfwd(ll, ϕ, 1000) - ll), ϕ * u"°", atol=τϕ)
   end
 
   # the tangent is consistent with the azimuth of the inverse problem

--- a/test/geodesics.jl
+++ b/test/geodesics.jl
@@ -73,14 +73,14 @@
       )
     ]
     for (lat₁, lon₁, azi₁, lat₂, lon₂, azi₂, s₁₂) in cases
-      p₁ = latlon(lat₁, lon₁)
-      p₂ = latlon(lat₂, lon₂)
+      ll₁ = latlon(lat₁, lon₁)
+      ll₂ = latlon(lat₂, lon₂)
       # inverse problem: the azimuth at each end
-      @test isapprox(geodesicbwd(p₁, p₂), azi₁ * u"°", atol=τϕ)
-      @test isapprox(geodesicbwd(p₂, p₁), (azi₂ - 180) * u"°", atol=τϕ)
+      @test isapprox(geodesicbwd(ll₁, ll₂), azi₁ * u"°", atol=τϕ)
+      @test isapprox(geodesicbwd(ll₂, ll₁), (azi₂ - 180) * u"°", atol=τϕ)
       # direct problem: the point reached and the distance to it
-      @test isapprox(geodesicfwd(p₁, azi₁, s₁₂), p₂, atol=τ)
-      @test isapprox(GeodesicDistance()(p₁, geodesicfwd(p₁, azi₁, s₁₂)), s₁₂ * u"m", atol=1e-7u"m")
+      @test isapprox(geodesicfwd(ll₁, azi₁, s₁₂), ll₂, atol=τ)
+      @test isapprox(GeodesicDistance()(ll₁, geodesicfwd(ll₁, azi₁, s₁₂)), s₁₂ * u"m", atol=1e-7u"m")
     end
 
     # on a datum with a spherical ellipsoid the azimuth is the great circle one

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -71,13 +71,15 @@
   s = Segment(latlon(0, 135), latlon(0, 45))
   @test_broken measure(s) ≈ 3C / 4
 
-  # parameterization
+  # the geodesics are accurate to nanometres, which is far coarser than the
+  # picometre default tolerance that Meshes uses to compare points
+  τ = T === Float64 ? 1e-7u"m" : 10u"m"
   s = Segment(latlon(45, 0), latlon(45, 90))
-  @test s(T(0)) == latlon(45, 0)
-  @test s(T(0.25)) == latlon(45, 22.5)
-  @test s(T(0.5)) == latlon(45, 45)
-  @test s(T(0.75)) == latlon(45, 67.5)
-  @test s(T(1)) == latlon(45, 90)
+  @test isapprox(s(T(0)), latlon(45, 0), atol=τ)
+  @test isapprox(s(T(0.25)), latlon(52.08325138646326, 20.102377286894075), atol=τ)
+  @test isapprox(s(T(0.5)), latlon(54.76310539889228, 45), atol=τ)
+  @test isapprox(s(T(0.75)), latlon(52.08325138646326, 69.89762271310592), atol=τ)
+  @test isapprox(s(T(1)), latlon(45, 90), atol=τ)
 
   s = Segment(cart(0, 0), cart(1, 1))
   @test sprint(show, s) == "Segment((x: 0.0 m, y: 0.0 m), (x: 1.0 m, y: 1.0 m))"

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -252,12 +252,16 @@ end
   @test r(T(0.5)) == cart(2, 0)
   @test r(T(0.75)) == cart(3, 0)
   @test r(T(1)) == cart(4, 0)
+
+  # the geodesics are accurate to nanometres, which is far coarser than the
+  # picometre default tolerance that Meshes uses to compare points
+  τ = T === Float64 ? 1e-7u"m" : 10u"m"
   r = Ring(latlon(45, 0), latlon(45, 90), latlon(90, 90))
-  @test r(T(0)) == latlon(45, 0)
-  @test r(T(1)) == latlon(45, 0)
+  @test isapprox(r(T(0)), latlon(45, 0), atol=τ)
+  @test isapprox(r(T(1)), latlon(45, 0), atol=τ)
   r = Rope(latlon(45, 0), latlon(45, 90), latlon(90, 90))
-  @test r(T(0)) == latlon(45, 0)
-  @test r(T(1)) == latlon(90, 90)
+  @test isapprox(r(T(0)), latlon(45, 0), atol=τ)
+  @test isapprox(r(T(1)), latlon(90, 90), atol=τ)
 
   # https://github.com/JuliaGeometry/Meshes.jl/issues/1381
   r = Rope(cart(0, 0), cart(1, 0), cart(1, 1), cart(0, 1))

--- a/test/polytopes.jl
+++ b/test/polytopes.jl
@@ -67,12 +67,10 @@
   r = majoraxis(ellipsoid(datum(crs(s))))
   C = 2 * T(π) * ℳ(r)
   @test measure(s) ≈ C / 4
-  # TODO: fix measure of segments on the globe
-  s = Segment(latlon(0, 135), latlon(0, 45))
-  @test_broken measure(s) ≈ 3C / 4
+  @test measure(reverse(s)) ≈ C / 4
 
   # the geodesics are accurate to nanometres, which is far coarser than the
-  # picometre default tolerance that Meshes uses to compare points
+  # picometer default tolerance that Meshes uses to compare points
   τ = T === Float64 ? 1e-7u"m" : 10u"m"
   s = Segment(latlon(45, 0), latlon(45, 90))
   @test isapprox(s(T(0)), latlon(45, 0), atol=τ)
@@ -254,7 +252,7 @@ end
   @test r(T(1)) == cart(4, 0)
 
   # the geodesics are accurate to nanometres, which is far coarser than the
-  # picometre default tolerance that Meshes uses to compare points
+  # picometer default tolerance that Meshes uses to compare points
   τ = T === Float64 ? 1e-7u"m" : 10u"m"
   r = Ring(latlon(45, 0), latlon(45, 90), latlon(90, 90))
   @test isapprox(r(T(0)), latlon(45, 0), atol=τ)


### PR DESCRIPTION
Now our `Segment{🌐}` is a geodesic, and because of our design, we get geodesic `Rope`s, `Ring`s, `BezierCurve`s, ... for free 🙂  Below is an example with a `Ring` that is made of 3 geodesic segments:

```julia
using Meshes
using CoordRefSystems
import GLMakie

Ring(Point(LatLon(45,0)), Point(LatLon(45,90)), Point(LatLon(90,90))) |> viz
```
<img width="1052" height="698" alt="image" src="https://github.com/user-attachments/assets/3d72a293-4a93-4398-9317-880aa5b03364" />
